### PR TITLE
chore(ci): enable merge-group CI and merge queue runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    paths:
-      - "typescript/**"
-      - ".github/workflows/ci.yml"
+  merge_group:
+    branches: [main, master, next]
   workflow_dispatch:
 
 jobs:

--- a/docs/merge-queue-runbook.md
+++ b/docs/merge-queue-runbook.md
@@ -1,0 +1,43 @@
+# Merge Queue Runbook
+
+## Purpose
+
+This runbook prevents PR-head vs merge-ref drift by enforcing CI in merge context and serializing merges through GitHub merge queue.
+
+## Required repository settings
+
+- `CI` workflow includes `merge_group` trigger.
+- Branch rulesets for `next` and default branch require:
+  - Strict required status checks (`build`).
+  - Merge queue enabled.
+
+## Daily workflow
+
+1. Open PR as usual and wait for required checks.
+2. Resolve review feedback and re-run checks.
+3. Use merge queue instead of direct merge.
+4. Let queue revalidate in merge context before final merge.
+
+## When to run a local merge-ref check (optional)
+
+Run local parity checks when a PR is high-risk or multiple related PRs are landing together.
+
+Recommended quick check:
+
+```bash
+act merge_group -W .github/workflows/ci.yml -n
+```
+
+If you suspect integration conflicts, run a local merge-ref simulation and verify lint/build:
+
+```bash
+git fetch origin pull/<PR_NUMBER>/head:pr-head pull/<PR_NUMBER>/merge:pr-merge
+git diff pr-head..pr-merge -- <path/to/suspect/file>
+pnpm -C typescript lint
+pnpm -C typescript build
+```
+
+## Operational notes
+
+- Keep admin bypasses rare; bypassing queue weakens merge guarantees.
+- If queue latency grows, tune merge queue batch settings before disabling protection.


### PR DESCRIPTION
## Summary
- add `merge_group` trigger to `CI` workflow for `main`, `master`, and `next`
- remove `pull_request.paths` filter so required `build` status is always emitted on PRs
- add `docs/merge-queue-runbook.md` with queue-first merge flow and optional local merge-ref checks

## Verification
- `act merge_group -W .github/workflows/ci.yml -n`
- `pnpm -C typescript lint`
- `pnpm -C typescript build`

## Notes
- repository rulesets were updated out-of-band to require strict `build` status checks and enable merge queue on default branch and `next`
