### PR TITLE
fix(liquidity): expand pooled and fees tokens

### DIFF
--- a/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
+++ b/typescript/community/agents/liquidity-agent-no-wallet/src/agent.ts
@@ -106,12 +106,18 @@ export interface LiquidityPosition {
   symbol1: string;
   pooledTokens: {
     tokenUid: { chainId: string; address: string };
+    name: string;
+    symbol: string;
+    decimals: number;
     amount: string;
     usdPrice?: string;
     valueUsd?: string;
   }[];
   feesOwedTokens: {
     tokenUid: { chainId: string; address: string };
+    name: string;
+    symbol: string;
+    decimals: number;
     amount: string;
     usdPrice?: string;
     valueUsd?: string;

--- a/typescript/lib/ember-api/src/schemas/liquidity.ts
+++ b/typescript/lib/ember-api/src/schemas/liquidity.ts
@@ -37,6 +37,9 @@ export type LiquidityRewardsOwedToken = z.infer<typeof LiquidityRewardsOwedToken
 
 export const LiquidityPooledTokenSchema = z.object({
   tokenUid: TokenIdentifierSchema,
+  name: z.string(),
+  symbol: z.string(),
+  decimals: z.number().int(),
   amount: z.string(),
   usdPrice: z.string().optional(),
   valueUsd: z.string().optional(),
@@ -45,6 +48,9 @@ export type LiquidityPooledToken = z.infer<typeof LiquidityPooledTokenSchema>;
 
 export const LiquidityFeesOwedTokenSchema = z.object({
   tokenUid: TokenIdentifierSchema,
+  name: z.string(),
+  symbol: z.string(),
+  decimals: z.number().int(),
   amount: z.string(),
   usdPrice: z.string().optional(),
   valueUsd: z.string().optional(),

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/liquidity.ts
@@ -20,13 +20,6 @@ export const LiquidityPositionRangeSchema = z.object({
 });
 export type LiquidityPositionRange = z.infer<typeof LiquidityPositionRangeSchema>;
 
-export const LiquiditySuppliedTokenSchema = z.object({
-  tokenUid: TokenIdentifierSchema,
-  suppliedAmount: z.string(),
-  owedTokens: z.string(),
-});
-export type LiquiditySuppliedToken = z.infer<typeof LiquiditySuppliedTokenSchema>;
-
 export const LiquidityRewardsOwedTokenSchema = z.object({
   tokenUid: TokenIdentifierSchema,
   amount: z.string(),
@@ -38,6 +31,9 @@ export type LiquidityRewardsOwedToken = z.infer<typeof LiquidityRewardsOwedToken
 
 export const LiquidityPooledTokenSchema = z.object({
   tokenUid: TokenIdentifierSchema,
+  name: z.string(),
+  symbol: z.string(),
+  decimals: z.number().int(),
   amount: z.string(),
   usdPrice: z.string().optional(),
   valueUsd: z.string().optional(),
@@ -46,6 +42,9 @@ export type LiquidityPooledToken = z.infer<typeof LiquidityPooledTokenSchema>;
 
 export const LiquidityFeesOwedTokenSchema = z.object({
   tokenUid: TokenIdentifierSchema,
+  name: z.string(),
+  symbol: z.string(),
+  decimals: z.number().int(),
   amount: z.string(),
   usdPrice: z.string().optional(),
   valueUsd: z.string().optional(),
@@ -56,7 +55,6 @@ export const LiquidityPositionSchema = z.object({
   positionId: z.string(),
   poolIdentifier: TokenIdentifierSchema,
   operator: z.string(),
-  suppliedTokens: z.array(LiquiditySuppliedTokenSchema),
   pooledTokens: z.array(LiquidityPooledTokenSchema),
   feesOwedTokens: z.array(LiquidityFeesOwedTokenSchema),
   rewardsOwedTokens: z.array(LiquidityRewardsOwedTokenSchema),


### PR DESCRIPTION
## Summary

Remove suppliedTokens and add token metadata to pooled/fees owed tokens in liquidity schemas and typings.

## Changes

- remove suppliedTokens from registry liquidity positions
- add name/symbol/decimals to pooledTokens and feesOwedTokens in registry and ember-api schemas
- align liquidity agent typings with the expanded token fields

## Testing

- [ ] Unit tests pass (not run; not requested)
- [ ] Integration tests pass (not run; not requested)
- [ ] Manual testing completed (not run; not requested)

## Related Issues

Closes #n/a

## Notes

Schema-only changes; provider implementations should supply token metadata fields for pooled and fees owed tokens.
