### PR TITLE
fix(web): handle no-caveat delegation signing guard

### DIFF
--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -11,7 +11,6 @@ import {
   Check,
   RefreshCw,
 } from 'lucide-react';
-import { signDelegation } from '@metamask/delegation-toolkit/actions';
 import { formatUnits } from 'viem';
 import { useEffect, useState, type FormEvent } from 'react';
 import type {
@@ -38,6 +37,7 @@ import type {
 import { usePrivyWalletClient } from '../hooks/usePrivyWalletClient';
 import { formatPoolPair } from '../utils/poolFormat';
 import { resolveMetricsTabLabel } from '../utils/agentUi';
+import { signDelegationWithFallback } from '../utils/delegationSigning';
 
 export type { AgentProfile, AgentMetrics, Transaction, TelemetryItem, ClmmEvent };
 
@@ -1053,13 +1053,12 @@ function AgentBlockersTab({
             `Delegation delegator ${delegation.delegator} does not match required signer ${interrupt.delegatorAddress}.`,
           );
         }
-        const allowInsecureUnrestrictedDelegation = delegation.caveats.length === 0;
-        const signature = await signDelegation(walletClient, {
+        const signature = await signDelegationWithFallback({
+          walletClient,
           delegation,
           delegationManager: interrupt.delegationManager,
           chainId: interrupt.chainId,
           account: interrupt.delegatorAddress,
-          allowInsecureUnrestrictedDelegation,
         });
         signedDelegations.push({ ...delegation, signature });
       }

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/delegationSigning.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/delegationSigning.ts
@@ -1,0 +1,59 @@
+import { signDelegation } from '@metamask/delegation-toolkit/actions';
+
+import type { UnsignedDelegation } from '../types/agent';
+
+type SignDelegationAction = typeof signDelegation;
+type WalletSignerClient = Parameters<SignDelegationAction>[0];
+
+const NO_CAVEATS_ERROR_FRAGMENT = 'No caveats found';
+const INSECURE_FLAG_ERROR_FRAGMENT = 'allowInsecureUnrestrictedDelegation';
+
+function hasNoCaveatsGuardError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error.message.includes(NO_CAVEATS_ERROR_FRAGMENT) &&
+    error.message.includes(INSECURE_FLAG_ERROR_FRAGMENT)
+  );
+}
+
+function resolveCaveatCount(delegation: UnsignedDelegation): number {
+  return Array.isArray(delegation.caveats) ? delegation.caveats.length : 0;
+}
+
+export async function signDelegationWithFallback(params: {
+  walletClient: WalletSignerClient;
+  delegation: UnsignedDelegation;
+  delegationManager: `0x${string}`;
+  chainId: number;
+  account: `0x${string}`;
+  signDelegationFn?: SignDelegationAction;
+}): Promise<`0x${string}`> {
+  const signDelegationFn = params.signDelegationFn ?? signDelegation;
+  const shouldAllowUnrestrictedDelegation = resolveCaveatCount(params.delegation) === 0;
+
+  try {
+    return await signDelegationFn(params.walletClient, {
+      delegation: params.delegation,
+      delegationManager: params.delegationManager,
+      chainId: params.chainId,
+      account: params.account,
+      allowInsecureUnrestrictedDelegation: shouldAllowUnrestrictedDelegation,
+    });
+  } catch (error) {
+    if (shouldAllowUnrestrictedDelegation || !hasNoCaveatsGuardError(error)) {
+      throw error;
+    }
+
+    // Some runtime payloads can still trip the toolkit no-caveats guard.
+    // Retry once with the explicit opt-in flag so signing can proceed.
+    return await signDelegationFn(params.walletClient, {
+      delegation: params.delegation,
+      delegationManager: params.delegationManager,
+      chainId: params.chainId,
+      account: params.account,
+      allowInsecureUnrestrictedDelegation: true,
+    });
+  }
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/delegationSigning.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/delegationSigning.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { UnsignedDelegation } from '../types/agent';
+
+import { signDelegationWithFallback } from './delegationSigning';
+
+type SignDelegationAction = typeof import('@metamask/delegation-toolkit/actions').signDelegation;
+
+const makeDelegation = (caveatCount: number): UnsignedDelegation => ({
+  delegate: '0x0000000000000000000000000000000000000001',
+  delegator: '0x0000000000000000000000000000000000000002',
+  authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  caveats: Array.from({ length: caveatCount }, () => ({
+    enforcer: '0x0000000000000000000000000000000000000003',
+    terms: '0x',
+    args: '0x',
+  })),
+  salt: '0x01',
+});
+
+describe('signDelegationWithFallback', () => {
+  it('signs empty-caveat delegations with unrestricted flag on first attempt', async () => {
+    const walletClient = {} as Parameters<SignDelegationAction>[0];
+    const signDelegationFn = vi.fn(async () => '0xabc' as const) as SignDelegationAction;
+
+    const signature = await signDelegationWithFallback({
+      walletClient,
+      delegation: makeDelegation(0),
+      delegationManager: '0x0000000000000000000000000000000000000004',
+      chainId: 42161,
+      account: '0x0000000000000000000000000000000000000002',
+      signDelegationFn,
+    });
+
+    expect(signature).toBe('0xabc');
+    expect(signDelegationFn).toHaveBeenCalledTimes(1);
+    expect(signDelegationFn).toHaveBeenCalledWith(
+      walletClient,
+      expect.objectContaining({ allowInsecureUnrestrictedDelegation: true }),
+    );
+  });
+
+  it('retries once with unrestricted flag when toolkit throws no-caveat guard error', async () => {
+    const walletClient = {} as Parameters<SignDelegationAction>[0];
+    const noCaveatsError = new Error(
+      'No caveats found. If you definitely want to sign a delegation without caveats, set `allowInsecureUnrestrictedDelegation` to `true`.',
+    );
+    const signDelegationFn = vi
+      .fn()
+      .mockRejectedValueOnce(noCaveatsError)
+      .mockResolvedValueOnce('0xdef') as SignDelegationAction;
+
+    const signature = await signDelegationWithFallback({
+      walletClient,
+      delegation: makeDelegation(1),
+      delegationManager: '0x0000000000000000000000000000000000000004',
+      chainId: 42161,
+      account: '0x0000000000000000000000000000000000000002',
+      signDelegationFn,
+    });
+
+    expect(signature).toBe('0xdef');
+    expect(signDelegationFn).toHaveBeenCalledTimes(2);
+    expect(signDelegationFn).toHaveBeenNthCalledWith(
+      1,
+      walletClient,
+      expect.objectContaining({ allowInsecureUnrestrictedDelegation: false }),
+    );
+    expect(signDelegationFn).toHaveBeenNthCalledWith(
+      2,
+      walletClient,
+      expect.objectContaining({ allowInsecureUnrestrictedDelegation: true }),
+    );
+  });
+
+  it('does not retry for non-guard errors', async () => {
+    const walletClient = {} as Parameters<SignDelegationAction>[0];
+    const signDelegationFn = vi.fn(async () => {
+      throw new Error('wallet disconnected');
+    }) as SignDelegationAction;
+
+    await expect(
+      signDelegationWithFallback({
+        walletClient,
+        delegation: makeDelegation(1),
+        delegationManager: '0x0000000000000000000000000000000000000004',
+        chainId: 42161,
+        account: '0x0000000000000000000000000000000000000002',
+        signDelegationFn,
+      }),
+    ).rejects.toThrow('wallet disconnected');
+
+    expect(signDelegationFn).toHaveBeenCalledTimes(1);
+    expect(signDelegationFn).toHaveBeenCalledWith(
+      walletClient,
+      expect.objectContaining({ allowInsecureUnrestrictedDelegation: false }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a `signDelegationWithFallback` helper in the web app to centralize delegation signing behavior
- keep the safe default (`allowInsecureUnrestrictedDelegation` only when caveats are empty)
- retry once with `allowInsecureUnrestrictedDelegation: true` only when the toolkit throws the explicit no-caveat guard error
- wire `AgentDetailPage` to use the helper and add focused unit tests

## Verification
- `pnpm --filter web test:unit src/utils/delegationSigning.unit.test.ts`
- `pnpm lint`
- `pnpm build`

Closes #416
