### PR TITLE
feat(registry): adopt canonical perpetual contracts

### DIFF
--- a/typescript/onchain-actions-plugins/registry/src/core/actions/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/actions/perpetuals.ts
@@ -1,20 +1,42 @@
 import type {
-  ClosePerpetualsOrdersRequest,
-  ClosePerpetualsOrdersResponse,
-  CreatePerpetualsPositionRequest,
-  CreatePerpetualsPositionResponse,
+  CreatePerpetualsDecreasePlanRequest,
+  CreatePerpetualsDecreasePlanResponse,
+  CreatePerpetualsDecreaseQuoteRequest,
+  CreatePerpetualsDecreaseQuoteResponse,
+  CreatePerpetualsIncreasePlanRequest,
+  CreatePerpetualsIncreasePlanResponse,
+  CreatePerpetualsIncreaseQuoteRequest,
+  CreatePerpetualsIncreaseQuoteResponse,
+  CreatePerpetualsOrderCancelPlanRequest,
+  CreatePerpetualsOrderCancelPlanResponse,
 } from '../schemas/perpetuals.js';
 
-export type PerpetualsCreateShortPositionCallback = (
-  request: CreatePerpetualsPositionRequest
-) => Promise<CreatePerpetualsPositionResponse>;
+export type PerpetualsIncreaseQuoteCallback = (
+  request: CreatePerpetualsIncreaseQuoteRequest
+) => Promise<CreatePerpetualsIncreaseQuoteResponse>;
 
-export type PerpetualsCreateLongPositionCallback = (
-  request: CreatePerpetualsPositionRequest
-) => Promise<CreatePerpetualsPositionResponse>;
+export type PerpetualsIncreasePlanCallback = (
+  request: CreatePerpetualsIncreasePlanRequest
+) => Promise<CreatePerpetualsIncreasePlanResponse>;
 
-export type PerpetualsCloseOrdersCallback = (
-  request: ClosePerpetualsOrdersRequest
-) => Promise<ClosePerpetualsOrdersResponse>;
+export type PerpetualsDecreaseQuoteCallback = (
+  request: CreatePerpetualsDecreaseQuoteRequest
+) => Promise<CreatePerpetualsDecreaseQuoteResponse>;
 
-export type PerpetualsActions = 'perpetuals-short' | 'perpetuals-long' | 'perpetuals-close';
+export type PerpetualsDecreasePlanCallback = (
+  request: CreatePerpetualsDecreasePlanRequest
+) => Promise<CreatePerpetualsDecreasePlanResponse>;
+
+export type PerpetualsOrderCancelPlanCallback = (
+  request: CreatePerpetualsOrderCancelPlanRequest
+) => Promise<CreatePerpetualsOrderCancelPlanResponse>;
+
+export const PerpetualsActionTypes = [
+  'perpetuals-increase-quote',
+  'perpetuals-increase-plan',
+  'perpetuals-decrease-quote',
+  'perpetuals-decrease-plan',
+  'perpetuals-orders-cancel-plan',
+] as const;
+
+export type PerpetualsActions = (typeof PerpetualsActionTypes)[number];

--- a/typescript/onchain-actions-plugins/registry/src/core/actions/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/actions/perpetuals.unit.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { PerpetualsActionTypes } from './perpetuals.js';
+
+describe('PerpetualsActions', () => {
+  it('exposes canonical action keys and excludes legacy action keys', () => {
+    expect(PerpetualsActionTypes).toEqual([
+      'perpetuals-increase-quote',
+      'perpetuals-increase-plan',
+      'perpetuals-decrease-quote',
+      'perpetuals-decrease-plan',
+      'perpetuals-orders-cancel-plan',
+    ]);
+    expect(PerpetualsActionTypes.includes('perpetuals-close')).toBe(false);
+  });
+});

--- a/typescript/onchain-actions-plugins/registry/src/core/actions/types.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/actions/types.ts
@@ -12,9 +12,11 @@ import type {
 } from './liquidity.js';
 import type {
   PerpetualsActions,
-  PerpetualsCloseOrdersCallback,
-  PerpetualsCreateLongPositionCallback,
-  PerpetualsCreateShortPositionCallback,
+  PerpetualsDecreasePlanCallback,
+  PerpetualsDecreaseQuoteCallback,
+  PerpetualsIncreasePlanCallback,
+  PerpetualsIncreaseQuoteCallback,
+  PerpetualsOrderCancelPlanCallback,
 } from './perpetuals.js';
 import type { SwapActionCallback, SwapActions } from './swap.js';
 import type {
@@ -49,9 +51,11 @@ type CallbacksRecord = {
   'lending-withdraw': LendingWithdrawCallback;
   'liquidity-supply': LiquiditySupplyCallback;
   'liquidity-withdraw': LiquidityWithdrawCallback;
-  'perpetuals-short': PerpetualsCreateShortPositionCallback;
-  'perpetuals-long': PerpetualsCreateLongPositionCallback;
-  'perpetuals-close': PerpetualsCloseOrdersCallback;
+  'perpetuals-increase-quote': PerpetualsIncreaseQuoteCallback;
+  'perpetuals-increase-plan': PerpetualsIncreasePlanCallback;
+  'perpetuals-decrease-quote': PerpetualsDecreaseQuoteCallback;
+  'perpetuals-decrease-plan': PerpetualsDecreasePlanCallback;
+  'perpetuals-orders-cancel-plan': PerpetualsOrderCancelPlanCallback;
   'tokenizedYield-mintPtAndYt': TokenizedYieldMintPtAndYtCallback;
   'tokenizedYield-buyPt': TokenizedYieldBuyPtCallback;
   'tokenizedYield-buyYt': TokenizedYieldBuyYtCallback;

--- a/typescript/onchain-actions-plugins/registry/src/core/queries/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/queries/perpetuals.ts
@@ -1,6 +1,8 @@
 import type {
   GetPerpetualsMarketsOrdersRequest,
   GetPerpetualsMarketsOrdersResponse,
+  GetPerpetualLifecycleRequest,
+  GetPerpetualLifecycleResponse,
   GetPerpetualsMarketsPositionsRequest,
   GetPerpetualsMarketsPositionsResponse,
   GetPerpetualsMarketsRequest,
@@ -19,8 +21,20 @@ export type PerpetualsGetOrders = (
   request: GetPerpetualsMarketsOrdersRequest
 ) => Promise<GetPerpetualsMarketsOrdersResponse>;
 
+export type PerpetualsGetLifecycle = (
+  request: GetPerpetualLifecycleRequest
+) => Promise<GetPerpetualLifecycleResponse>;
+
+export const PerpetualsQueryKeys = [
+  'getMarkets',
+  'getPositions',
+  'getOrders',
+  'getLifecycle',
+] as const;
+
 export type PerpetualsQueries = {
   getMarkets: PerpetualsGetMarkets;
   getPositions: PerpetualsGetPositions;
   getOrders: PerpetualsGetOrders;
+  getLifecycle: PerpetualsGetLifecycle;
 };

--- a/typescript/onchain-actions-plugins/registry/src/core/queries/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/queries/perpetuals.unit.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { PerpetualsQueryKeys } from './perpetuals.js';
+
+describe('PerpetualsQueryKeys', () => {
+  it('includes lifecycle lookup query key', () => {
+    expect(PerpetualsQueryKeys).toEqual(['getMarkets', 'getPositions', 'getOrders', 'getLifecycle']);
+  });
+});

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CreatePerpetualsDecreaseQuoteRequestSchema,
+  CreatePerpetualsIncreaseQuoteRequestSchema,
+  CreatePerpetualsOrderCancelPlanRequestSchema,
+  GetPerpetualLifecycleRequestSchema,
+  PerpetualQuoteResponseSchema,
+} from './perpetuals.js';
+import * as perpetualSchemas from './perpetuals.js';
+
+describe('CreatePerpetualsDecreaseQuoteRequestSchema', () => {
+  it('requires sizeDeltaUsd for partial mode', () => {
+    const validPartial = CreatePerpetualsDecreaseQuoteRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'long',
+      mode: 'partial',
+      partial: {
+        sizeDeltaUsd: '100000000',
+        slippageBps: '100',
+      },
+    });
+
+    const invalidPartial = CreatePerpetualsDecreaseQuoteRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'long',
+      mode: 'partial',
+      partial: {
+        slippageBps: '100',
+      },
+    });
+
+    expect(validPartial.success).toBe(true);
+    expect(invalidPartial.success).toBe(false);
+  });
+});
+
+describe('CreatePerpetualsIncreaseQuoteRequestSchema', () => {
+  it('rejects decimal numeric strings for collateralDeltaAmount', () => {
+    const valid = CreatePerpetualsIncreaseQuoteRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'short',
+      collateralDeltaAmount: '1000000',
+      sizeDeltaUsd: '250000000',
+      slippageBps: '120',
+    });
+
+    const invalid = CreatePerpetualsIncreaseQuoteRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'short',
+      collateralDeltaAmount: '1.2',
+      sizeDeltaUsd: '250000000',
+      slippageBps: '120',
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('CreatePerpetualsOrderCancelPlanRequestSchema', () => {
+  it('requires orderKey', () => {
+    const valid = CreatePerpetualsOrderCancelPlanRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      orderKey: '0xorder',
+    });
+
+    const invalid = CreatePerpetualsOrderCancelPlanRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('GetPerpetualLifecycleRequestSchema', () => {
+  it('requires txHash', () => {
+    const valid = GetPerpetualLifecycleRequestSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      txHash: '0xhash',
+    });
+
+    const invalid = GetPerpetualLifecycleRequestSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('PerpetualQuoteResponseSchema', () => {
+  it('requires integer-string numeric fields and precision metadata', () => {
+    const valid = PerpetualQuoteResponseSchema.safeParse({
+      asOf: '2026-02-24T00:00:00.000Z',
+      ttlMs: 30000,
+      precision: {
+        tokenDecimals: 6,
+        priceDecimals: 30,
+        usdDecimals: 30,
+      },
+      pricing: {
+        markPrice: '1234500000000000000000000000000',
+        acceptablePrice: '1234000000000000000000000000000',
+        slippageBps: '100',
+        priceImpactDeltaUsd: '1000000',
+      },
+      fees: {
+        positionFeeUsd: '100000',
+        borrowingFeeUsd: '25000',
+        fundingFeeUsd: '1000',
+      },
+      warnings: [],
+    });
+
+    const invalid = PerpetualQuoteResponseSchema.safeParse({
+      asOf: '2026-02-24T00:00:00.000Z',
+      ttlMs: 30000,
+      precision: {
+        tokenDecimals: 6,
+        priceDecimals: 30,
+        usdDecimals: 30,
+      },
+      pricing: {
+        markPrice: '1234500000000000000000000000000',
+        acceptablePrice: '1.234',
+        slippageBps: '100',
+        priceImpactDeltaUsd: '1000000',
+      },
+      fees: {
+        positionFeeUsd: '100000',
+        borrowingFeeUsd: '25000',
+        fundingFeeUsd: '1000',
+      },
+      warnings: [],
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+});
+
+describe('legacy perpetual core schema removal', () => {
+  it('does not export close-order request schema', () => {
+    expect(perpetualSchemas.ClosePerpetualsOrdersRequestSchema).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- migrate perpetual core action types from legacy long/short/close model to canonical increase/decrease/cancel contracts
- introduce canonical perpetual request/response schemas, including discriminated decrease-mode inputs and normalized quote/plan response shapes
- update perpetual query typings to include lifecycle query support and align query contracts with the canonical schema layer
- add focused unit coverage for new perpetual action keys, query keys, and schema validation behavior

## Testing
- `pnpm -C typescript/onchain-actions-plugins/registry lint`
- `pnpm -C typescript/onchain-actions-plugins/registry build`
- `pnpm -C typescript/onchain-actions-plugins/registry exec vitest run --config /tmp/vitest.registry.config.ts src/core/schemas/perpetuals.unit.test.ts src/core/actions/perpetuals.unit.test.ts src/core/queries/perpetuals.unit.test.ts`
