### PR TITLE
fix(liquidity): include pooled and fee tokens

### DIFF
--- a/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
+++ b/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
@@ -104,6 +104,18 @@ export interface LiquidityPosition {
   amount1: string;
   symbol0: string;
   symbol1: string;
+  pooledTokens: {
+    tokenUid: { chainId: string; address: string };
+    amount: string;
+    usdPrice?: string;
+    valueUsd?: string;
+  }[];
+  feesOwedTokens: {
+    tokenUid: { chainId: string; address: string };
+    amount: string;
+    usdPrice?: string;
+    valueUsd?: string;
+  }[];
   rewardsOwedTokens: {
     tokenUid: { chainId: string; address: string };
     amount: string;

--- a/typescript/lib/ember-api/src/schemas/liquidity.ts
+++ b/typescript/lib/ember-api/src/schemas/liquidity.ts
@@ -35,6 +35,22 @@ export const LiquidityRewardsOwedTokenSchema = z.object({
 });
 export type LiquidityRewardsOwedToken = z.infer<typeof LiquidityRewardsOwedTokenSchema>;
 
+export const LiquidityPooledTokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  usdPrice: z.string().optional(),
+  valueUsd: z.string().optional(),
+});
+export type LiquidityPooledToken = z.infer<typeof LiquidityPooledTokenSchema>;
+
+export const LiquidityFeesOwedTokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  usdPrice: z.string().optional(),
+  valueUsd: z.string().optional(),
+});
+export type LiquidityFeesOwedToken = z.infer<typeof LiquidityFeesOwedTokenSchema>;
+
 export const LiquidityPositionSchema = z.object({
   positionId: z.string(),
   tokenId: z.string(),
@@ -48,6 +64,8 @@ export const LiquidityPositionSchema = z.object({
   amount1: z.string(),
   symbol0: z.string(),
   symbol1: z.string(),
+  pooledTokens: z.array(LiquidityPooledTokenSchema),
+  feesOwedTokens: z.array(LiquidityFeesOwedTokenSchema),
   rewardsOwedTokens: z.array(LiquidityRewardsOwedTokenSchema),
   feesValueUsd: z.string().optional(),
   rewardsValueUsd: z.string().optional(),

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
@@ -36,11 +36,29 @@ export const LiquidityRewardsOwedTokenSchema = z.object({
 });
 export type LiquidityRewardsOwedToken = z.infer<typeof LiquidityRewardsOwedTokenSchema>;
 
+export const LiquidityPooledTokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  usdPrice: z.string().optional(),
+  valueUsd: z.string().optional(),
+});
+export type LiquidityPooledToken = z.infer<typeof LiquidityPooledTokenSchema>;
+
+export const LiquidityFeesOwedTokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  usdPrice: z.string().optional(),
+  valueUsd: z.string().optional(),
+});
+export type LiquidityFeesOwedToken = z.infer<typeof LiquidityFeesOwedTokenSchema>;
+
 export const LiquidityPositionSchema = z.object({
   positionId: z.string(),
   poolIdentifier: TokenIdentifierSchema,
   operator: z.string(),
   suppliedTokens: z.array(LiquiditySuppliedTokenSchema),
+  pooledTokens: z.array(LiquidityPooledTokenSchema),
+  feesOwedTokens: z.array(LiquidityFeesOwedTokenSchema),
   rewardsOwedTokens: z.array(LiquidityRewardsOwedTokenSchema),
   feesValueUsd: z.string().optional(),
   rewardsValueUsd: z.string().optional(),


### PR DESCRIPTION
## Summary

Include pooledTokens and feesOwedTokens in liquidity position schemas to match adapter output.

## Changes

- add pooled/fees token schemas in registry and ember-api liquidity schemas
- include pooledTokens and feesOwedTokens on liquidity position schemas
- update liquidity agent position type to accept pooled/fees tokens

## Testing

- [ ] Unit tests pass (Not run; not requested)
- [ ] Integration tests pass (Not run; not requested)
- [ ] Manual testing completed (Not run; not requested)

## Related Issues

Closes #N/A

## Notes

-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/tomdaniel/Documents/Ember_Cognition_Inc/Software/vibekit-worktrees/ember-registry-liquidity-schemas".
-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/tomdaniel/Documents/Ember_Cognition_Inc/Software/vibekit-worktrees/ember-registry-liquidity-schemas".