### PR TITLE
fix(release): sync next via PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,8 +227,10 @@ jobs:
 
             echo "Created sync PR: $pr_url"
 
-            # Prefer a linear, fast-forward style merge; fall back to a merge commit if rebase isn't allowed.
-            gh pr merge --auto --rebase "$pr_url" || gh pr merge --auto --merge "$pr_url" || \
+            # Prefer merge-commit so commits from main keep their SHAs.
+            # Note: GitHub PR merges cannot "fast-forward" next to main; the best we can do under PR-only
+            # branch protection is ensure next contains main, while preserving main's commit SHAs.
+            gh pr merge --auto --merge "$pr_url" || gh pr merge --auto --rebase "$pr_url" || \
               echo "::warning::Unable to auto-merge $pr_url; please merge manually."
           else
             echo "::warning::origin/next has diverged from main; skipping auto-sync. Please merge main into next manually."


### PR DESCRIPTION
## Summary
- Replace direct fast-forward push to `next` (blocked by repo rules) with an automated PR from `main` -> `next`.
- Attempt auto-merge (rebase preferred, merge fallback).

## Why
`next` is PR-only protected, so the release workflow cannot `git push ...:next`. Creating a PR satisfies repository rules while keeping `next` aligned after releases.

## Test Plan
- Not run (workflow-only change).
