### PR TITLE
fix(registry): nest perpetual decrease request payload and restore vitest setup

### DIFF
--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.ts
@@ -204,25 +204,25 @@ const PerpetualDecreaseRequestBaseSchema = z.object({
   side: PositionSideSchema,
 });
 
-const PerpetualDecreaseFullRequestSchema = PerpetualDecreaseRequestBaseSchema.extend({
+const PerpetualDecreaseFullSchema = z.object({
   mode: z.literal('full'),
-  full: z.object({
-    slippageBps: Base10IntegerStringSchema,
-  }),
+  slippageBps: Base10IntegerStringSchema,
 });
 
-const PerpetualDecreasePartialRequestSchema = PerpetualDecreaseRequestBaseSchema.extend({
+const PerpetualDecreasePartialSchema = z.object({
   mode: z.literal('partial'),
-  partial: z.object({
-    sizeDeltaUsd: Base10IntegerStringSchema,
-    slippageBps: Base10IntegerStringSchema,
-  }),
+  sizeDeltaUsd: Base10IntegerStringSchema,
+  slippageBps: Base10IntegerStringSchema,
 });
 
-export const CreatePerpetualsDecreaseQuoteRequestSchema = z.discriminatedUnion('mode', [
-  PerpetualDecreaseFullRequestSchema,
-  PerpetualDecreasePartialRequestSchema,
+const PerpetualDecreaseSchema = z.discriminatedUnion('mode', [
+  PerpetualDecreaseFullSchema,
+  PerpetualDecreasePartialSchema,
 ]);
+
+export const CreatePerpetualsDecreaseQuoteRequestSchema = PerpetualDecreaseRequestBaseSchema.extend({
+  decrease: PerpetualDecreaseSchema,
+});
 export type CreatePerpetualsDecreaseQuoteRequest = z.infer<
   typeof CreatePerpetualsDecreaseQuoteRequestSchema
 >;

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts
@@ -10,7 +10,7 @@ import {
 import * as perpetualSchemas from './perpetuals.js';
 
 describe('CreatePerpetualsDecreaseQuoteRequestSchema', () => {
-  it('requires sizeDeltaUsd for partial mode', () => {
+  it('requires sizeDeltaUsd for nested partial decrease mode', () => {
     const validPartial = CreatePerpetualsDecreaseQuoteRequestSchema.safeParse({
       walletAddress: '0xabc',
       providerName: 'gmx',
@@ -18,8 +18,8 @@ describe('CreatePerpetualsDecreaseQuoteRequestSchema', () => {
       marketAddress: '0xmarket',
       collateralTokenAddress: '0xcollateral',
       side: 'long',
-      mode: 'partial',
-      partial: {
+      decrease: {
+        mode: 'partial',
         sizeDeltaUsd: '100000000',
         slippageBps: '100',
       },
@@ -32,14 +32,45 @@ describe('CreatePerpetualsDecreaseQuoteRequestSchema', () => {
       marketAddress: '0xmarket',
       collateralTokenAddress: '0xcollateral',
       side: 'long',
-      mode: 'partial',
-      partial: {
+      decrease: {
+        mode: 'partial',
         slippageBps: '100',
       },
     });
 
     expect(validPartial.success).toBe(true);
     expect(invalidPartial.success).toBe(false);
+  });
+
+  it('accepts nested full mode and rejects legacy top-level mode payload', () => {
+    const validFull = CreatePerpetualsDecreaseQuoteRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'short',
+      decrease: {
+        mode: 'full',
+        slippageBps: '100',
+      },
+    });
+
+    const legacyTopLevel = CreatePerpetualsDecreaseQuoteRequestSchema.safeParse({
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'short',
+      mode: 'full',
+      full: {
+        slippageBps: '100',
+      },
+    });
+
+    expect(validFull.success).toBe(true);
+    expect(legacyTopLevel.success).toBe(false);
   });
 });
 

--- a/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/index.ts
+++ b/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/index.ts
@@ -236,6 +236,14 @@ export namespace EndpointInterfaces {
     perpetuals.PerpetualsCreatePositionRequestSchema;
   export type PerpetualsCreatePositionRequest =
     perpetuals.PerpetualsCreatePositionRequest;
+  export const CreatePerpetualsDecreaseQuoteRequestSchema =
+    perpetuals.CreatePerpetualsDecreaseQuoteRequestSchema;
+  export type CreatePerpetualsDecreaseQuoteRequest =
+    perpetuals.CreatePerpetualsDecreaseQuoteRequest;
+  export const CreatePerpetualsDecreasePlanRequestSchema =
+    perpetuals.CreatePerpetualsDecreasePlanRequestSchema;
+  export type CreatePerpetualsDecreasePlanRequest =
+    perpetuals.CreatePerpetualsDecreasePlanRequest;
   export const PerpetualsPositionPromptSchema =
     perpetuals.PerpetualsPositionPromptSchema;
   export const PossiblePerpetualPositionsRequestSchema =

--- a/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-import { PositionSideSchema } from '../core/schemas/perpetuals.js';
+import {
+  CreatePerpetualsDecreasePlanRequestSchema as CoreCreatePerpetualsDecreasePlanRequestSchema,
+  CreatePerpetualsDecreaseQuoteRequestSchema as CoreCreatePerpetualsDecreaseQuoteRequestSchema,
+  PositionSideSchema,
+} from '../core/schemas/perpetuals.js';
 
 import {
   PaginatedPossibleResultsRequestSchema,
@@ -27,6 +31,18 @@ export const PerpetualsCreatePositionRequestSchema = z.object({
 });
 export type PerpetualsCreatePositionRequest = z.infer<
   typeof PerpetualsCreatePositionRequestSchema
+>;
+
+export const CreatePerpetualsDecreaseQuoteRequestSchema =
+  CoreCreatePerpetualsDecreaseQuoteRequestSchema;
+export type CreatePerpetualsDecreaseQuoteRequest = z.infer<
+  typeof CreatePerpetualsDecreaseQuoteRequestSchema
+>;
+
+export const CreatePerpetualsDecreasePlanRequestSchema =
+  CoreCreatePerpetualsDecreasePlanRequestSchema;
+export type CreatePerpetualsDecreasePlanRequest = z.infer<
+  typeof CreatePerpetualsDecreasePlanRequestSchema
 >;
 
 export const PerpetualsPositionPromptSchema = PerpetualsCreatePositionRequestSchema.pick({

--- a/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import * as perpetualInterfaces from './perpetuals.js';
+
+type SafeParseResult = { success: boolean };
+type SafeParseSchema = { safeParse: (input: unknown) => SafeParseResult };
+
+function getSchemaExport(schemaName: string): SafeParseSchema {
+  const candidate = (perpetualInterfaces as Record<string, unknown>)[schemaName];
+
+  expect(candidate).toBeDefined();
+
+  if (!candidate || typeof candidate !== 'object' || !('safeParse' in candidate)) {
+    throw new Error(`${schemaName} was not exported as a Zod schema`);
+  }
+
+  const schema = candidate as { safeParse: unknown };
+  if (typeof schema.safeParse !== 'function') {
+    throw new Error(`${schemaName} does not provide safeParse`);
+  }
+
+  return { safeParse: schema.safeParse as (input: unknown) => SafeParseResult };
+}
+
+describe('perpetual endpoint decrease request schemas', () => {
+  it('exports decrease quote and plan request schemas with nested decrease mode', () => {
+    const quoteSchema = getSchemaExport('CreatePerpetualsDecreaseQuoteRequestSchema');
+    const planSchema = getSchemaExport('CreatePerpetualsDecreasePlanRequestSchema');
+
+    const request = {
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'long',
+      decrease: {
+        mode: 'partial',
+        sizeDeltaUsd: '100000000',
+        slippageBps: '100',
+      },
+    };
+
+    expect(quoteSchema.safeParse(request).success).toBe(true);
+    expect(planSchema.safeParse(request).success).toBe(true);
+
+    const legacyRequest = {
+      walletAddress: '0xabc',
+      providerName: 'gmx',
+      chainId: '42161',
+      marketAddress: '0xmarket',
+      collateralTokenAddress: '0xcollateral',
+      side: 'long',
+      mode: 'partial',
+      partial: {
+        sizeDeltaUsd: '100000000',
+        slippageBps: '100',
+      },
+    };
+
+    expect(quoteSchema.safeParse(legacyRequest).success).toBe(false);
+    expect(planSchema.safeParse(legacyRequest).success).toBe(false);
+  });
+});

--- a/typescript/tests/setup/vitest.base.setup.ts
+++ b/typescript/tests/setup/vitest.base.setup.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll } from 'vitest';
+
+beforeAll(() => {
+  process.env['NODE_ENV'] = 'test';
+
+  const logLevel = process.env['LOG_LEVEL'] || 'none';
+
+  if (logLevel !== 'debug') {
+    global.originalConsole = {
+      log: console.log,
+      error: console.error,
+      warn: console.warn,
+      debug: console.debug,
+    };
+
+    switch (logLevel) {
+      case 'error':
+        console.log = () => {};
+        console.warn = () => {};
+        console.debug = () => {};
+        break;
+      case 'warn':
+        console.log = () => {};
+        console.debug = () => {};
+        break;
+      case 'none':
+      default:
+        console.log = () => {};
+        console.error = () => {};
+        console.warn = () => {};
+        console.debug = () => {};
+        break;
+    }
+  }
+});
+
+afterAll(() => {
+  if (global.originalConsole) {
+    console.log = global.originalConsole.log;
+    console.error = global.originalConsole.error;
+    console.warn = global.originalConsole.warn;
+    console.debug = global.originalConsole.debug;
+  }
+});
+
+declare global {
+  var originalConsole:
+    | {
+        log: typeof console.log;
+        error: typeof console.error;
+        warn: typeof console.warn;
+        debug: typeof console.debug;
+      }
+    | undefined;
+}

--- a/typescript/tests/setup/vitest.setup.ts
+++ b/typescript/tests/setup/vitest.setup.ts
@@ -1,0 +1,1 @@
+import './vitest.base.setup.js';


### PR DESCRIPTION
## Summary
- refactor perpetual decrease quote/plan request contracts to a shared outer object with nested `decrease` discriminated union (`full` | `partial`)
- update and harden registry schema tests for nested decrease payloads and explicit rejection of legacy top-level `mode/full/partial` payloads
- export decrease quote/plan request schemas from endpoint interfaces and add endpoint-interface unit coverage
- restore missing root Vitest setup files at `typescript/tests/setup/` so workspace-level Vitest commands stop failing on missing setup path

## Test Plan
- `pnpm -C typescript lint`
- `pnpm -C typescript build`
- `pnpm -C typescript test:ci`
- `pnpm -C typescript exec vitest run --dir onchain-actions-plugins/registry`

## Notes
- This is an intentional breaking contract change for perpetual decrease request shape (internal codebase policy: update call sites directly, no compatibility aliases).
