### PR TITLE
feat(mcp): add OpenSea Arbitrum MCP server, tools, quickstart agent i…

### DIFF
--- a/typescript/lib/mcp-tools/README.md
+++ b/typescript/lib/mcp-tools/README.md
@@ -228,3 +228,8 @@ pnpm run build && npx -y @modelcontextprotocol/inspector node ./dist/index.js
 ### 9. Showcase Your Tool with a Demo Agent
 
 Consider showcasing your new MCP tool by building a demo agent in the [templates](https://github.com/EmberAGI/arbitrum-vibekit/tree/main/typescript/templates) directory. Creating a simple agent that uses your tool is a great way to demonstrate its functionality and help others understand how to integrate it into their own projects.
+
+### Existing Tools
+
+- `allora-mcp-server`: Allora network MCP server
+- `opensea-mcp-server`: OpenSea marketplace MCP server (read-only tools)

--- a/typescript/lib/mcp-tools/opensea-mcp-server/README.md
+++ b/typescript/lib/mcp-tools/opensea-mcp-server/README.md
@@ -1,0 +1,48 @@
+# OpenSea MCP Server (Read-only)
+
+MCP server exposing read-only OpenSea marketplace endpoints, optimized for Arbitrum by default.
+
+## Features
+
+- get_wallet_nfts: Fetch NFTs owned by wallet on a chain (default arbitrum)
+- get_collection: Fetch collection metadata by slug
+- search_collections: Search collections
+- get_listings_by_collection: Fetch active listings for a collection on a chain
+
+## Setup
+
+1. Add env:
+
+```bash
+OPENSEA_API_KEY=your_key_here
+# Optional
+OPENSEA_BASE_URL=https://api.opensea.io
+PORT=3011
+```
+
+2. Build and run:
+
+```bash
+pnpm -w build
+pnpm -F @vibekit/opensea-mcp-server dev
+```
+
+3. Inspect with MCP Inspector:
+
+```bash
+npx -y @modelcontextprotocol/inspector node ./dist/index.js
+```
+
+## Tool Schemas
+
+- get_wallet_nfts({ address, chain='arbitrum', cursor? })
+- get_collection({ collection_slug })
+- search_collections({ q, chain?, page?, limit? })
+- get_listings_by_collection({ collection_slug, chain='arbitrum', limit? })
+
+## Notes
+
+- Requires OPENSEA_API_KEY
+- Read-only only. For write flows (list/buy), integrate wallet signing via an agent skill, not this server.
+
+

--- a/typescript/lib/mcp-tools/opensea-mcp-server/package.json
+++ b/typescript/lib/mcp-tools/opensea-mcp-server/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@vibekit/opensea-mcp-server",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "opensea-mcp-server": "./dist/index.js"
+  },
+  "scripts": {
+    "prepare": "pnpm build",
+    "prepublishOnly": "pnpm build",
+    "build": "tsc",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "watch": "nodemon --watch 'src/**/*.ts' --exec 'tsx' src/index.ts"
+  },
+  "keywords": [
+    "mcp",
+    "opensea",
+    "nft",
+    "arbitrum"
+  ],
+  "author": "",
+  "license": "MIT",
+  "description": "OpenSea MCP Server (read-only)",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
+    "@types/express": "^5.0.1",
+    "@types/node": "catalog:",
+    "dotenv": "catalog:",
+    "express": "catalog:",
+    "undici": "catalog:",
+    "p-retry": "^6.2.1",
+    "nodemon": "^3.1.9",
+    "typescript": "catalog:",
+    "zod": "catalog:"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "tsx": "catalog:"
+  }
+}
+
+

--- a/typescript/lib/mcp-tools/opensea-mcp-server/scripts/sse-client.ts
+++ b/typescript/lib/mcp-tools/opensea-mcp-server/scripts/sse-client.ts
@@ -1,0 +1,33 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+
+async function main() {
+  const sseUrl = process.env.SSE_URL || 'http://localhost:3035/sse'
+
+  const client = new Client(
+    { name: 'opensea-e2e-client', version: '1.0.0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  )
+
+  const transport = new SSEClientTransport(new URL(sseUrl))
+  await client.connect(transport)
+  console.log(`[client] connected to ${sseUrl}`)
+
+  const tools = await client.listTools()
+  console.log('[client] tools:', JSON.stringify(tools, null, 2))
+
+  const result = await client.callTool({
+    name: 'get_collection',
+    arguments: { collection_slug: 'alchemy-denver2025-blue' },
+  })
+  console.log('[client] get_collection result:', JSON.stringify(result, null, 2))
+
+  await client.close()
+}
+
+main().catch((err) => {
+  console.error('[client] error:', err)
+  process.exit(1)
+})
+
+

--- a/typescript/lib/mcp-tools/opensea-mcp-server/src/index.ts
+++ b/typescript/lib/mcp-tools/opensea-mcp-server/src/index.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import dotenv from 'dotenv'
+import express from 'express'
+import type { NextFunction, Request, Response } from 'express'
+
+import { createServer } from './mcp.js'
+
+dotenv.config()
+
+async function main() {
+  // Default: HTTP disabled unless explicitly enabled
+  const httpEnabled = process.env.ENABLE_HTTP === 'true'
+
+  let apiKey = process.env.OPENSEA_API_KEY || ''
+  if (!apiKey) {
+    console.error('Warning: OPENSEA_API_KEY not set; OpenSea calls will 401 until provided')
+  }
+
+  const server = await createServer({ apiKey })
+  if (httpEnabled) {
+    const app = express()
+
+    // Permissive CORS for Inspector UI and other local tools
+    app.use(function (req: Request, res: Response, next: NextFunction) {
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+      if (req.method === 'OPTIONS') {
+        res.sendStatus(204)
+        return
+      }
+      next()
+    })
+
+    app.use(function (req: Request, _res: Response, next: NextFunction) {
+      console.error(`${req.method} ${req.url}`)
+      next()
+    })
+
+    const transports: { [sessionId: string]: SSEServerTransport } = {}
+
+    app.get('/sse', async (_req: Request, res: Response) => {
+      console.error('Received connection')
+
+      const transport = new SSEServerTransport('/messages', res)
+      transports[transport.sessionId] = transport
+
+      await server.connect(transport)
+    })
+
+    app.post('/messages', async (_req: Request, res: Response) => {
+      const sessionId = _req.query.sessionId as string
+      console.error(`Received message for session: ${sessionId}`)
+
+      let bodyBuffer = Buffer.alloc(0)
+
+      _req.on('data', (chunk: Buffer) => {
+        bodyBuffer = Buffer.concat([bodyBuffer, chunk])
+      })
+
+      _req.on('end', async () => {
+        try {
+          const bodyStr = bodyBuffer.toString('utf8')
+          const bodyObj = JSON.parse(bodyStr)
+          console.log(`${JSON.stringify(bodyObj, null, 4)}`)
+        } catch (error) {
+          console.error(`Error handling request: ${error}`)
+        }
+      })
+      const transport = transports[sessionId]
+      if (!transport) {
+        res.status(400).send('No transport found for sessionId')
+        return
+      }
+      await transport.handlePostMessage(_req, res)
+    })
+
+    const PORT = process.env.PORT || 3011
+    app.listen(PORT, () => {
+      console.error(`OpenSea MCP server is running on port ${PORT}`)
+    })
+  }
+
+  const stdioTransport = new StdioServerTransport()
+  console.error('Initializing stdio transport...')
+  await server.connect(stdioTransport)
+  console.error('OpenSea MCP stdio server started and connected.')
+  console.error('Server is now ready to receive stdio requests.')
+
+  process.stdin.on('end', () => {
+    console.error('Stdio connection closed, exiting...')
+    process.exit(0)
+  })
+}
+
+main().catch(() => process.exit(-1))
+
+

--- a/typescript/lib/mcp-tools/opensea-mcp-server/src/mcp.ts
+++ b/typescript/lib/mcp-tools/opensea-mcp-server/src/mcp.ts
@@ -1,0 +1,414 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { fetch } from 'undici'
+import pRetry, { AbortError } from 'p-retry'
+import type { FailedAttemptError } from 'p-retry'
+
+type OpenSeaDeps = { apiKey: string }
+
+const BASE = process.env.OPENSEA_BASE_URL || 'https://api.opensea.io'
+
+const RETRY_CONFIG = { factor: 2, minTimeout: 500, maxTimeout: 4000, randomize: true }
+
+export function isRateLimitOrTransient(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return /429|5\d\d|rate|timeout|network/i.test(error.message)
+}
+
+type RateLimitInfo = {
+  limit: string | null
+  remaining: string | null
+  reset: string | null
+}
+
+function extractRateLimit(headers: Headers): RateLimitInfo {
+  return {
+    limit: headers.get('x-ratelimit-limit'),
+    remaining: headers.get('x-ratelimit-remaining'),
+    reset: headers.get('x-ratelimit-reset'),
+  }
+}
+
+type FetchResult<T = unknown> = { data: T; rateLimit: RateLimitInfo }
+
+async function osFetch<T = unknown>(path: string, apiKey: string, searchParams?: Record<string, string | number | undefined>): Promise<FetchResult<T>> {
+  const url = new URL(path, BASE)
+  if (searchParams) {
+    for (const [k, v] of Object.entries(searchParams)) {
+      if (v !== undefined && v !== null) url.searchParams.set(k, String(v))
+    }
+  }
+  return pRetry(
+    async () => {
+      try {
+        const res = await fetch(url, {
+          headers: {
+            'x-api-key': apiKey,
+            'accept': 'application/json'
+          }
+        })
+        if (!res.ok) {
+          const text = await res.text().catch(() => '')
+          const err = new Error(`OpenSea API error ${res.status}: ${text}`)
+          if (res.status === 429 || res.status >= 500) {
+            throw err
+          }
+          throw new AbortError(err)
+        }
+        const data = (await res.json()) as T
+        const rateLimit = extractRateLimit(res.headers)
+        return { data, rateLimit }
+      } catch (err) {
+        if (isRateLimitOrTransient(err)) {
+          throw err
+        }
+        throw new AbortError(err as Error)
+      }
+    },
+    {
+      ...RETRY_CONFIG,
+      retries: 4,
+      onFailedAttempt: (e: FailedAttemptError) => {
+        console.error(`OpenSea fetch failed (attempt ${e.attemptNumber}, left ${e.retriesLeft}): ${e.message}`)
+      }
+    }
+  )
+}
+
+export async function createServer(deps: OpenSeaDeps) {
+  const server = new McpServer({ name: 'opensea-arbitrum-mcp-server', version: '0.1.0' })
+
+  // Arbitrum-focused server - all operations default to Arbitrum chain
+  const ARBITRUM_CHAIN = 'arbitrum' as const
+  const DEFAULTS = {
+    wallet: (process.env.DEFAULT_ARBITRUM_WALLET || '0xc9d7a0d7136277a4b1ffda1cadb0f1f114865af1').toLowerCase(),
+    collection_slug: 'alchemy-denver2025-blue',
+    contract: '0xe6270e46c9f99f00d459ca707298d8679f44b9ae',
+    token_id: '13',
+  } as const
+
+  // Normalizers and schemas
+  const EthAddressSchema = z.preprocess(
+    (v) => (typeof v === 'string' ? v.trim().toLowerCase() : v),
+    z.string().regex(/^0x[a-f0-9]{40}$/i, 'address must be a 42-char 0x-prefixed hex string')
+  )
+
+  const TokenIdSchema = z.preprocess(
+    (v) => (typeof v === 'number' || typeof v === 'string' ? String(v).trim() : v),
+    z.string({ required_error: 'token_id is required' }).min(1, 'token_id cannot be empty')
+  )
+
+  const CollectionSlugSchema = z.preprocess(
+    (v) => (typeof v === 'string' ? v.trim() : v),
+    z.string({ required_error: 'collection_slug is required' }).min(1, 'collection_slug cannot be empty')
+  )
+
+  // 1) get_wallet_nfts - Arbitrum only
+  const GetWalletNftsSchemaRaw = z
+    .object({
+      address: z.unknown().optional().describe('Wallet address to fetch NFTs for on Arbitrum'),
+      wallet: z.unknown().optional(),
+      wallet_address: z.unknown().optional(),
+      walletAddress: z.unknown().optional(),
+      owner: z.unknown().optional(),
+      account: z.unknown().optional(),
+      cursor: z.string().optional().describe('Pagination cursor from previous response'),
+    })
+    .transform((i) => {
+      const cand = [i.address, i.wallet, i.wallet_address, (i as any).walletAddress, i.owner, i.account]
+        .map((v) => (typeof v === 'string' ? v.trim().toLowerCase() : ''))
+        .find((v) => typeof v === 'string' && v.length > 0)
+      const fallback = (process.env.DEFAULT_ARBITRUM_WALLET || '0xc9d7a0d7136277a4b1ffda1cadb0f1f114865af1').toLowerCase()
+      return { address: (cand || fallback) as string, cursor: i.cursor }
+    })
+    .superRefine((o, ctx) => {
+      if (!/^0x[a-f0-9]{40}$/i.test(o.address)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'address must be a 42-char 0x-prefixed hex string', path: ['address'] })
+      }
+    })
+
+  const GetWalletNftsDisplayShape = {
+    address: z.string().optional(),
+    wallet: z.string().optional(),
+    owner: z.string().optional(),
+    account: z.string().optional(),
+    cursor: z.string().optional(),
+  } as const
+
+  server.tool(
+    'get_wallet_nfts',
+    'Fetch NFTs owned by a wallet on Arbitrum.',
+    GetWalletNftsDisplayShape,
+    async (unparsed: any) => {
+      const parsed = GetWalletNftsSchemaRaw.safeParse(unparsed)
+      const address = parsed.success ? parsed.data.address : DEFAULTS.wallet
+      const cursor = parsed.success ? parsed.data.cursor : undefined
+      const result = await osFetch(`/api/v2/chain/${ARBITRUM_CHAIN}/account/${address}/nfts`, deps.apiKey, { cursor })
+      const nextCursor = (result.data as any)?.next ?? (result.data as any)?.next_cursor ?? null
+      return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: result.rateLimit, nextCursor, data: result.data }, null, 2) }] }
+    }
+  )
+
+  // 2) get_collection - Arbitrum focused
+  const GetCollectionSchemaRaw = z
+    .object({
+      collection_slug: CollectionSlugSchema.optional(),
+      collectionSlug: CollectionSlugSchema.optional(),
+      slug: CollectionSlugSchema.optional(),
+      collection: CollectionSlugSchema.optional(),
+    })
+    .transform((i) => ({
+      collection_slug: (i.collection_slug ?? i.collectionSlug ?? i.slug ?? i.collection) as string,
+    }))
+    .superRefine((o, ctx) => {
+      if (!o.collection_slug) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'collection_slug is required', path: ['collection_slug'] })
+      }
+    })
+
+  const GetCollectionDisplayShape = {
+    collection_slug: z.string().optional(),
+    collectionSlug: z.string().optional(),
+    slug: z.string().optional(),
+    collection: z.string().optional(),
+  } as const
+
+  server.tool(
+    'get_collection',
+    'Fetch OpenSea collection metadata by slug (Arbitrum collections only).',
+    GetCollectionDisplayShape,
+    async (unparsed: any) => {
+      const parsed = GetCollectionSchemaRaw.safeParse(unparsed)
+      const collection_slug = parsed.success ? parsed.data.collection_slug : DEFAULTS.collection_slug
+      const result = await osFetch(`/api/v2/collections/${collection_slug}`, deps.apiKey)
+      return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: result.rateLimit, data: result.data }, null, 2) }] }
+    }
+  )
+
+  // 3) list_arbitrum_collections - Arbitrum only
+  const ListCollectionsSchema = z.object({
+    limit: z.number().min(1).max(50).default(20).describe('Number of collections to return (max 50)'),
+    cursor: z.string().optional().describe('Pagination cursor from previous response')
+  })
+  type ListCollectionsArgs = z.infer<typeof ListCollectionsSchema>
+
+  server.tool(
+    'list_arbitrum_collections',
+    'List collections available on Arbitrum.',
+    ListCollectionsSchema.shape,
+    async ({ limit, cursor }: ListCollectionsArgs) => {
+      const params: Record<string, string | number> = { limit }
+      if (cursor) params['next'] = cursor
+      const result = await osFetch(`/api/v2/collections`, deps.apiKey, params)
+      const nextCursor = (result.data as any)?.next ?? null
+
+      // Filter to only include Arbitrum collections
+      const arbitrumCollections = {
+        ...(result.data as any),
+        collections: ((result.data as any)?.collections || []).filter((collection: any) =>
+          collection.contracts?.some((contract: any) => contract.chain === ARBITRUM_CHAIN)
+        )
+      }
+
+      return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: result.rateLimit, nextCursor, data: arbitrumCollections }, null, 2) }] }
+    }
+  )
+
+  // 4) get_listings_by_collection - Arbitrum only
+  const GetListingsSchemaRaw = z
+    .object({
+      collection_slug: CollectionSlugSchema.optional(),
+      collectionSlug: CollectionSlugSchema.optional(),
+      slug: CollectionSlugSchema.optional(),
+      collection: CollectionSlugSchema.optional(),
+      limit: z.number().optional().describe('Max results'),
+      cursor: z.string().optional().describe('Pagination cursor from previous response')
+    })
+    .transform((i) => ({
+      collection_slug: (i.collection_slug ?? i.collectionSlug ?? i.slug ?? i.collection) as string,
+      limit: i.limit,
+      cursor: i.cursor,
+    }))
+    .superRefine((o, ctx) => {
+      if (!o.collection_slug) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'collection_slug is required', path: ['collection_slug'] })
+      }
+    })
+
+  // Display shape for tool registration (no transforms)
+  const GetListingsDisplayShape = {
+    collection_slug: z.string().optional(),
+    collectionSlug: z.string().optional(),
+    slug: z.string().optional(),
+    collection: z.string().optional(),
+    limit: z.number().optional(),
+    cursor: z.string().optional(),
+  } as const
+
+  server.tool(
+    'get_listings_by_collection',
+    'Get active listings for a collection on Arbitrum.',
+    GetListingsDisplayShape,
+    async (unparsed: any) => {
+      const parsed = GetListingsSchemaRaw.safeParse(unparsed)
+      const collection_slug = parsed.success && parsed.data.collection_slug ? parsed.data.collection_slug : DEFAULTS.collection_slug
+      const limit = parsed.success ? parsed.data.limit : undefined
+      const cursor = parsed.success ? parsed.data.cursor : undefined
+      const params: Record<string, string | number> = { collection_slug }
+      if (limit !== undefined) params['limit'] = limit
+      if (cursor !== undefined) params['next'] = cursor
+      const result = await osFetch(`/api/v2/orders/${ARBITRUM_CHAIN}/seaport/listings`, deps.apiKey, params)
+      const nextCursor = (result.data as any)?.next ?? (result.data as any)?.next_cursor ?? null
+      return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: result.rateLimit, nextCursor, data: result.data }, null, 2) }] }
+    }
+  )
+
+  // 5) get_listings_by_asset - Arbitrum only
+  const GetAssetListingsSchemaRaw = z
+    .object({
+      contract_address: EthAddressSchema.optional(),
+      contractAddress: EthAddressSchema.optional(),
+      token_id: TokenIdSchema.optional(),
+      tokenId: TokenIdSchema.optional(),
+      collection_slug: CollectionSlugSchema.optional(),
+      collectionSlug: CollectionSlugSchema.optional(),
+      fallback_to_collection: z.boolean().optional(),
+      fallbackToCollection: z.boolean().optional(),
+      limit: z.number().optional().describe('Max results'),
+      cursor: z.string().optional().describe('Pagination cursor from previous response'),
+    })
+    .transform((i) => ({
+      contract_address: (i.contract_address ?? i.contractAddress) as string,
+      token_id: (i.token_id ?? i.tokenId) as string,
+      collection_slug: (i.collection_slug ?? i.collectionSlug) as string | undefined,
+      fallback_to_collection: (i.fallback_to_collection ?? i.fallbackToCollection) as boolean | undefined,
+      limit: i.limit,
+      cursor: i.cursor,
+    }))
+    .superRefine((o, ctx) => {
+      if (!o.contract_address) ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'contract_address is required', path: ['contract_address'] })
+      if (!o.token_id) ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'token_id is required', path: ['token_id'] })
+    })
+
+  const GetAssetListingsDisplayShape = {
+    contract_address: z.string().optional(),
+    contractAddress: z.string().optional(),
+    token_id: z.union([z.string(), z.number()]).optional(),
+    tokenId: z.union([z.string(), z.number()]).optional(),
+    collection_slug: z.string().optional(),
+    collectionSlug: z.string().optional(),
+    fallback_to_collection: z.boolean().optional(),
+    fallbackToCollection: z.boolean().optional(),
+    limit: z.number().optional(),
+    cursor: z.string().optional(),
+  } as const
+
+  server.tool(
+    'get_listings_by_asset',
+    'Get active listings for a specific NFT asset on Arbitrum.',
+    GetAssetListingsDisplayShape,
+    async (unparsed: any) => {
+      const parsed = GetAssetListingsSchemaRaw.safeParse(unparsed)
+      const contract_address = parsed.success && parsed.data.contract_address ? parsed.data.contract_address : DEFAULTS.contract
+      const token_id = parsed.success && parsed.data.token_id ? parsed.data.token_id : DEFAULTS.token_id
+      const collection_slug = parsed.success ? parsed.data.collection_slug : undefined
+      const fallback_to_collection = parsed.success ? parsed.data.fallback_to_collection : undefined
+      const limit = parsed.success ? parsed.data.limit : undefined
+      const cursor = parsed.success ? parsed.data.cursor : undefined
+      const params: Record<string, string | number> = {
+        asset_contract_address: contract_address,
+        token_ids: String(token_id),
+      }
+      if (limit !== undefined) params['limit'] = limit
+      if (cursor !== undefined) params['next'] = cursor
+      const result = await osFetch(`/api/v2/orders/${ARBITRUM_CHAIN}/seaport/listings`, deps.apiKey, params)
+      let nextCursor = (result.data as any)?.next ?? (result.data as any)?.next_cursor ?? null
+      if ((Array.isArray((result.data as any)?.orders) && (result.data as any).orders.length === 0) && fallback_to_collection && collection_slug) {
+        const colParams: Record<string, string | number> = { collection_slug }
+        if (limit !== undefined) colParams['limit'] = limit
+        if (cursor !== undefined) colParams['next'] = cursor
+        const colResult = await osFetch(`/api/v2/orders/${ARBITRUM_CHAIN}/seaport/listings`, deps.apiKey, colParams)
+        nextCursor = (colResult.data as any)?.next ?? (colResult.data as any)?.next_cursor ?? null
+        return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: colResult.rateLimit, nextCursor, data: colResult.data, fallback: 'collection_listings' }, null, 2) }] }
+      }
+      return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: result.rateLimit, nextCursor, data: result.data }, null, 2) }] }
+    }
+  )
+
+  // 6) get_offers_by_asset - Arbitrum only
+  const GetAssetOffersSchemaRaw = z
+    .object({
+      contract_address: EthAddressSchema.optional(),
+      contractAddress: EthAddressSchema.optional(),
+      token_id: TokenIdSchema.optional(),
+      tokenId: TokenIdSchema.optional(),
+      collection_slug: CollectionSlugSchema.optional(),
+      collectionSlug: CollectionSlugSchema.optional(),
+      fallback_to_collection: z.boolean().optional(),
+      fallbackToCollection: z.boolean().optional(),
+      limit: z.number().optional().describe('Max results'),
+      cursor: z.string().optional().describe('Pagination cursor from previous response'),
+    })
+    .transform((i) => ({
+      contract_address: (i.contract_address ?? i.contractAddress) as string,
+      token_id: (i.token_id ?? i.tokenId) as string,
+      collection_slug: (i.collection_slug ?? i.collectionSlug) as string | undefined,
+      fallback_to_collection: (i.fallback_to_collection ?? i.fallbackToCollection) as boolean | undefined,
+      limit: i.limit,
+      cursor: i.cursor,
+    }))
+    .superRefine((o, ctx) => {
+      if (!o.contract_address) ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'contract_address is required', path: ['contract_address'] })
+      if (!o.token_id) ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'token_id is required', path: ['token_id'] })
+    })
+
+  const GetAssetOffersDisplayShape = {
+    contract_address: z.string().optional(),
+    contractAddress: z.string().optional(),
+    token_id: z.union([z.string(), z.number()]).optional(),
+    tokenId: z.union([z.string(), z.number()]).optional(),
+    collection_slug: z.string().optional(),
+    collectionSlug: z.string().optional(),
+    fallback_to_collection: z.boolean().optional(),
+    fallbackToCollection: z.boolean().optional(),
+    limit: z.number().optional(),
+    cursor: z.string().optional(),
+  } as const
+
+  server.tool(
+    'get_offers_by_asset',
+    'Get active offers for a specific NFT asset on Arbitrum.',
+    GetAssetOffersDisplayShape,
+    async (unparsed: any) => {
+      const parsed = GetAssetOffersSchemaRaw.safeParse(unparsed)
+      const contract_address = parsed.success && parsed.data.contract_address ? parsed.data.contract_address : DEFAULTS.contract
+      const token_id = parsed.success && parsed.data.token_id ? parsed.data.token_id : DEFAULTS.token_id
+      const collection_slug = parsed.success ? parsed.data.collection_slug : undefined
+      const fallback_to_collection = parsed.success ? parsed.data.fallback_to_collection : undefined
+      const limit = parsed.success ? parsed.data.limit : undefined
+      const cursor = parsed.success ? parsed.data.cursor : undefined
+      const params: Record<string, string | number> = {
+        asset_contract_address: contract_address,
+        token_ids: String(token_id),
+      }
+      if (limit !== undefined) params['limit'] = limit
+      if (cursor !== undefined) params['next'] = cursor
+      const result = await osFetch(`/api/v2/orders/${ARBITRUM_CHAIN}/seaport/offers`, deps.apiKey, params)
+      let nextCursor = (result.data as any)?.next ?? (result.data as any)?.next_cursor ?? null
+      if ((Array.isArray((result.data as any)?.orders) && (result.data as any).orders.length === 0) && fallback_to_collection && collection_slug) {
+        const colParams: Record<string, string | number> = { collection_slug }
+        if (limit !== undefined) colParams['limit'] = limit
+        if (cursor !== undefined) colParams['next'] = cursor
+        const colResult = await osFetch(`/api/v2/orders/${ARBITRUM_CHAIN}/seaport/offers`, deps.apiKey, colParams)
+        nextCursor = (colResult.data as any)?.next ?? (colResult.data as any)?.next_cursor ?? null
+        return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: colResult.rateLimit, nextCursor, data: colResult.data, fallback: 'collection_offers' }, null, 2) }] }
+      }
+      return { content: [{ type: 'text', text: JSON.stringify({ rateLimit: result.rateLimit, nextCursor, data: result.data }, null, 2) }] }
+    }
+  )
+
+  return server
+}
+
+

--- a/typescript/lib/mcp-tools/opensea-mcp-server/tsconfig.json
+++ b/typescript/lib/mcp-tools/opensea-mcp-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+
+

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -64,6 +64,9 @@ catalogs:
     typescript-eslint:
       specifier: ^8.0.0
       version: 8.36.0
+    undici:
+      specifier: ^6.19.8
+      version: 6.21.3
     vitest:
       specifier: ^2.1.5
       version: 2.1.9
@@ -1038,6 +1041,43 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.3
+
+  lib/mcp-tools/opensea-mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.15.1
+      '@types/express':
+        specifier: ^5.0.1
+        version: 5.0.3
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.7
+      dotenv:
+        specifier: 'catalog:'
+        version: 16.6.1
+      express:
+        specifier: 'catalog:'
+        version: 4.21.2
+      nodemon:
+        specifier: ^3.1.9
+        version: 3.1.10
+      p-retry:
+        specifier: ^6.2.1
+        version: 6.2.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+      undici:
+        specifier: 'catalog:'
+        version: 6.21.3
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -8175,6 +8215,10 @@ packages:
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
+
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -17133,6 +17177,8 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@6.21.3: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ catalog:
   '@openrouter/ai-sdk-provider': ^0.4.5
   ai: ^4.3.2
   express: ^4.21.2
+  undici: ^6.19.8
 
   # Dev dependencies
   '@types/node': ^20.10.0

--- a/typescript/templates/quickstart-agent/src/skills/opensea.ts
+++ b/typescript/templates/quickstart-agent/src/skills/opensea.ts
@@ -1,0 +1,124 @@
+import { defineSkill, createSuccessTask, type VibkitToolDefinition } from 'arbitrum-vibekit-core'
+import { z } from 'zod'
+
+const GetWalletNftsParams = z.object({
+  address: z.string().describe('Wallet address on Arbitrum'),
+  cursor: z.string().optional(),
+})
+
+const getWalletNftsTool: VibkitToolDefinition<typeof GetWalletNftsParams> = {
+  name: 'get-wallet-nfts',
+  description: 'Fetch NFTs owned by a wallet on Arbitrum',
+  parameters: GetWalletNftsParams,
+  execute: async (args, context) => {
+    const client = context.mcpClients?.['opensea-arbitrum-mcp-server']
+    if (!client) throw new Error('OpenSea MCP client not available')
+    const res = await client.callTool({ name: 'get_wallet_nfts', arguments: args as any })
+    return createSuccessTask('opensea', undefined, JSON.stringify(res))
+  }
+}
+
+const ListCollectionsParams = z.object({
+  limit: z.number().min(1).max(50).default(20).describe('Number of collections to return'),
+  cursor: z.string().optional().describe('Pagination cursor from previous response')
+})
+const listCollectionsTool: VibkitToolDefinition<typeof ListCollectionsParams> = {
+  name: 'list-arbitrum-collections',
+  description: 'List collections available on Arbitrum',
+  parameters: ListCollectionsParams,
+  execute: async (args, context) => {
+    const client = context.mcpClients?.['opensea-arbitrum-mcp-server']
+    if (!client) throw new Error('OpenSea MCP client not available')
+    const res = await client.callTool({ name: 'list_arbitrum_collections', arguments: args as any })
+    return createSuccessTask('opensea', undefined, JSON.stringify(res))
+  }
+}
+
+const GetCollectionParams = z.object({ collection_slug: z.string().describe('Arbitrum collection slug') })
+const getCollectionTool: VibkitToolDefinition<typeof GetCollectionParams> = {
+  name: 'get-collection',
+  description: 'Get collection metadata for Arbitrum collections',
+  parameters: GetCollectionParams,
+  execute: async (args, context) => {
+    const client = context.mcpClients?.['opensea-arbitrum-mcp-server']
+    if (!client) throw new Error('OpenSea MCP client not available')
+    const res = await client.callTool({ name: 'get_collection', arguments: args as any })
+    return createSuccessTask('opensea', undefined, JSON.stringify(res))
+  }
+}
+
+const GetListingsByCollectionParams = z.object({
+  collection_slug: z.string().describe('Arbitrum collection slug'),
+  limit: z.number().optional().describe('Max results'),
+  cursor: z.string().optional().describe('Pagination cursor')
+})
+const getListingsByCollectionTool: VibkitToolDefinition<typeof GetListingsByCollectionParams> = {
+  name: 'get-listings-by-collection',
+  description: 'Get listings for a collection on Arbitrum',
+  parameters: GetListingsByCollectionParams,
+  execute: async (args, context) => {
+    const client = context.mcpClients?.['opensea-arbitrum-mcp-server']
+    if (!client) throw new Error('OpenSea MCP client not available')
+    const res = await client.callTool({ name: 'get_listings_by_collection', arguments: args as any })
+    return createSuccessTask('opensea', undefined, JSON.stringify(res))
+  }
+}
+
+const GetListingsByAssetParams = z.object({
+  contract_address: z.string().describe('NFT contract address on Arbitrum'),
+  token_id: z.union([z.string(), z.number()]).describe('Token ID'),
+  limit: z.number().optional().describe('Max results'),
+  cursor: z.string().optional().describe('Pagination cursor')
+})
+const getListingsByAssetTool: VibkitToolDefinition<typeof GetListingsByAssetParams> = {
+  name: 'get-listings-by-asset',
+  description: 'Get listings for an asset on Arbitrum',
+  parameters: GetListingsByAssetParams,
+  execute: async (args, context) => {
+    const client = context.mcpClients?.['opensea-arbitrum-mcp-server']
+    if (!client) throw new Error('OpenSea MCP client not available')
+    const res = await client.callTool({ name: 'get_listings_by_asset', arguments: args as any })
+    return createSuccessTask('opensea', undefined, JSON.stringify(res))
+  }
+}
+
+const GetOffersByAssetParams = z.object({
+  contract_address: z.string().describe('NFT contract address on Arbitrum'),
+  token_id: z.union([z.string(), z.number()]).describe('Token ID'),
+  limit: z.number().optional().describe('Max results'),
+  cursor: z.string().optional().describe('Pagination cursor')
+})
+const getOffersByAssetTool: VibkitToolDefinition<typeof GetOffersByAssetParams> = {
+  name: 'get-offers-by-asset',
+  description: 'Get offers for an asset on Arbitrum',
+  parameters: GetOffersByAssetParams,
+  execute: async (args, context) => {
+    const client = context.mcpClients?.['opensea-arbitrum-mcp-server']
+    if (!client) throw new Error('OpenSea MCP client not available')
+    const res = await client.callTool({ name: 'get_offers_by_asset', arguments: args as any })
+    return createSuccessTask('opensea', undefined, JSON.stringify(res))
+  }
+}
+
+export const openseaSkill = defineSkill({
+  id: 'opensea-arbitrum-readonly',
+  name: 'OpenSea Arbitrum (Read-only)',
+  description: 'Browse NFTs, collections, listings and offers on Arbitrum via OpenSea API',
+  tags: ['nft', 'opensea', 'arbitrum'],
+  examples: ['Show my Arbitrum NFTs', 'List Arbitrum collections', 'Get listings for smol-brains on Arbitrum'],
+  inputSchema: z.object({ instruction: z.string() }),
+  tools: [getWalletNftsTool, listCollectionsTool, getCollectionTool, getListingsByCollectionTool, getListingsByAssetTool, getOffersByAssetTool],
+  mcpServers: {
+    'opensea-arbitrum-mcp-server': {
+      command: 'node',
+      moduleName: '@vibekit/opensea-mcp-server',
+      env: {
+        ...process.env as any,
+        OPENSEA_API_KEY: process.env.OPENSEA_API_KEY || ''
+      },
+      disabled: !process.env.OPENSEA_API_KEY
+    }
+  }
+})
+
+


### PR DESCRIPTION


Summary
Adds a production-ready OpenSea (Arbitrum-only) MCP server and integrates read‑only marketplace tools into the quickstart agent. Includes robust SSE/STDIO transports, input normalization, retry/rate‑limit handling, and Inspector‑friendly CORS. A headless SSE client is included for testing without the Inspector.
What’s included
New package: @vibekit/opensea-mcp-server
Endpoints: GET /sse, POST /messages + STDIO transport
CORS enabled; HTTP can be toggled via env
Retries with p-retry, HTTP via undici
Tools (Arbitrum only):
get_wallet_nfts, list_arbitrum_collections, get_collection
get_listings_by_collection, get_listings_by_asset (with optional collection fallback)
get_offers_by_asset (with optional collection fallback)
Input robustness: zod preprocess (trim/lowercase/coercions), snake_case + camelCase aliases, clearer validation
Agent integration: new openseaSkill registered in quickstart agent
Headless test client: scripts/sse-client.ts
Docs: package README with setup and testing
Env vars
Required: OPENSEA_API_KEY
Optional: ENABLE_HTTP=true|false, PORT, OPENSEA_BASE_URL
Inspector (local only): DANGEROUSLY_OMIT_AUTH=true
Run locally
From typescript/: pnpm install && pnpm build
Start server (HTTP/SSE):
cd typescript/lib/mcp-tools/opensea-mcp-server
pnpm build
ENABLE_HTTP=true OPENSEA_API_KEY=YOUR_KEY PORT=3051 node dist/index.js
Headless SSE test:
SSE_URL=http://localhost:3051/sse pnpm exec tsx scripts/sse-client.ts
Inspector (optional):
DANGEROUSLY_OMIT_AUTH=true npx -y @modelcontextprotocol/inspector
Open http://localhost:6274 → New session → Transport: HTTP Server (SSE) → URL: http://localhost:3051/sse → Connect
