### PR TITLE
ci(release): fix tweet copy working dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,9 +116,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Generate release tweet copy
-        run: |
-          cd typescript
-          node scripts/release-tweet-copy.mjs "release-summary-${{ matrix.package.id }}.json"
+        run: node scripts/release-tweet-copy.mjs "release-summary-${{ matrix.package.id }}.json"
 
   sync-next:
     name: Sync next branch


### PR DESCRIPTION
## Summary

Fix release workflow tweet copy working directory.

## Changes

- run release tweet copy using the job default working directory instead of an extra cd

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Related Issues

Closes #

## Notes

Target base branch: next