### PR TITLE
fix(liquidity): remove position price

### DIFF
--- a/typescript/clients/web/src/components/tools/Liquidity.tsx
+++ b/typescript/clients/web/src/components/tools/Liquidity.tsx
@@ -13,7 +13,7 @@ interface IPool {
   symbol1: string;
   token0: { chainId: string; address: string };
   token1: { chainId: string; address: string };
-  price: string;
+  currentPrice?: string;
 }
 
 interface IPosition {
@@ -28,7 +28,6 @@ interface IPosition {
   symbol1: string;
   amount0: string;
   amount1: string;
-  price: string;
   providerId: string;
   positionRange: { fromPrice: string; toPrice: string };
 }
@@ -121,7 +120,10 @@ export function Liquidity({
             </h2>
           </div>
           {pools.map((x) => (
-            <div key={x.handle + x.price} className="bg-black/30 rounded p-3 space-y-2">
+            <div
+              key={x.handle + (x.currentPrice ?? '')}
+              className="bg-black/30 rounded p-3 space-y-2"
+            >
               <div className="text-sm font-semibold text-white">
                 {x.symbol0} / {x.symbol1}
               </div>
@@ -135,7 +137,9 @@ export function Liquidity({
                   <div className="text-gray-600 truncate">{x.token1.address}</div>
                 </div>
               </div>
-              <div className="text-xs text-gray-500">Price: {strToDecimal(x.price)}</div>
+              <div className="text-xs text-gray-500">
+                Current Price: {x.currentPrice ? strToDecimal(x.currentPrice) : 'N/A'}
+              </div>
             </div>
           ))}
         </div>

--- a/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
+++ b/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
@@ -126,7 +126,6 @@ export interface LiquidityPosition {
   feesValueUsd?: string;
   rewardsValueUsd?: string;
   positionValueUsd?: string;
-  price: string;
   currentPrice?: string;
   currentTick?: number;
   tickLower?: number;

--- a/typescript/community/agents/liquidity-agent-no-wallet/src/agentToolHandlers.ts
+++ b/typescript/community/agents/liquidity-agent-no-wallet/src/agentToolHandlers.ts
@@ -141,7 +141,7 @@ export async function handleGetWalletLiquidityPositions(
       responseText += `${index + 1}: ${pos.symbol0}/${pos.symbol1}\n`;
       responseText += `  Amount0: ${pos.amount0} ${pos.symbol0}\n`;
       responseText += `  Amount1: ${pos.amount1} ${pos.symbol1}\n`;
-      responseText += `  Price: ${pos.price}\n`;
+      responseText += `  Current Price: ${pos.currentPrice ?? 'N/A'}\n`;
       responseText += `  Price Range: ${
         pos.positionRange
           ? pos.positionRange.fromPrice + ' to ' + pos.positionRange.toPrice

--- a/typescript/lib/ember-api/src/schemas/liquidity.ts
+++ b/typescript/lib/ember-api/src/schemas/liquidity.ts
@@ -70,7 +70,6 @@ export const LiquidityPositionSchema = z.object({
   feesValueUsd: z.string().optional(),
   rewardsValueUsd: z.string().optional(),
   positionValueUsd: z.string().optional(),
-  price: z.string(),
   currentPrice: z.string().optional(),
   currentTick: z.number().int().optional(),
   tickLower: z.number().int().optional(),

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
@@ -63,7 +63,6 @@ export const LiquidityPositionSchema = z.object({
   feesValueUsd: z.string().optional(),
   rewardsValueUsd: z.string().optional(),
   positionValueUsd: z.string().optional(),
-  price: z.string(),
   currentPrice: z.string().optional(),
   currentTick: z.number().int().optional(),
   tickLower: z.number().int().optional(),


### PR DESCRIPTION
## Summary

Remove the price field from liquidity position schemas and update consumers to use currentPrice.

## Changes

- Drop LiquidityPosition.price from registry and ember-api schemas
- Update liquidity agent output to show currentPrice when available
- Align web liquidity component types/labels with currentPrice

## Testing

- [ ] Unit tests pass (not run)
- [ ] Integration tests pass (not run)
- [ ] Manual testing completed (not run)

## Related Issues

Closes #

## Notes

- Ran pnpm lint and pnpm build from typescript/
- pnpm lint and pnpm build in typescript/community/agents/liquidity-agent-no-wallet fail due to missing typescript/community/tsconfig.base.json and related paths
