### PR TITLE
Add CI (build only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7
+          run_install: false
+
+      - name: Install dependencies
+        working-directory: ./typescript
+        run: pnpm install
+
+      - name: Build project
+        working-directory: ./typescript
+        run: pnpm build


### PR DESCRIPTION
This is a single commit branch, cherry-picked from #79. It enables build-only CI. For some reason GH action does not trigger in #79 (maybe, due to conflicts?)