### PR TITLE
fix(agent-pendle): resolve GraphRecursionError recursion limit exhaustion

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/agent.ts
@@ -9,6 +9,10 @@ import {
   resolveLangGraphDurability,
   type LangGraphDurability,
 } from './config/serviceConfig.js';
+import {
+  canStartBackgroundCycle,
+  getBackgroundCycleReadiness,
+} from './workflow/backgroundCycleReadiness.js';
 import { ClmmStateAnnotation, memory, type ClmmState } from './workflow/context.js';
 import { configureCronExecutor } from './workflow/cronScheduler.js';
 import { bootstrapNode } from './workflow/nodes/bootstrap.js';
@@ -154,7 +158,7 @@ async function updateCycleState(
   baseUrl: string,
   threadId: string,
   runMessage: { id: string; role: 'user'; content: string },
-) {
+): Promise<boolean> {
   let existingView: Record<string, unknown> | null = null;
   try {
     const currentState = await fetchThreadStateValues(baseUrl, threadId);
@@ -167,6 +171,14 @@ async function updateCycleState(
     console.warn('[cron] Unable to fetch thread state before cycle update', { threadId, error: message });
   }
 
+  if (!canStartBackgroundCycle(existingView)) {
+    console.warn('[cron] Skipping cycle run; onboarding/setup is incomplete for background execution', {
+      threadId,
+      readiness: getBackgroundCycleReadiness(existingView),
+    });
+    return false;
+  }
+
   const view = existingView ? { ...existingView, command: 'cycle' } : { command: 'cycle' };
   const response = await fetch(`${baseUrl}/threads/${threadId}/state`, {
     method: 'POST',
@@ -177,6 +189,7 @@ async function updateCycleState(
     }),
   });
   await parseJsonResponse(response, ThreadStateUpdateResponseSchema);
+  return true;
 }
 
 async function createRun(params: {
@@ -268,7 +281,10 @@ export async function runGraphOnce(
 
   try {
     await ensureThread(baseUrl, threadId, graphId);
-    await updateCycleState(baseUrl, threadId, runMessage);
+    const stateUpdated = await updateCycleState(baseUrl, threadId, runMessage);
+    if (!stateUpdated) {
+      return;
+    }
     const runId = await createRun({ baseUrl, threadId, graphId, durability });
     if (!runId) {
       return;

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/backgroundCycleReadiness.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/backgroundCycleReadiness.ts
@@ -1,0 +1,54 @@
+type ThreadView = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export type BackgroundCycleReadiness = {
+  hasView: boolean;
+  hasOperatorInput: boolean;
+  hasFundingTokenInput: boolean;
+  hasDelegationAccess: boolean;
+  hasOperatorConfig: boolean;
+  isSetupComplete: boolean;
+};
+
+export function getBackgroundCycleReadiness(view: ThreadView | null): BackgroundCycleReadiness {
+  if (!isRecord(view)) {
+    return {
+      hasView: false,
+      hasOperatorInput: false,
+      hasFundingTokenInput: false,
+      hasDelegationAccess: false,
+      hasOperatorConfig: false,
+      isSetupComplete: false,
+    };
+  }
+
+  const hasOperatorInput = isRecord(view['operatorInput']);
+  const hasFundingTokenInput = isRecord(view['fundingTokenInput']);
+  const hasDelegationAccess =
+    view['delegationsBypassActive'] === true || isRecord(view['delegationBundle']);
+  const hasOperatorConfig = isRecord(view['operatorConfig']);
+  const isSetupComplete = view['setupComplete'] === true;
+
+  return {
+    hasView: true,
+    hasOperatorInput,
+    hasFundingTokenInput,
+    hasDelegationAccess,
+    hasOperatorConfig,
+    isSetupComplete,
+  };
+}
+
+export function canStartBackgroundCycle(view: ThreadView | null): boolean {
+  const readiness = getBackgroundCycleReadiness(view);
+  return (
+    readiness.hasView &&
+    readiness.hasOperatorInput &&
+    readiness.hasFundingTokenInput &&
+    readiness.hasDelegationAccess &&
+    readiness.hasOperatorConfig &&
+    readiness.isSetupComplete
+  );
+}

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/backgroundCycleReadiness.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/backgroundCycleReadiness.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  canStartBackgroundCycle,
+  getBackgroundCycleReadiness,
+} from './backgroundCycleReadiness.js';
+
+describe('background cycle readiness', () => {
+  it('is not ready when no persisted view exists', () => {
+    const readiness = getBackgroundCycleReadiness(null);
+
+    expect(readiness).toEqual({
+      hasView: false,
+      hasOperatorInput: false,
+      hasFundingTokenInput: false,
+      hasDelegationAccess: false,
+      hasOperatorConfig: false,
+      isSetupComplete: false,
+    });
+    expect(canStartBackgroundCycle(null)).toBe(false);
+  });
+
+  it('is not ready when setup is incomplete', () => {
+    const view = {
+      operatorInput: { walletAddress: '0xabc', baseContributionUsd: 10 },
+      fundingTokenInput: { fundingTokenAddress: '0xdef' },
+      delegationsBypassActive: true,
+      operatorConfig: { walletAddress: '0xabc' },
+      setupComplete: false,
+    };
+
+    expect(canStartBackgroundCycle(view)).toBe(false);
+  });
+
+  it('is ready when setup is complete and delegation bypass is active', () => {
+    const view = {
+      operatorInput: { walletAddress: '0xabc', baseContributionUsd: 10 },
+      fundingTokenInput: { fundingTokenAddress: '0xdef' },
+      delegationsBypassActive: true,
+      operatorConfig: { walletAddress: '0xabc' },
+      setupComplete: true,
+    };
+
+    expect(canStartBackgroundCycle(view)).toBe(true);
+  });
+
+  it('is ready when setup is complete and a delegation bundle exists', () => {
+    const view = {
+      operatorInput: { walletAddress: '0xabc', baseContributionUsd: 10 },
+      fundingTokenInput: { fundingTokenAddress: '0xdef' },
+      delegationsBypassActive: false,
+      delegationBundle: { delegations: [{ signature: '0xsig' }] },
+      operatorConfig: { walletAddress: '0xabc' },
+      setupComplete: true,
+    };
+
+    expect(canStartBackgroundCycle(view)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a background-cycle readiness guard for `agent-pendle` cron runs.
- Skip background `cycle` runs when onboarding/setup state is incomplete.
- Add regression unit coverage for readiness evaluation.

## Context
- Observed at `2026-02-11T00:34:26Z` (UTC)
- Run ID: `d4eb1584-5d1d-410f-bf2f-a8b248368dbd`
- Error: `GraphRecursionError` with recursion limit `25` reached

## Root Cause
Background cron execution (`runGraphOnce`) always attempted a `cycle` run even when persisted thread state was onboarding-incomplete. In non-interactive runs this can route into onboarding interrupt paths and produce non-terminating transition behavior that surfaces as recursion-limit exhaustion.

## Changes
- Added `backgroundCycleReadiness` helper to evaluate whether a thread is ready for background `cycle` execution.
- Updated `updateCycleState` in `agent.ts` to:
  - return `false` when readiness checks fail,
  - log readiness details,
  - avoid posting cycle state and avoid creating a run in that case.
- Added `backgroundCycleReadiness.unit.test.ts` coverage.

Closes #414

## Test Plan
- [x] `pnpm test:unit src/workflow/backgroundCycleReadiness.unit.test.ts src/workflow/nodes/runCommand.unit.test.ts`
- [x] `pnpm test:int src/workflow/nodes/pollCycle.int.test.ts -t "no onboarding recursion"`
- [x] `pnpm lint`
- [x] `pnpm build`