### PR TITLE
feat(registry): add perpetual transaction submit schemas

### DIFF
--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.ts
@@ -311,6 +311,28 @@ export type CreatePerpetualsOrderCancelPlanResponse = z.infer<
   typeof CreatePerpetualsOrderCancelPlanResponseSchema
 >;
 
+export const SubmitPerpetualsTransactionRequestSchema = z.object({
+  providerName: z.string(),
+  chainId: z.string(),
+  signedTx: z.string().regex(/^0x[0-9a-fA-F]+$/u),
+});
+export type SubmitPerpetualsTransactionRequest = z.infer<
+  typeof SubmitPerpetualsTransactionRequestSchema
+>;
+
+export const SubmitPerpetualsTransactionResponseSchema = z.object({
+  providerName: z.string(),
+  chainId: z.string(),
+  txHash: z.string(),
+  orderKey: z.string().optional(),
+  walletAddress: z.string().optional(),
+  submittedAtBlock: z.string().optional(),
+  asOf: z.string(),
+});
+export type SubmitPerpetualsTransactionResponse = z.infer<
+  typeof SubmitPerpetualsTransactionResponseSchema
+>;
+
 const PerpetualLifecycleDisambiguationResponseSchema = z.object({
   providerName: z.string(),
   chainId: z.string(),

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts
@@ -6,6 +6,8 @@ import {
   CreatePerpetualsOrderCancelPlanRequestSchema,
   GetPerpetualLifecycleRequestSchema,
   PerpetualQuoteResponseSchema,
+  SubmitPerpetualsTransactionRequestSchema,
+  SubmitPerpetualsTransactionResponseSchema,
 } from './perpetuals.js';
 import * as perpetualSchemas from './perpetuals.js';
 
@@ -197,5 +199,45 @@ describe('PerpetualQuoteResponseSchema', () => {
 describe('legacy perpetual core schema removal', () => {
   it('does not export close-order request schema', () => {
     expect(perpetualSchemas.ClosePerpetualsOrdersRequestSchema).toBeUndefined();
+  });
+});
+
+describe('SubmitPerpetualsTransaction schemas', () => {
+  it('validates request signed tx shape', () => {
+    const valid = SubmitPerpetualsTransactionRequestSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      signedTx: '0xdeadbeef',
+    });
+
+    const invalid = SubmitPerpetualsTransactionRequestSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      signedTx: 'deadbeef',
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+
+  it('requires canonical response fields and allows tracking metadata', () => {
+    const valid = SubmitPerpetualsTransactionResponseSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      txHash: '0xtxhash',
+      orderKey: '0xorder',
+      walletAddress: '0xwallet',
+      submittedAtBlock: '123456',
+      asOf: '2026-02-25T00:00:00.000Z',
+    });
+
+    const invalid = SubmitPerpetualsTransactionResponseSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      asOf: '2026-02-25T00:00:00.000Z',
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
   });
 });

--- a/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/index.ts
+++ b/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/index.ts
@@ -244,6 +244,14 @@ export namespace EndpointInterfaces {
     perpetuals.CreatePerpetualsDecreasePlanRequestSchema;
   export type CreatePerpetualsDecreasePlanRequest =
     perpetuals.CreatePerpetualsDecreasePlanRequest;
+  export const SubmitPerpetualsTransactionRequestSchema =
+    perpetuals.SubmitPerpetualsTransactionRequestSchema;
+  export type SubmitPerpetualsTransactionRequest =
+    perpetuals.SubmitPerpetualsTransactionRequest;
+  export const SubmitPerpetualsTransactionResponseSchema =
+    perpetuals.SubmitPerpetualsTransactionResponseSchema;
+  export type SubmitPerpetualsTransactionResponse =
+    perpetuals.SubmitPerpetualsTransactionResponse;
   export const PerpetualsPositionPromptSchema =
     perpetuals.PerpetualsPositionPromptSchema;
   export const PossiblePerpetualPositionsRequestSchema =

--- a/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.ts
+++ b/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.ts
@@ -4,6 +4,8 @@ import {
   CreatePerpetualsDecreasePlanRequestSchema as CoreCreatePerpetualsDecreasePlanRequestSchema,
   CreatePerpetualsDecreaseQuoteRequestSchema as CoreCreatePerpetualsDecreaseQuoteRequestSchema,
   PositionSideSchema,
+  SubmitPerpetualsTransactionRequestSchema as CoreSubmitPerpetualsTransactionRequestSchema,
+  SubmitPerpetualsTransactionResponseSchema as CoreSubmitPerpetualsTransactionResponseSchema,
 } from '../core/schemas/perpetuals.js';
 
 import {
@@ -43,6 +45,18 @@ export const CreatePerpetualsDecreasePlanRequestSchema =
   CoreCreatePerpetualsDecreasePlanRequestSchema;
 export type CreatePerpetualsDecreasePlanRequest = z.infer<
   typeof CreatePerpetualsDecreasePlanRequestSchema
+>;
+
+export const SubmitPerpetualsTransactionRequestSchema =
+  CoreSubmitPerpetualsTransactionRequestSchema;
+export type SubmitPerpetualsTransactionRequest = z.infer<
+  typeof SubmitPerpetualsTransactionRequestSchema
+>;
+
+export const SubmitPerpetualsTransactionResponseSchema =
+  CoreSubmitPerpetualsTransactionResponseSchema;
+export type SubmitPerpetualsTransactionResponse = z.infer<
+  typeof SubmitPerpetualsTransactionResponseSchema
 >;
 
 export const PerpetualsPositionPromptSchema = PerpetualsCreatePositionRequestSchema.pick({

--- a/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.unit.test.ts
@@ -62,3 +62,42 @@ describe('perpetual endpoint decrease request schemas', () => {
     expect(planSchema.safeParse(legacyRequest).success).toBe(false);
   });
 });
+
+describe('perpetual endpoint submit transaction schemas', () => {
+  it('exports submit request/response schemas', () => {
+    const submitRequestSchema = getSchemaExport(
+      'SubmitPerpetualsTransactionRequestSchema',
+    );
+    const submitResponseSchema = getSchemaExport(
+      'SubmitPerpetualsTransactionResponseSchema',
+    );
+
+    const validRequest = submitRequestSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      signedTx: '0xdeadbeef',
+    });
+    const invalidRequest = submitRequestSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      signedTx: 'deadbeef',
+    });
+
+    const validResponse = submitResponseSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      txHash: '0xtxhash',
+      asOf: '2026-02-25T00:00:00.000Z',
+    });
+    const invalidResponse = submitResponseSchema.safeParse({
+      providerName: 'gmx',
+      chainId: '42161',
+      asOf: '2026-02-25T00:00:00.000Z',
+    });
+
+    expect(validRequest.success).toBe(true);
+    expect(invalidRequest.success).toBe(false);
+    expect(validResponse.success).toBe(true);
+    expect(invalidResponse.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add canonical perpetual submit-transaction schema/types to registry core schemas:
  - `SubmitPerpetualsTransactionRequestSchema`
  - `SubmitPerpetualsTransactionResponseSchema`
- re-export submit schema/types via endpoint interfaces so consumers can import from `EndpointInterfaces`
- add unit coverage for both core schema validation and endpoint-interface export surface

## Why
- onchain-actions currently defines submit transaction request/response types locally.
- this change makes the contract canonical in `@emberai/onchain-actions-registry` so consumers share one source of truth.

## Testing
- `pnpm -C typescript exec vitest run --config /tmp/vitest.registry.config.ts onchain-actions-plugins/registry/src/core/schemas/perpetuals.unit.test.ts`
- `pnpm -C typescript exec vitest run --config /tmp/vitest.registry.config.ts onchain-actions-plugins/registry/src/endpoint-interfaces/perpetuals.unit.test.ts`
- `pnpm -C typescript/onchain-actions-plugins/registry lint`
- `pnpm -C typescript/onchain-actions-plugins/registry build`
