### PR TITLE
fix(registry): coerce perpetual create amount to bigint

### DIFF
--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.ts
@@ -92,9 +92,33 @@ export type PerpetualsOrder = z.infer<typeof OrderSchema>;
 
 export const OrdersDataSchema = z.array(OrderSchema);
 
+const BaseUnitAmountSchema = z.preprocess((value) => {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      return value;
+    }
+
+    return BigInt(value);
+  }
+
+  if (typeof value === 'string') {
+    if (!/^\d+$/u.test(value)) {
+      return value;
+    }
+
+    return BigInt(value);
+  }
+
+  return value;
+}, z.bigint());
+
 // Definition for plugin with mapped entities already in place
 export const CreatePerpetualsPositionRequestSchema = z.object({
-  amount: z.bigint(),
+  amount: BaseUnitAmountSchema,
   walletAddress: z.string(),
   chainId: z.string(),
   marketAddress: z.string(),


### PR DESCRIPTION
## Summary
- update `CreatePerpetualsPositionRequestSchema` in `@emberai/onchain-actions-registry` to coerce integer `amount` inputs (`string`/`number`/`bigint`) to `bigint`
- keep output typing as `bigint` for downstream adapters while removing the need for local schema patching in onchain-actions
- this is the registry-side change requested by the review discussion in `EmberAGI/onchain-actions#262`

## Why
`onchain-actions` PR #262 introduced a local coercion schema for perpetual create requests. The review requested moving this typing/parsing behavior into the source package (`arbitrum-vibekit` registry) instead of patching it downstream.

## Validation
- `pnpm -C typescript --filter @emberai/onchain-actions-registry lint`
- `pnpm -C typescript --filter @emberai/onchain-actions-registry build`
- `pnpm -C typescript lint`
- `pnpm -C typescript build`
