### PR TITLE
feat(liquidity): update schemas for new fields

### DIFF
--- a/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
+++ b/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
@@ -92,6 +92,7 @@ export interface LiquidityPair {
 }
 
 export interface LiquidityPosition {
+  positionId: string;
   tokenId: string;
   poolAddress: string;
   operator: string;
@@ -103,7 +104,25 @@ export interface LiquidityPosition {
   amount1: string;
   symbol0: string;
   symbol1: string;
+  rewardsOwedTokens: {
+    tokenUid: { chainId: string; address: string };
+    amount: string;
+    usdPrice?: string;
+    valueUsd?: string;
+    source: string;
+  }[];
+  feesValueUsd?: string;
+  rewardsValueUsd?: string;
+  positionValueUsd?: string;
   price: string;
+  currentPrice?: string;
+  currentTick?: number;
+  tickLower?: number;
+  tickUpper?: number;
+  inRange?: boolean;
+  apr?: string;
+  apy?: string;
+  poolFeeBps?: number;
   providerId: string;
   positionRange?: {
     fromPrice: string;

--- a/typescript/community/agents/liquidity-agent-no-wallet/src/agentToolHandlers.ts
+++ b/typescript/community/agents/liquidity-agent-no-wallet/src/agentToolHandlers.ts
@@ -82,7 +82,7 @@ export async function handleGetLiquidityPools(
 
     let responseText = 'Available Liquidity Pools:\n';
     liquidityPools.forEach((pool: LiquidityPool) => {
-      responseText += `- ${pool.symbol0}/${pool.symbol1} (Price: ${pool.price})\n`;
+      responseText += `- ${pool.symbol0}/${pool.symbol1} (Price: ${pool.currentPrice})\n`;
     });
 
     return createTaskResult(context.userAddress, TaskState.Completed, responseText, [

--- a/typescript/lib/ember-api/src/schemas/liquidity.ts
+++ b/typescript/lib/ember-api/src/schemas/liquidity.ts
@@ -26,7 +26,17 @@ export const LiquidityPositionRangeSchema = z.object({
 });
 export type LiquidityPositionRange = z.infer<typeof LiquidityPositionRangeSchema>;
 
+export const LiquidityRewardsOwedTokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  usdPrice: z.string().optional(),
+  valueUsd: z.string().optional(),
+  source: z.string(),
+});
+export type LiquidityRewardsOwedToken = z.infer<typeof LiquidityRewardsOwedTokenSchema>;
+
 export const LiquidityPositionSchema = z.object({
+  positionId: z.string(),
   tokenId: z.string(),
   poolAddress: z.string(),
   operator: z.string(),
@@ -38,7 +48,19 @@ export const LiquidityPositionSchema = z.object({
   amount1: z.string(),
   symbol0: z.string(),
   symbol1: z.string(),
+  rewardsOwedTokens: z.array(LiquidityRewardsOwedTokenSchema),
+  feesValueUsd: z.string().optional(),
+  rewardsValueUsd: z.string().optional(),
+  positionValueUsd: z.string().optional(),
   price: z.string(),
+  currentPrice: z.string().optional(),
+  currentTick: z.number().int().optional(),
+  tickLower: z.number().int().optional(),
+  tickUpper: z.number().int().optional(),
+  inRange: z.boolean().optional(),
+  apr: z.string().optional(),
+  apy: z.string().optional(),
+  poolFeeBps: z.number().int().optional(),
   providerId: z.string(),
   positionRange: LiquidityPositionRangeSchema.optional(),
 });
@@ -49,8 +71,12 @@ export const LiquidityPoolSchema = z.object({
   token1: TokenIdentifierSchema,
   symbol0: z.string(),
   symbol1: z.string(),
-  price: z.string(),
+  currentPrice: z.string(),
   providerId: z.string(),
+  feeTierBps: z.number().int().optional(),
+  liquidity: z.string().optional(),
+  tvlUsd: z.string().optional(),
+  volume24hUsd: z.string().optional(),
 });
 export type LiquidityPool = z.infer<typeof LiquidityPoolSchema>;
 

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
@@ -27,11 +27,33 @@ export const LiquiditySuppliedTokenSchema = z.object({
 });
 export type LiquiditySuppliedToken = z.infer<typeof LiquiditySuppliedTokenSchema>;
 
+export const LiquidityRewardsOwedTokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  usdPrice: z.string().optional(),
+  valueUsd: z.string().optional(),
+  source: z.string(),
+});
+export type LiquidityRewardsOwedToken = z.infer<typeof LiquidityRewardsOwedTokenSchema>;
+
 export const LiquidityPositionSchema = z.object({
+  positionId: z.string(),
   poolIdentifier: TokenIdentifierSchema,
   operator: z.string(),
   suppliedTokens: z.array(LiquiditySuppliedTokenSchema),
+  rewardsOwedTokens: z.array(LiquidityRewardsOwedTokenSchema),
+  feesValueUsd: z.string().optional(),
+  rewardsValueUsd: z.string().optional(),
+  positionValueUsd: z.string().optional(),
   price: z.string(),
+  currentPrice: z.string().optional(),
+  currentTick: z.number().int().optional(),
+  tickLower: z.number().int().optional(),
+  tickUpper: z.number().int().optional(),
+  inRange: z.boolean().optional(),
+  apr: z.string().optional(),
+  apy: z.string().optional(),
+  poolFeeBps: z.number().int().optional(),
   providerId: z.string(),
   positionRange: LiquidityPositionRangeSchema.optional(),
 });
@@ -45,8 +67,12 @@ export type LiquidityPoolTokens = z.infer<typeof LiquidityPoolTokens>;
 export const LiquidityPoolSchema = z.object({
   identifier: TokenIdentifierSchema,
   tokens: z.array(LiquidityPoolTokens),
-  price: z.string(),
+  currentPrice: z.string(),
   providerId: z.string(),
+  feeTierBps: z.number().int().optional(),
+  liquidity: z.string().optional(),
+  tvlUsd: z.string().optional(),
+  volume24hUsd: z.string().optional(),
   tickSpacing: z.number().int().optional(),
 });
 export type LiquidityPool = z.infer<typeof LiquidityPoolSchema>;
@@ -86,7 +112,7 @@ export type WithdrawLiquidityResponse = z.infer<typeof WithdrawLiquidityResponse
 export const GetWalletLiquidityPositionsRequestSchema = z.object({
   walletAddress: z.string(),
   includePrices: z.boolean().optional(),
-  positionIds: z.array(z.number()).optional(),
+  positionIds: z.array(z.string()).optional(),
 });
 export type GetWalletLiquidityPositionsRequest = z.infer<
   typeof GetWalletLiquidityPositionsRequestSchema


### PR DESCRIPTION
## Summary

Update liquidity schemas and agent types to reflect new position and pool fields.

## Changes

- add rewards owed token schema and new position fields in registry and ember-api
- replace pool price with currentPrice and add pool metrics
- align liquidity agent types and pool display with currentPrice
- change positionIds filter to string array

## Testing

- [ ] Unit tests pass (Not run; not requested)
- [ ] Integration tests pass (Not run; not requested)
- [ ] Manual testing completed (Not run; not requested)

## Related Issues

Closes #N/A

## Notes

-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/tomdaniel/Documents/Ember_Cognition_Inc/Software/vibekit-worktrees/ember-registry-liquidity-schemas".
-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/tomdaniel/Documents/Ember_Cognition_Inc/Software/vibekit-worktrees/ember-registry-liquidity-schemas".