### PR TITLE
feat(registry): add public lifecycle capability contracts

### DIFF
--- a/typescript/onchain-actions-plugins/registry/README.md
+++ b/typescript/onchain-actions-plugins/registry/README.md
@@ -87,7 +87,7 @@ interface EmberPlugin<Type extends PluginType> {
   x?: string; // Twitter/X handle
   actions: ActionDefinition<AvailableActions[Type]>[]; // Available actions for this plugin type
   queries: AvailableQueries[Type]; // Data queries for this plugin type
-  lifecycleCapability?: GraphLifecycleCapability; // Optional lifecycle refresh metadata
+  lifecycleCapability?: LifecycleCapability; // Optional lifecycle refresh metadata
 }
 ```
 
@@ -283,7 +283,7 @@ an optional `lifecycleCapability` contract:
 
 ```typescript
 import type {
-  GraphLifecycleCapability,
+  LifecycleCapability,
   LifecycleSegmentTopology,
 } from '@emberai/onchain-actions-registry';
 ```

--- a/typescript/onchain-actions-plugins/registry/src/core/index.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/index.ts
@@ -1,5 +1,5 @@
 import type { ActionDefinition } from './actions/index.js';
-import type { GraphLifecycleCapability } from './lifecycle.js';
+import type { LifecycleCapability } from './lifecycle.js';
 import type { AvailableActions, AvailableQueries, PluginType } from './pluginType.js';
 
 export interface EmberPlugin<Type extends PluginType> {
@@ -38,7 +38,7 @@ export interface EmberPlugin<Type extends PluginType> {
   /**
    * Optional lifecycle capability for topology-sensitive providers.
    */
-  lifecycleCapability?: GraphLifecycleCapability;
+  lifecycleCapability?: LifecycleCapability;
 }
 
 export * from './actions/index.js';

--- a/typescript/onchain-actions-plugins/registry/src/core/lifecycle.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/lifecycle.ts
@@ -34,7 +34,7 @@ export interface LifecycleSegmentTopology {
 /**
  * Optional plugin capability that describes lifecycle-sensitive topology.
  */
-export interface GraphLifecycleCapability {
+export interface LifecycleCapability {
   /**
    * Provider/plugin id whose topology this capability refreshes.
    */

--- a/typescript/onchain-actions-plugins/registry/src/registry.ts
+++ b/typescript/onchain-actions-plugins/registry/src/registry.ts
@@ -1,6 +1,6 @@
 import type {
   EmberPlugin,
-  GraphLifecycleCapability,
+  LifecycleCapability,
   PluginType,
 } from './core/index.js';
 
@@ -10,7 +10,7 @@ import type {
 export class PublicEmberPluginRegistry {
   private plugins: EmberPlugin<PluginType>[] = [];
   private deferredPlugins: Promise<EmberPlugin<PluginType>>[] = [];
-  private lifecycleCapabilities = new Map<string, GraphLifecycleCapability>();
+  private lifecycleCapabilities = new Map<string, LifecycleCapability>();
 
   /**
    * Register a new Ember plugin.
@@ -36,14 +36,14 @@ export class PublicEmberPluginRegistry {
    * Register lifecycle capability metadata for a provider plugin.
    * @param capability Lifecycle capability contract for refresh orchestration.
    */
-  public registerLifecycleCapability(capability: GraphLifecycleCapability) {
+  public registerLifecycleCapability(capability: LifecycleCapability) {
     this.lifecycleCapabilities.set(capability.providerId, capability);
   }
 
   /**
    * Returns all lifecycle capabilities registered in the registry.
    */
-  public getLifecycleCapabilities(): GraphLifecycleCapability[] {
+  public getLifecycleCapabilities(): LifecycleCapability[] {
     return Array.from(this.lifecycleCapabilities.values());
   }
 


### PR DESCRIPTION
## Summary
- add public lifecycle types to `@emberai/onchain-actions-registry` for external plugin authors
- extend `EmberPlugin` with optional `lifecycleCapability` contract
- extend `PublicEmberPluginRegistry` with lifecycle capability registration/discovery APIs
- auto-register lifecycle capability when a plugin is registered
- document lifecycle capability usage in the registry README

## Test Plan
- `pnpm --filter @emberai/onchain-actions-registry lint`
- `pnpm --filter @emberai/onchain-actions-registry build`