### PR TITLE
build(agent-node): run build before packaging

### DIFF
--- a/typescript/lib/agent-node/package.json
+++ b/typescript/lib/agent-node/package.json
@@ -105,6 +105,7 @@
     "cli:dev": "tsx src/cli/loader.ts",
     "client": "tsx src/a2aClient.ts",
     "clean": "rimraf node_modules dist .tsbuildinfo",
+    "prepack": "pnpm build",
     "postinstall": "node ./scripts/remove-local-pnpm-shim.mjs",
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint . --fix && prettier --write .",


### PR DESCRIPTION
## Summary

Ensure the agent-node package always builds before npm pack/publish so the CLI dist assets ship with future releases.

## Changes

- add a prepack hook to run pnpm build prior to packaging
- verified pnpm lint/build succeed and pnpm pack includes dist outputs

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (pnpm lint, pnpm build, pnpm pack)

## Related Issues

Closes #

## Notes

Verified the new prepack hook by running pnpm pack inside lib/agent-node and inspecting the tarball contents.
