### PR TITLE
fix(liquidity): require request for wallet positions

### DIFF
--- a/typescript/onchain-actions-plugins/registry/src/core/queries/liquidity.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/queries/liquidity.ts
@@ -14,8 +14,8 @@ export type LiquidityGetPoolsOptions = {
 };
 
 /**
- * Optional hints for fetching wallet liquidity positions. includePrices defaults to true when omitted,
- * and an empty or undefined positionIds array means no filtering.
+ * Request params for fetching wallet liquidity positions. walletAddress is required, includePrices defaults
+ * to true when omitted, and an empty or undefined positionIds array means no filtering.
  */
 export type LiquidityGetWalletPositionsOptions = GetWalletLiquidityPositionsRequest;
 
@@ -23,7 +23,7 @@ export type LiquidityGetWalletPositionsOptions = GetWalletLiquidityPositionsRequ
  * Get liquidity positions for a wallet.
  */
 export type LiquidityGetWalletPositions = (
-  options?: LiquidityGetWalletPositionsOptions
+  options: LiquidityGetWalletPositionsOptions
 ) => Promise<GetWalletLiquidityPositionsResponse>;
 
 /**


### PR DESCRIPTION
## Summary

- require wallet liquidity query to take a non-optional request object
- clarify doc comment about required walletAddress and optional filters

## Changes

- make LiquidityGetWalletPositions require GetWalletLiquidityPositionsRequest in registry queries

## Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Related Issues

Closes #

## Notes

- lint and build run via pnpm
