### PR TITLE
refactor(ember): update API endpoints from HTTP to HTTPS

### DIFF
--- a/typescript/.env.example
+++ b/typescript/.env.example
@@ -1,5 +1,5 @@
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:50051/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # EVM RPC URL
 RPC_URL=https://arbitrum.llamarpc.com

--- a/typescript/examples/lending-agent-no-wallet/.env.example
+++ b/typescript/examples/lending-agent-no-wallet/.env.example
@@ -22,7 +22,7 @@
 # AI_MODEL=your-preferred-model
 
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:3001/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # EVM RPC URL
 RPC_URL=https://arbitrum.llamarpc.com

--- a/typescript/examples/liquidity-agent-no-wallet/.env.example
+++ b/typescript/examples/liquidity-agent-no-wallet/.env.example
@@ -25,7 +25,7 @@ MNEMONIC=
 # AI_MODEL=your-preferred-model
 
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:3001/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # QuickNode RPC Endpoint Configuration
 # Subdomain for your QuickNode endpoint (e.g., omniscient-capable-wave)

--- a/typescript/examples/pendle-agent/.env.example
+++ b/typescript/examples/pendle-agent/.env.example
@@ -25,7 +25,7 @@ MNEMONIC=
 # AI_MODEL=your-preferred-model
 
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:3001/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # QuickNode RPC Endpoint Configuration
 # Subdomain for your QuickNode endpoint (e.g., omniscient-capable-wave)

--- a/typescript/examples/swapping-agent-no-wallet/.env.example
+++ b/typescript/examples/swapping-agent-no-wallet/.env.example
@@ -25,7 +25,7 @@ MNEMONIC=
 # AI_MODEL=your-preferred-model
 
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:50051/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # QuickNode RPC Endpoint Configuration
 # Subdomain for your QuickNode endpoint (e.g., omniscient-capable-wave)

--- a/typescript/examples/swapping-agent/.env.example
+++ b/typescript/examples/swapping-agent/.env.example
@@ -25,7 +25,7 @@ MNEMONIC=
 # AI_MODEL=your-preferred-model
 
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:50051/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # QuickNode RPC Endpoint Configuration
 # Subdomain for your QuickNode endpoint (e.g., omniscient-capable-wave)

--- a/typescript/lib/arbitrum-vibekit-core/docs/http-mcp-client-usage.md
+++ b/typescript/lib/arbitrum-vibekit-core/docs/http-mcp-client-usage.md
@@ -57,7 +57,7 @@ export const hybridSkill = defineSkill({
   mcpServers: {
     // HTTP server
     'ember-onchain': {
-      url: process.env.EMBER_MCP_SERVER_URL || 'http://api.emberai.xyz/mcp',
+      url: process.env.EMBER_MCP_SERVER_URL || 'https://api.emberai.xyz/mcp',
     } as HttpMcpConfig,
 
     // Local stdio server
@@ -164,7 +164,7 @@ export const swappingSkill = defineSkill({
   }),
   mcpServers: {
     'ember-onchain': {
-      url: process.env.EMBER_MCP_SERVER_URL || 'http://api.emberai.xyz/mcp',
+      url: process.env.EMBER_MCP_SERVER_URL || 'https://api.emberai.xyz/mcp',
       alwaysAllow: ['getTokens', 'swapTokens'],
     },
   },

--- a/typescript/lib/arbitrum-vibekit-core/docs/lesson-04.md
+++ b/typescript/lib/arbitrum-vibekit-core/docs/lesson-04.md
@@ -131,7 +131,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 // The framework automatically sets up MCP clients based on your skills
 // For agents that need to access remote servers like Ember, ensure you have:
-// - EMBER_ENDPOINT=@http://api.emberai.xyz/mcp in your environment variables
+// - EMBER_ENDPOINT=@https://api.emberai.xyz/mcp in your environment variables
 // - Skills that reference the remote MCP server
 
 // The ember client will be available as deps.mcpClients['ember']

--- a/typescript/lib/arbitrum-vibekit-core/docs/lesson-07.md
+++ b/typescript/lib/arbitrum-vibekit-core/docs/lesson-07.md
@@ -17,7 +17,7 @@ You can call these tools directly from your agent, or **wrap them in adapters** 
 
 The framework comes with a growing library of ready-made services:
 
-- **Ember AI** (Remote): On-chain DeFi execution via `@http://api.emberai.xyz/mcp`
+- **Ember AI** (Remote): On-chain DeFi execution via `@https://api.emberai.xyz/mcp`
 - `providers/allora`: Token price forecasting
 - `providers/trendmoon`: Social sentiment metrics
 
@@ -29,7 +29,7 @@ To use Ember AI's remote MCP server in your agent:
 
 ```bash
 # .env
-EMBER_ENDPOINT=@http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=@https://api.emberai.xyz/mcp
 ```
 
 The framework automatically handles the connection setup using `StreamableHTTPClientTransport`. In your context provider or tools, access the client as:

--- a/typescript/lib/arbitrum-vibekit-core/docs/lesson-21.md
+++ b/typescript/lib/arbitrum-vibekit-core/docs/lesson-21.md
@@ -227,7 +227,7 @@ When your agent needs to connect to external MCP servers (like Ember AI), the fr
 
 ```bash
 # Remote MCP servers
-EMBER_ENDPOINT=@http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=@https://api.emberai.xyz/mcp
 ALLORA_ENDPOINT=@http://allora.example.com/mcp
 ```
 
@@ -346,7 +346,7 @@ ENABLE_NOTIFICATIONS=false
 ENABLE_HISTORY=false
 
 # Service Dependencies
-EMBER_ENDPOINT=@http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=@https://api.emberai.xyz/mcp
 QUICKNODE_API_KEY=your_quicknode_key
 ```
 

--- a/typescript/lib/arbitrum-vibekit-core/docs/lesson-24.md
+++ b/typescript/lib/arbitrum-vibekit-core/docs/lesson-24.md
@@ -121,7 +121,7 @@ ENABLE_HISTORY=true
 ENABLE_ANALYTICS=true
 
 # External Service Dependencies
-EMBER_ENDPOINT=@http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=@https://api.emberai.xyz/mcp
 QUICKNODE_API_KEY=qn_...
 ALCHEMY_API_KEY=alch_...
 

--- a/typescript/templates/ember-agent/.env.example
+++ b/typescript/templates/ember-agent/.env.example
@@ -27,7 +27,7 @@ ENABLE_CORS=true
 ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
 
 # Ember MCP Server Configuration (required)
-EMBER_MCP_SERVER_URL=http://api.emberai.xyz/mcp
+EMBER_MCP_SERVER_URL=https://api.emberai.xyz/mcp
 
 # Optional Configuration
 # MCP_TOOL_TIMEOUT_MS=120000

--- a/typescript/templates/ember-agent/README.md
+++ b/typescript/templates/ember-agent/README.md
@@ -58,7 +58,7 @@ ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
 # Required: Ember MCP Server Configuration
-EMBER_MCP_SERVER_URL=http://api.emberai.xyz/mcp
+EMBER_MCP_SERVER_URL=https://api.emberai.xyz/mcp
 
 # Optional: Server configuration
 PORT=3001

--- a/typescript/templates/ember-agent/src/context/provider.ts
+++ b/typescript/templates/ember-agent/src/context/provider.ts
@@ -127,7 +127,7 @@ export async function contextProvider(
 
   // Parse configuration from environment
   const arbitrumRpcUrl = process.env.ARBITRUM_RPC_URL || 'https://arb1.arbitrum.io/rpc';
-  const emberMcpServerUrl = process.env.EMBER_MCP_SERVER_URL || 'http://api.emberai.xyz/mcp';
+  const emberMcpServerUrl = process.env.EMBER_MCP_SERVER_URL || 'https://api.emberai.xyz/mcp';
   const defaultUserAddress = parseUserAddress(process.env.DEFAULT_USER_ADDRESS);
   const enableCaching = process.env.AGENT_CACHE_TOKENS === 'true';
 

--- a/typescript/templates/ember-agent/src/skills/swapping.ts
+++ b/typescript/templates/ember-agent/src/skills/swapping.ts
@@ -30,7 +30,7 @@ export const swappingSkill = defineSkill({
   inputSchema: swappingSkillInputSchema,
   mcpServers: {
     'ember-onchain': {
-      url: process.env.EMBER_MCP_SERVER_URL || 'http://api.emberai.xyz/mcp',
+      url: process.env.EMBER_MCP_SERVER_URL || 'https://api.emberai.xyz/mcp',
       // No authorization needed according to user
       alwaysAllow: ['getCapabilities', 'getTokens', 'swapTokens'],
       disabled: false,

--- a/typescript/templates/ember-agent/test/README.md
+++ b/typescript/templates/ember-agent/test/README.md
@@ -22,7 +22,7 @@ The `getCapabilities-integration.vitest.ts` file contains tests for the Ember MC
 
    ```bash
    # Set your Ember MCP server URL
-   export EMBER_MCP_SERVER_URL="http://api.emberai.xyz/mcp"
+   export EMBER_MCP_SERVER_URL="https://api.emberai.xyz/mcp"
 
    # Run the tests
    pnpm test getCapabilities-integration

--- a/typescript/templates/ember-agent/test/agent-e2e-swapping.vitest.ts
+++ b/typescript/templates/ember-agent/test/agent-e2e-swapping.vitest.ts
@@ -16,7 +16,7 @@ describe.skip('Ember Agent E2E Swapping Integration', () => {
     // Set required environment variables for the test
     process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || 'test-key-for-ci';
     process.env.ARBITRUM_RPC_URL = 'https://arb1.arbitrum.io/rpc';
-    process.env.EMBER_MCP_SERVER_URL = 'http://api.emberai.xyz/mcp';
+    process.env.EMBER_MCP_SERVER_URL = 'https://api.emberai.xyz/mcp';
     // Use a dummy address for testing, as we only need to generate a plan, not execute it
     process.env.DEFAULT_USER_ADDRESS = '0x000000000000000000000000000000000000dead';
 

--- a/typescript/templates/ember-agent/test/agent-integration.vitest.ts
+++ b/typescript/templates/ember-agent/test/agent-integration.vitest.ts
@@ -5,7 +5,7 @@ describe('Agent Integration', () => {
     // Set required environment variables for testing
     process.env.OPENROUTER_API_KEY = 'test-key';
     process.env.ARBITRUM_RPC_URL = 'https://arb1.arbitrum.io/rpc';
-    process.env.EMBER_MCP_SERVER_URL = 'http://api.emberai.xyz/mcp';
+    process.env.EMBER_MCP_SERVER_URL = 'https://api.emberai.xyz/mcp';
   });
 
   it('should be able to import agent configuration', async () => {

--- a/typescript/templates/ember-agent/test/ember-mcp-integration.vitest.ts
+++ b/typescript/templates/ember-agent/test/ember-mcp-integration.vitest.ts
@@ -10,7 +10,7 @@ describe('Ember MCP Server Integration', () => {
     if (!emberConfig || !('url' in emberConfig)) {
       throw new Error('Expected HttpMcpConfig');
     }
-    expect(emberConfig.url).toBe('http://api.emberai.xyz/mcp');
+    expect(emberConfig.url).toBe('https://api.emberai.xyz/mcp');
     expect(emberConfig.alwaysAllow).toContain('swapTokens');
     expect(emberConfig.disabled).toBe(false);
   });

--- a/typescript/templates/lending-agent/.env.example
+++ b/typescript/templates/lending-agent/.env.example
@@ -22,7 +22,7 @@
 # AI_MODEL=your-preferred-model
 
 # The MCP endpoint for Ember API. For local development, you can use http://localhost:50051/mcp
-EMBER_ENDPOINT=http://api.emberai.xyz/mcp
+EMBER_ENDPOINT=https://api.emberai.xyz/mcp
 
 # EVM RPC URL
 RPC_URL=https://arbitrum.llamarpc.com


### PR DESCRIPTION
## Summary

Update all Ember API endpoint references to use HTTPS instead of HTTP for improved security.

## Changes

- Updated 8 `.env.example` files to use HTTPS endpoints
- Updated 2 TypeScript source files with HTTPS default URLs
- Updated 3 test files to expect HTTPS endpoints
- Updated 7 documentation files with HTTPS examples

## Testing

- [x] Unit tests pass
- [x] Build completes successfully
- [ ] Integration tests pass
- [ ] Manual testing completed

## Related Issues

<\!-- Link any related issues -->

## Notes

This is a security improvement that ensures all communication with the Ember API uses HTTPS encryption. The change updates:
- `http://api.emberai.xyz/mcp` → `https://api.emberai.xyz/mcp`