### PR TITLE
fix(agent-node): ship postinstall script

### DIFF
--- a/typescript/lib/agent-node/package.json
+++ b/typescript/lib/agent-node/package.json
@@ -30,7 +30,8 @@
   "types": "./dist/config/index.d.mts",
   "files": [
     "dist",
-    ".env.example"
+    ".env.example",
+    "scripts/remove-local-pnpm-shim.mjs"
   ],
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Ensure the published CLI tarball includes the postinstall helper so npm/npx installs stop crashing before the binary runs.

## Changes

- add `scripts/remove-local-pnpm-shim.mjs` to the package files list so the postinstall script exists inside the tarball
- verified the packed artifact now ships the script and reran `pnpm lint`/`pnpm build` for safety

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (`pnpm pack` + install tarball)

## Related Issues

Closes #

## Notes

- Confirmed `@emberai/onchain-actions-registry` prereleases already ship full dist outputs and do not have this postinstall regression.
