### PR TITLE
fix(web-ag-ui): restore env example files

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-clmm/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/.env.example
@@ -1,0 +1,30 @@
+# Required (used to derive the managed agent wallet address)
+A2A_TEST_AGENT_NODE_PRIVATE_KEY=replace-with-private-key
+
+# RPC
+ARBITRUM_RPC_URL=https://arb-mainnet.g.alchemy.com/v2/your-key
+
+# Ember API (optional override; defaults to https://api.emberai.xyz)
+#EMBER_API_BASE_URL=http://localhost:50051
+
+# Workflow runtime controls (optional)
+#CLMM_MODE=production # default: debug
+#DEBUG_MODE=true # default: false
+#CLMM_POLL_INTERVAL_MS=30000
+#CLMM_STREAM_LIMIT=50
+
+# Hire entrypoint inputs (pick ONE option)
+#
+# Option A: provide JSON matching OperatorConfigInputSchema
+#CLMM_OPERATOR_INPUT_JSON={"poolAddress":"0x...","walletAddress":"0x...","baseContributionUsd":5000}
+#
+# Option B: provide fields individually (base contribution optional)
+#CLMM_POOL_ADDRESS=0x...
+#CLMM_WALLET_ADDRESS=0x...
+#CLMM_BASE_CONTRIBUTION_USD=5000
+
+# Thread id (optional; if omitted, the hire entrypoint generates a UUIDv7)
+#CLMM_THREAD_ID=
+
+# Keep the process alive after hire so in-process cron ticks can run (default: true)
+#CLMM_KEEP_ALIVE=true

--- a/typescript/clients/web-ag-ui/apps/web/.env.example
+++ b/typescript/clients/web-ag-ui/apps/web/.env.example
@@ -1,0 +1,11 @@
+# Privy App ID for authentication + embedded wallet support.
+# Required at runtime (the app will show a configuration error UI if missing).
+NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id_here
+
+# Required for MetaMask smart-account (EIP-7702) upgrade flow.
+# Client-side: executor address used when requesting a 7702 authorization signature from Privy.
+NEXT_PUBLIC_EXECUTOR_ADDRESS=0x0000000000000000000000000000000000000000
+
+# Server-side: relayer wallet that broadcasts the EIP-7702 authorization transaction.
+# Never expose this key publicly.
+FUNDING_WALLET_PRIVATE_KEY=0x


### PR DESCRIPTION
## Summary

Restore the deleted web-ag-ui .env.example files.

## Changes

- Re-add `apps/agent-clmm/.env.example` and `apps/web/.env.example`.

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Related Issues

Closes #

## Notes

