### PR TITLE
feat(web-ag-ui): add optional Traefik auth override

### DIFF
--- a/typescript/clients/web-ag-ui/README.md
+++ b/typescript/clients/web-ag-ui/README.md
@@ -51,6 +51,26 @@ All scripts use Turborepo to run tasks across the monorepo:
 - `pnpm build` - Builds all apps for production
 - `pnpm lint` - Runs linting across all apps
 
+## Traefik Auth Toggle (Production)
+
+The default `compose.yaml` deploys `demo.emberai.xyz` without Traefik auth middleware.
+
+To deploy with auth disabled (default):
+
+```bash
+docker compose --env-file traefik.env -f compose.yaml up -d --build
+```
+
+To deploy with auth enabled, include the override file:
+
+```bash
+docker compose --env-file traefik.env -f compose.yaml -f compose.auth.yaml up -d --build
+```
+
+When auth is enabled, make sure:
+- `TRAUTH_COOKIE_KEY` is set in `traefik.env`
+- `auth/users.htpasswd` exists and contains valid credentials
+
 ### Running Scripts for Individual Apps
 
 You can also run scripts for individual apps using pnpm's filter flag:

--- a/typescript/clients/web-ag-ui/compose.auth.yaml
+++ b/typescript/clients/web-ag-ui/compose.auth.yaml
@@ -1,0 +1,10 @@
+services:
+  web:
+    labels:
+      - traefik.http.routers.demo.middlewares=site-auth@docker
+      - traefik.http.middlewares.site-auth.plugin.trauth.domain=demo.emberai.xyz
+      - traefik.http.middlewares.site-auth.plugin.trauth.usersfile=/etc/traefik/users.htpasswd
+      - traefik.http.middlewares.site-auth.plugin.trauth.cookiekey=${TRAUTH_COOKIE_KEY}
+      - traefik.http.middlewares.site-auth.plugin.trauth.cookiename=trauth
+      - traefik.http.middlewares.site-auth.plugin.trauth.cookiesecure=true
+      - traefik.http.middlewares.site-auth.plugin.trauth.cookiehttponly=true

--- a/typescript/clients/web-ag-ui/compose.yaml
+++ b/typescript/clients/web-ag-ui/compose.yaml
@@ -44,14 +44,7 @@ services:
       - traefik.http.routers.demo.entrypoints=websecure
       - traefik.http.routers.demo.tls=true
       - traefik.http.routers.demo.tls.certresolver=cloudflare
-      - traefik.http.routers.demo.middlewares=site-auth@docker
       - traefik.http.services.demo.loadbalancer.server.port=3000
-      - traefik.http.middlewares.site-auth.plugin.trauth.domain=demo.emberai.xyz
-      - traefik.http.middlewares.site-auth.plugin.trauth.usersfile=/etc/traefik/users.htpasswd
-      - traefik.http.middlewares.site-auth.plugin.trauth.cookiekey=${TRAUTH_COOKIE_KEY}
-      - traefik.http.middlewares.site-auth.plugin.trauth.cookiename=trauth
-      - traefik.http.middlewares.site-auth.plugin.trauth.cookiesecure=true
-      - traefik.http.middlewares.site-auth.plugin.trauth.cookiehttponly=true
     ports:
       - "3000:3000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- disable Traefik auth middleware in `compose.yaml` by default
- add `compose.auth.yaml` as an override to re-enable `site-auth` middleware when needed
- document auth ON/OFF deployment commands and prerequisites in `typescript/clients/web-ag-ui/README.md`

## Test Plan
- pnpm lint (run in `typescript/clients/web-ag-ui`)
- pnpm build (run in `typescript/clients/web-ag-ui`)
