### PR TITLE
feat(web): add wallet management + withdraw receipt tracking

### DIFF
--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/onchain-actions/wallet/[walletAddress]/portfolio/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/onchain-actions/wallet/[walletAddress]/portfolio/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const WalletAddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/);
+
+const PaginationSchema = z.object({
+  cursor: z.string().nullable().optional(),
+  currentPage: z.number().int().optional(),
+  totalPages: z.number().int().optional(),
+  totalItems: z.number().int().optional(),
+});
+
+const TokenIdentifierSchema = z.object({
+  chainId: z.string(),
+  address: z.string(),
+});
+
+const WalletBalanceSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  amount: z.string(),
+  symbol: z.string().optional(),
+  valueUsd: z.number().optional(),
+  decimals: z.number().int().optional(),
+});
+
+const PerpetualPositionSchema = z.object({
+  key: z.string(),
+  marketAddress: z.string(),
+  positionSide: z.enum(['long', 'short']),
+  sizeInUsd: z.string(),
+});
+
+const TokenSchema = z.object({
+  tokenUid: TokenIdentifierSchema,
+  name: z.string(),
+  symbol: z.string(),
+  isNative: z.boolean(),
+  decimals: z.number().int(),
+  iconUri: z.string().nullish().optional(),
+  isVetted: z.boolean(),
+});
+
+const TokenizedYieldPositionSchema = z.object({
+  marketIdentifier: TokenIdentifierSchema,
+  pt: z.object({
+    token: TokenSchema,
+    exactAmount: z.string(),
+  }),
+  yt: z.object({
+    token: TokenSchema,
+    exactAmount: z.string(),
+    claimableRewards: z.array(
+      z.object({
+        token: TokenSchema,
+        exactAmount: z.string(),
+      }),
+    ),
+  }),
+});
+
+const LiquidityPositionSchema = z.object({
+  positionId: z.string().optional(),
+  poolName: z.string().optional(),
+  positionValueUsd: z.string().optional(),
+  providerId: z.string(),
+  pooledTokens: z.array(z.unknown()),
+  feesOwedTokens: z.array(z.unknown()),
+  rewardsOwedTokens: z.array(z.unknown()),
+});
+
+function resolveOnchainActionsBaseUrl(): string {
+  return (
+    process.env.ONCHAIN_ACTIONS_API_URL ??
+    process.env.NEXT_PUBLIC_ONCHAIN_ACTIONS_API_URL ??
+    'https://api.emberai.xyz'
+  );
+}
+
+type CollectionKey = 'balances' | 'positions';
+
+async function fetchPaginatedCollection<T>(params: {
+  endpoint: string;
+  key: CollectionKey;
+  schema: z.ZodType<T>;
+}): Promise<T[]> {
+  const baseUrl = resolveOnchainActionsBaseUrl().replace(/\/$/, '');
+  let page = 1;
+  let totalPages = 1;
+  let cursor: string | undefined;
+  const results: T[] = [];
+
+  while (page <= totalPages) {
+    const pageUrl = new URL(`${baseUrl}${params.endpoint}`);
+    if (page > 1) {
+      pageUrl.searchParams.set('page', String(page));
+      if (cursor) {
+        pageUrl.searchParams.set('cursor', cursor);
+      }
+    }
+
+    const response = await fetch(pageUrl.toString());
+    const payloadText = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `onchain-actions request failed (${response.status}) for ${params.endpoint}: ${payloadText}`,
+      );
+    }
+
+    const payload = payloadText.trim().length > 0 ? JSON.parse(payloadText) : {};
+    const pageSchema = PaginationSchema.extend({
+      [params.key]: z.array(params.schema),
+    });
+    const parsed = pageSchema.parse(payload) as {
+      cursor?: string | null;
+      totalPages?: number;
+    } & Record<string, unknown>;
+
+    const items = parsed[params.key];
+    if (!Array.isArray(items)) {
+      throw new Error(`Invalid ${params.key} payload`);
+    }
+    results.push(...(items as T[]));
+
+    totalPages = parsed.totalPages ?? 1;
+    cursor = parsed.cursor ?? undefined;
+    page += 1;
+  }
+
+  return results;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ walletAddress: string }> },
+): Promise<NextResponse> {
+  const { walletAddress } = await params;
+  const parsedWalletAddress = WalletAddressSchema.safeParse(walletAddress);
+  if (!parsedWalletAddress.success) {
+    return NextResponse.json({ error: 'Invalid wallet address' }, { status: 400 });
+  }
+
+  try {
+    const [balances, perpetuals, pendle, liquidity] = await Promise.all([
+      fetchPaginatedCollection({
+        endpoint: `/wallet/balances/${walletAddress}`,
+        key: 'balances',
+        schema: WalletBalanceSchema,
+      }),
+      fetchPaginatedCollection({
+        endpoint: `/perpetuals/positions/${walletAddress}`,
+        key: 'positions',
+        schema: PerpetualPositionSchema,
+      }),
+      fetchPaginatedCollection({
+        endpoint: `/tokenizedYield/positions/${walletAddress}`,
+        key: 'positions',
+        schema: TokenizedYieldPositionSchema,
+      }),
+      fetchPaginatedCollection({
+        endpoint: `/liquidity/positions/${walletAddress}`,
+        key: 'positions',
+        schema: LiquidityPositionSchema,
+      }),
+    ]);
+
+    return NextResponse.json(
+      {
+        walletAddress,
+        balances,
+        positions: {
+          perpetuals,
+          pendle,
+          liquidity,
+        },
+      },
+      {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: 'Failed to load wallet portfolio', details: message }, { status: 502 });
+  }
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/onchain-actions/wallet/[walletAddress]/portfolio/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/onchain-actions/wallet/[walletAddress]/portfolio/route.unit.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { GET } from './route';
+
+describe('/api/onchain-actions/wallet/[walletAddress]/portfolio', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.ONCHAIN_ACTIONS_API_URL = 'https://api.example.test';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns balances and grouped positions for a wallet', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+
+      if (url.includes('/wallet/balances/0x1111111111111111111111111111111111111111')) {
+        return new Response(
+          JSON.stringify({
+            balances: [
+              {
+                tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+                amount: '1000000',
+                symbol: 'USDC',
+                decimals: 6,
+                valueUsd: 1,
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes('/perpetuals/positions/0x1111111111111111111111111111111111111111')) {
+        return new Response(
+          JSON.stringify({
+            positions: [
+              {
+                key: 'perp-1',
+                marketAddress: '0x47c031236e19d024b42f8AE6780E44A573170703',
+                positionSide: 'long',
+                sizeInUsd: '1000000000000000000',
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes('/tokenizedYield/positions/0x1111111111111111111111111111111111111111')) {
+        return new Response(
+          JSON.stringify({
+            positions: [
+              {
+                marketIdentifier: {
+                  chainId: '42161',
+                  address: '0x6f9d8ef8fbcf2f3928c1f0f7f53295d85f4cb8d9',
+                },
+                pt: {
+                  token: {
+                    tokenUid: {
+                      chainId: '42161',
+                      address: '0x6f9d8ef8fbcf2f3928c1f0f7f53295d85f4cb8d9',
+                    },
+                    name: 'Pendle PT',
+                    symbol: 'PT',
+                    isNative: false,
+                    decimals: 18,
+                    isVetted: true,
+                  },
+                  exactAmount: '1',
+                },
+                yt: {
+                  token: {
+                    tokenUid: {
+                      chainId: '42161',
+                      address: '0x6f9d8ef8fbcf2f3928c1f0f7f53295d85f4cb8d9',
+                    },
+                    name: 'Pendle YT',
+                    symbol: 'YT',
+                    isNative: false,
+                    decimals: 18,
+                    isVetted: true,
+                  },
+                  exactAmount: '1',
+                  claimableRewards: [],
+                },
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes('/liquidity/positions/0x1111111111111111111111111111111111111111')) {
+        return new Response(
+          JSON.stringify({
+            positions: [
+              {
+                positionId: 'clmm-1',
+                poolName: 'USDC/WETH',
+                positionValueUsd: '500',
+                providerId: 'Algebra_0x1a3c9B1d2F0529D97f2afC5136Cc23e58f1FD35B_42161',
+                pooledTokens: [],
+                feesOwedTokens: [],
+                rewardsOwedTokens: [],
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request(
+      'http://localhost/api/onchain-actions/wallet/0x1111111111111111111111111111111111111111/portfolio',
+    );
+
+    const response = await GET(request, {
+      params: Promise.resolve({ walletAddress: '0x1111111111111111111111111111111111111111' }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      walletAddress: string;
+      balances: unknown[];
+      positions: {
+        perpetuals: unknown[];
+        pendle: unknown[];
+        liquidity: unknown[];
+      };
+    };
+
+    expect(payload.walletAddress).toBe('0x1111111111111111111111111111111111111111');
+    expect(payload.balances).toHaveLength(1);
+    expect(payload.positions.perpetuals).toHaveLength(1);
+    expect(payload.positions.pendle).toHaveLength(1);
+    expect(payload.positions.liquidity).toHaveLength(1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/app/wallet/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/wallet/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useWallets } from '@privy-io/react-auth';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { WalletManagementView, type WalletPortfolioView } from '@/components/wallet/WalletManagementView';
+import { selectConnectedDestinationWallet } from '@/components/wallet/withdraw';
+import { usePrivyWalletClient } from '@/hooks/usePrivyWalletClient';
+
+type PortfolioApiResponse = WalletPortfolioView & {
+  walletAddress: string;
+};
+
+const EMPTY_PORTFOLIO: WalletPortfolioView = {
+  balances: [],
+  positions: {
+    perpetuals: [],
+    pendle: [],
+    liquidity: [],
+  },
+};
+
+export default function WalletPage(): React.JSX.Element {
+  const { wallets } = useWallets();
+  const { walletClient, privyWallet, isLoading: isWalletLoading, error: walletError } = usePrivyWalletClient();
+  const [portfolio, setPortfolio] = useState<WalletPortfolioView>(EMPTY_PORTFOLIO);
+  const [isPortfolioLoading, setIsPortfolioLoading] = useState(false);
+  const [portfolioError, setPortfolioError] = useState<string | null>(null);
+
+  const loadPortfolio = useCallback(async (walletAddress: string) => {
+    setIsPortfolioLoading(true);
+    setPortfolioError(null);
+
+    const response = await fetch(`/api/onchain-actions/wallet/${walletAddress}/portfolio`, {
+      cache: 'no-store',
+    });
+    const payload = (await response.json()) as unknown;
+
+    if (!response.ok) {
+      const errorPayload = payload as {
+        error?: string;
+        details?: string;
+      };
+      throw new Error(errorPayload.error ?? errorPayload.details ?? 'Failed to load wallet portfolio');
+    }
+
+    const portfolioPayload = payload as PortfolioApiResponse;
+    setPortfolio({
+      balances: portfolioPayload.balances ?? [],
+      positions: {
+        perpetuals: portfolioPayload.positions?.perpetuals ?? [],
+        pendle: portfolioPayload.positions?.pendle ?? [],
+        liquidity: portfolioPayload.positions?.liquidity ?? [],
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!privyWallet?.address) {
+      setPortfolio(EMPTY_PORTFOLIO);
+      setPortfolioError(null);
+      setIsPortfolioLoading(false);
+      return;
+    }
+
+    let canceled = false;
+
+    const run = async () => {
+      try {
+        await loadPortfolio(privyWallet.address);
+      } catch (error) {
+        if (canceled) return;
+        const message = error instanceof Error ? error.message : 'Failed to load wallet portfolio';
+        setPortfolioError(message);
+      } finally {
+        if (!canceled) {
+          setIsPortfolioLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      canceled = true;
+    };
+  }, [loadPortfolio, privyWallet?.address]);
+
+  const connectedDestinationAddress = useMemo(() => {
+    if (!privyWallet?.address) return null;
+    return selectConnectedDestinationWallet({
+      sourceAddress: privyWallet.address,
+      wallets,
+    });
+  }, [privyWallet?.address, wallets]);
+
+  const handleWithdrawConfirmed = useCallback(
+    async (_hash: string) => {
+      if (!privyWallet?.address) return;
+      try {
+        await loadPortfolio(privyWallet.address);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to refresh wallet portfolio.';
+        setPortfolioError(message);
+      }
+    },
+    [loadPortfolio, privyWallet?.address],
+  );
+
+  if (!privyWallet?.address) {
+    return (
+      <div className="mx-auto w-full max-w-3xl p-6">
+        <section className="rounded-xl border border-[#2a2a2a] bg-[#111111] p-5">
+          <h1 className="text-2xl font-semibold text-white">Manage Wallet</h1>
+          <p className="mt-2 text-sm text-gray-400">Sign in with Privy to access wallet management.</p>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {(isWalletLoading || isPortfolioLoading) && (
+        <div className="mx-auto mt-6 w-full max-w-5xl rounded-lg border border-[#2a2a2a] bg-[#111111] px-4 py-3 text-sm text-gray-300">
+          Loading wallet portfolio...
+        </div>
+      )}
+
+      {walletError && (
+        <div className="mx-auto mt-6 w-full max-w-5xl rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {walletError.message}
+        </div>
+      )}
+      {portfolioError && (
+        <div className="mx-auto w-full max-w-5xl rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {portfolioError}
+        </div>
+      )}
+
+      <WalletManagementView
+        walletAddress={privyWallet.address}
+        connectedDestinationAddress={connectedDestinationAddress}
+        walletClient={walletClient}
+        portfolio={portfolio}
+        onWithdrawConfirmed={handleWithdrawConfirmed}
+      />
+    </div>
+  );
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/wallet/page.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/wallet/page.unit.test.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import WalletPage from './page';
+
+vi.mock('@privy-io/react-auth', () => {
+  return {
+    useWallets: () => ({ wallets: [] }),
+  };
+});
+
+vi.mock('@/hooks/usePrivyWalletClient', () => {
+  return {
+    usePrivyWalletClient: () => ({
+      walletClient: null,
+      privyWallet: {
+        address: '0x1111111111111111111111111111111111111111',
+      },
+      chainId: 42161,
+      switchChain: vi.fn(),
+      isLoading: false,
+      error: null,
+    }),
+  };
+});
+
+describe('/wallet page', () => {
+  it('renders manage wallet heading', () => {
+    const html = renderToStaticMarkup(React.createElement(WalletPage));
+    expect(html).toContain('Manage Wallet');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.unit.test.ts
@@ -1,0 +1,112 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { arbitrum, mainnet, polygon } from 'viem/chains';
+
+import { AppSidebar, getWalletSelectorChains } from './AppSidebar';
+
+vi.mock('next/navigation', () => {
+  return {
+    usePathname: () => '/hire-agents',
+    useRouter: () => ({ push: vi.fn() }),
+  };
+});
+
+vi.mock('next/link', () => {
+  return {
+    default: (props: React.PropsWithChildren<{ href: string; className?: string }>) =>
+      React.createElement('a', { href: props.href, className: props.className }, props.children),
+  };
+});
+
+vi.mock('next/image', () => {
+  return {
+    default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+  };
+});
+
+vi.mock('@privy-io/react-auth', () => {
+  return {
+    usePrivy: () => ({ ready: true, authenticated: true }),
+    useLogin: () => ({ login: vi.fn() }),
+    useLogout: () => ({ logout: vi.fn() }),
+  };
+});
+
+vi.mock('@/hooks/usePrivyWalletClient', () => {
+  return {
+    usePrivyWalletClient: () => ({
+      privyWallet: {
+        address: '0x1111111111111111111111111111111111111111',
+      },
+      chainId: 42161,
+      switchChain: vi.fn(),
+      isLoading: false,
+      error: null,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useUpgradeToSmartAccount', () => {
+  return {
+    useUpgradeToSmartAccount: () => ({
+      isDeployed: true,
+      isLoading: false,
+      isUpgrading: false,
+      upgradeToSmartAccount: vi.fn(),
+      error: null,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useOnchainActionsIconMaps', () => {
+  return {
+    useOnchainActionsIconMaps: () => ({
+      chainIconByName: {},
+      tokenIconBySymbol: {},
+    }),
+  };
+});
+
+vi.mock('@/contexts/AgentContext', () => {
+  return {
+    useAgent: () => ({
+      config: { id: 'inactive-agent' },
+      view: {
+        task: null,
+        command: null,
+        haltReason: null,
+        executionError: null,
+        setupComplete: false,
+        operatorConfig: null,
+        delegationBundle: null,
+      },
+    }),
+  };
+});
+
+vi.mock('@/contexts/AgentListContext', () => {
+  return {
+    useAgentList: () => ({ agents: {} }),
+  };
+});
+
+vi.mock('@/config/agents', () => {
+  return {
+    getAllAgents: () => [],
+  };
+});
+
+describe('AppSidebar wallet actions', () => {
+  it('limits wallet selector chain options to Arbitrum and Ethereum', () => {
+    const result = getWalletSelectorChains([arbitrum, mainnet, polygon]);
+    expect(result.map((chain) => chain.id)).toEqual([arbitrum.id, mainnet.id]);
+  });
+
+  it('renders a secondary Manage Wallet link when wallet is connected', () => {
+    const html = renderToStaticMarkup(React.createElement(AppSidebar));
+
+    expect(html).toContain('Manage Wallet');
+    expect(html).toContain('href="/wallet"');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletManagementView.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletManagementView.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { Account, Chain, Transport, WalletClient } from 'viem';
+
+import {
+  WalletPortfolioPanel,
+  type LiquidityPositionView,
+  type PendlePositionView,
+  type PerpetualPositionView,
+  type WalletBalanceView,
+} from './WalletPortfolioPanel';
+import { WalletWithdrawPanel } from './WalletWithdrawPanel';
+
+type WalletPortfolioView = {
+  balances: WalletBalanceView[];
+  positions: {
+    perpetuals: PerpetualPositionView[];
+    pendle: PendlePositionView[];
+    liquidity: LiquidityPositionView[];
+  };
+};
+
+type WalletManagementViewProps = {
+  walletAddress: string;
+  connectedDestinationAddress: string | null;
+  walletClient: WalletClient<Transport, Chain, Account> | null;
+  portfolio: WalletPortfolioView;
+  onWithdrawConfirmed?: (hash: string) => Promise<void> | void;
+};
+
+function formatAddress(value: string): string {
+  if (value.length < 12) return value;
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+export function WalletManagementView(props: WalletManagementViewProps): React.JSX.Element {
+  return (
+    <div className="mx-auto w-full max-w-5xl p-6 space-y-6">
+      <section className="rounded-xl border border-[#2a2a2a] bg-[#111111] p-5">
+        <h1 className="text-2xl font-semibold text-white">Manage Wallet</h1>
+        <p className="mt-2 text-sm text-gray-400">MetaMask smart account: {formatAddress(props.walletAddress)}</p>
+      </section>
+
+      <WalletPortfolioPanel balances={props.portfolio.balances} positions={props.portfolio.positions} />
+
+      <WalletWithdrawPanel
+        sourceAddress={props.walletAddress}
+        connectedDestinationAddress={props.connectedDestinationAddress}
+        walletClient={props.walletClient}
+        balances={props.portfolio.balances}
+        onWithdrawConfirmed={props.onWithdrawConfirmed}
+      />
+    </div>
+  );
+}
+
+export type { WalletManagementViewProps, WalletPortfolioView };

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletManagementView.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletManagementView.unit.test.ts
@@ -1,0 +1,58 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { WalletManagementView } from './WalletManagementView';
+
+describe('WalletManagementView', () => {
+  it('renders wallet portfolio and withdraw sections', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WalletManagementView, {
+        walletAddress: '0x1111111111111111111111111111111111111111',
+        connectedDestinationAddress: null,
+        walletClient: null,
+        portfolio: {
+          balances: [
+            {
+              tokenUid: { chainId: '42161', address: '0x0000000000000000000000000000000000000000' },
+              symbol: 'ETH',
+              amount: '1000000000000000000',
+              decimals: 18,
+            },
+          ],
+          positions: {
+            perpetuals: [
+              {
+                key: 'perp-1',
+                marketAddress: '0x2222222222222222222222222222222222222222',
+                positionSide: 'long',
+                sizeInUsd: '123.45',
+              },
+            ],
+            pendle: [
+              {
+                marketIdentifier: { chainId: '42161', address: '0x3333333333333333333333333333333333333333' },
+                pt: { exactAmount: '1' },
+                yt: { exactAmount: '2' },
+              },
+            ],
+            liquidity: [
+              {
+                positionId: 'lp-1',
+                poolName: 'Camelot ETH/USDC',
+                positionValueUsd: '321.00',
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(html).toContain('Manage Wallet');
+    expect(html).toContain('Token Balances');
+    expect(html).toContain('Perpetual Positions');
+    expect(html).toContain('Pendle Positions');
+    expect(html).toContain('CLMM / Camelot Positions');
+    expect(html).toContain('Withdraw');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletPortfolioPanel.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletPortfolioPanel.tsx
@@ -1,0 +1,171 @@
+import type React from 'react';
+import { formatUnits } from 'viem';
+
+export type WalletBalanceView = {
+  tokenUid: {
+    chainId: string;
+    address: string;
+  };
+  amount: string;
+  symbol?: string;
+  decimals?: number;
+  valueUsd?: number;
+};
+
+export type PerpetualPositionView = {
+  key: string;
+  marketAddress: string;
+  positionSide: 'long' | 'short';
+  sizeInUsd: string;
+};
+
+export type PendlePositionView = {
+  marketIdentifier: {
+    chainId: string;
+    address: string;
+  };
+  pt: {
+    exactAmount: string;
+  };
+  yt: {
+    exactAmount: string;
+  };
+};
+
+export type LiquidityPositionView = {
+  positionId?: string;
+  poolName?: string;
+  positionValueUsd?: string;
+};
+
+export type WalletPortfolioPanelProps = {
+  balances: WalletBalanceView[];
+  positions: {
+    perpetuals: PerpetualPositionView[];
+    pendle: PendlePositionView[];
+    liquidity: LiquidityPositionView[];
+  };
+};
+
+function formatBalanceAmount(balance: WalletBalanceView): string {
+  if (typeof balance.decimals !== 'number') {
+    return balance.amount;
+  }
+
+  try {
+    return formatUnits(BigInt(balance.amount), balance.decimals);
+  } catch {
+    return balance.amount;
+  }
+}
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function WalletPortfolioPanel(props: WalletPortfolioPanelProps): React.JSX.Element {
+  const walletTotalUsd = props.balances.reduce((total, balance) => {
+    if (typeof balance.valueUsd !== 'number' || !Number.isFinite(balance.valueUsd)) {
+      return total;
+    }
+    return total + balance.valueUsd;
+  }, 0);
+
+  const hasWalletTotalUsd = props.balances.some(
+    (balance) => typeof balance.valueUsd === 'number' && Number.isFinite(balance.valueUsd),
+  );
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-[#2a2a2a] bg-[#121212] p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">Token Balances</h2>
+          <div className="text-right">
+            <div className="text-xs text-gray-400">Wallet Total</div>
+            <div className="text-sm font-medium text-gray-100">
+              {hasWalletTotalUsd ? formatUsd(walletTotalUsd) : '--'}
+            </div>
+          </div>
+        </div>
+        {props.balances.length === 0 ? (
+          <p className="text-sm text-gray-400">No token balances found.</p>
+        ) : (
+          <ul className="space-y-2">
+            {props.balances.map((balance) => (
+              <li
+                key={`${balance.tokenUid.chainId}:${balance.tokenUid.address}`}
+                className="flex items-center justify-between text-sm text-gray-200"
+              >
+                <span>{balance.symbol ?? balance.tokenUid.address}</span>
+                <div className="text-right">
+                  <div>{formatBalanceAmount(balance)}</div>
+                  <div className="text-xs text-gray-400">
+                    {typeof balance.valueUsd === 'number' && Number.isFinite(balance.valueUsd)
+                      ? formatUsd(balance.valueUsd)
+                      : '--'}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-[#2a2a2a] bg-[#121212] p-4">
+        <h2 className="text-lg font-semibold text-white mb-3">Perpetual Positions</h2>
+        {props.positions.perpetuals.length === 0 ? (
+          <p className="text-sm text-gray-400">No perpetual positions.</p>
+        ) : (
+          <ul className="space-y-2">
+            {props.positions.perpetuals.map((position) => (
+              <li key={position.key} className="text-sm text-gray-200">
+                {position.positionSide.toUpperCase()} · {position.marketAddress.slice(0, 10)}… · $
+                {position.sizeInUsd}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-[#2a2a2a] bg-[#121212] p-4">
+        <h2 className="text-lg font-semibold text-white mb-3">Pendle Positions</h2>
+        {props.positions.pendle.length === 0 ? (
+          <p className="text-sm text-gray-400">No Pendle positions.</p>
+        ) : (
+          <ul className="space-y-2">
+            {props.positions.pendle.map((position) => (
+              <li
+                key={`${position.marketIdentifier.chainId}:${position.marketIdentifier.address}`}
+                className="text-sm text-gray-200"
+              >
+                {position.marketIdentifier.address.slice(0, 10)}… · PT {position.pt.exactAmount} · YT{' '}
+                {position.yt.exactAmount}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-[#2a2a2a] bg-[#121212] p-4">
+        <h2 className="text-lg font-semibold text-white mb-3">CLMM / Camelot Positions</h2>
+        {props.positions.liquidity.length === 0 ? (
+          <p className="text-sm text-gray-400">No CLMM/Camelot positions.</p>
+        ) : (
+          <ul className="space-y-2">
+            {props.positions.liquidity.map((position) => (
+              <li key={position.positionId ?? position.poolName ?? 'unknown'} className="text-sm text-gray-200">
+                {(position.poolName && position.poolName.length > 0) ? position.poolName : 'Unnamed Pool'}
+                {position.positionValueUsd ? ` · $${position.positionValueUsd}` : ''}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletPortfolioPanel.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletPortfolioPanel.unit.test.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { WalletPortfolioPanel } from './WalletPortfolioPanel';
+
+describe('WalletPortfolioPanel', () => {
+  it('renders balances with USD values, a wallet USD total, and grouped portfolio positions', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WalletPortfolioPanel, {
+        balances: [
+          {
+            tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+            amount: '25000000',
+            symbol: 'USDC',
+            decimals: 6,
+            valueUsd: 25,
+          },
+          {
+            tokenUid: { chainId: '42161', address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8' },
+            amount: '5500000',
+            symbol: 'USDC.e',
+            decimals: 6,
+            valueUsd: 5.5,
+          },
+        ],
+        positions: {
+          perpetuals: [
+            {
+              key: 'perp-1',
+              marketAddress: '0x47c031236e19d024b42f8AE6780E44A573170703',
+              positionSide: 'long',
+              sizeInUsd: '123.45',
+            },
+          ],
+          pendle: [
+            {
+              marketIdentifier: {
+                chainId: '42161',
+                address: '0x6f9d8ef8fbcf2f3928c1f0f7f53295d85f4cb8d9',
+              },
+              pt: { exactAmount: '1.00' },
+              yt: { exactAmount: '0.50' },
+            },
+          ],
+          liquidity: [
+            {
+              positionId: 'lp-1',
+              poolName: 'USDC/WETH',
+              positionValueUsd: '512.88',
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(html).toContain('Token Balances');
+    expect(html).toContain('USDC');
+    expect(html).toContain('USDC.e');
+    expect(html).toContain('Wallet Total');
+    expect(html).toContain('$30.50');
+    expect(html).toContain('$25.00');
+    expect(html).toContain('$5.50');
+    expect(html).toContain('Perpetual Positions');
+    expect(html).toContain('Pendle Positions');
+    expect(html).toContain('CLMM / Camelot Positions');
+    expect(html).toContain('USDC/WETH');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletWithdrawPanel.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletWithdrawPanel.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
+import {
+  createPublicClient,
+  erc20Abi,
+  http,
+  parseUnits,
+  type Account,
+  type Chain,
+  type Hex,
+  type Transport,
+  type WalletClient,
+} from 'viem';
+
+import type { WalletBalanceView } from './WalletPortfolioPanel';
+import { isUserRejectedTransactionError, validateWithdrawRequest } from './withdraw';
+import { defaultEvmChain } from '@/config/evmChains';
+
+type WithdrawResultStatus =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'confirming'; hash: string }
+  | { kind: 'confirmed'; hash: string }
+  | { kind: 'error'; message: string; hash?: string };
+
+type WalletWithdrawPanelProps = {
+  sourceAddress: string;
+  connectedDestinationAddress: string | null;
+  walletClient: WalletClient<Transport, Chain, Account> | null;
+  balances: WalletBalanceView[];
+  onWithdrawSubmitted?: (hash: string) => void;
+  onWithdrawConfirmed?: (hash: string) => Promise<void> | void;
+};
+
+const ZERO_ADDRESS = `0x${'0'.repeat(40)}` as const;
+
+function tokenLabel(balance: WalletBalanceView): string {
+  return balance.symbol ?? `${balance.tokenUid.address.slice(0, 8)}…`;
+}
+
+function balanceKey(balance: WalletBalanceView): string {
+  return `${balance.tokenUid.chainId}:${balance.tokenUid.address.toLowerCase()}`;
+}
+
+export function getPreferredSelectedTokenKey(input: {
+  currentKey: string;
+  balances: WalletBalanceView[];
+}): string {
+  if (input.balances.length === 0) return '';
+
+  const hasCurrentSelection =
+    input.currentKey.length > 0 &&
+    input.balances.some((balance) => balanceKey(balance) === input.currentKey);
+
+  if (hasCurrentSelection) return input.currentKey;
+  return balanceKey(input.balances[0]);
+}
+
+function isNativeToken(balance: WalletBalanceView): boolean {
+  if ((balance.symbol ?? '').toUpperCase() === 'ETH') return true;
+  return balance.tokenUid.address.toLowerCase() === ZERO_ADDRESS;
+}
+
+function resolveRpcUrl(chain: Chain): string | null {
+  const defaultHttp = chain.rpcUrls.default.http[0];
+  if (typeof defaultHttp === 'string' && defaultHttp.length > 0) return defaultHttp;
+
+  const publicHttp = chain.rpcUrls.public?.http?.[0];
+  if (typeof publicHttp === 'string' && publicHttp.length > 0) return publicHttp;
+
+  return null;
+}
+
+function formatHash(hash: string): string {
+  if (hash.length <= 14) return hash;
+  return `${hash.slice(0, 8)}...${hash.slice(-6)}`;
+}
+
+export function WalletWithdrawPanel(props: WalletWithdrawPanelProps): React.JSX.Element {
+  const [mode, setMode] = useState<'connected' | 'custom'>(
+    props.connectedDestinationAddress ? 'connected' : 'custom',
+  );
+  const [customDestination, setCustomDestination] = useState('');
+  const [amount, setAmount] = useState('');
+  const [userSelectedTokenKey, setUserSelectedTokenKey] = useState<string>('');
+  const [status, setStatus] = useState<WithdrawResultStatus>({ kind: 'idle' });
+
+  const selectedTokenKey = getPreferredSelectedTokenKey({
+    currentKey: userSelectedTokenKey,
+    balances: props.balances,
+  });
+
+  const selectedToken = useMemo(() => {
+    return (
+      props.balances.find((balance) => balanceKey(balance) === selectedTokenKey) ??
+      props.balances[0] ??
+      null
+    );
+  }, [props.balances, selectedTokenKey]);
+
+  const canSubmit = props.walletClient !== null && selectedToken !== null && amount.trim().length > 0;
+  const isWorking = status.kind === 'submitting' || status.kind === 'confirming';
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    const validated = validateWithdrawRequest({
+      mode,
+      customDestination,
+      connectedDestination: props.connectedDestinationAddress,
+      sourceAddress: props.sourceAddress,
+      amount,
+    });
+
+    if (!validated.ok) {
+      setStatus({ kind: 'error', message: validated.error });
+      return;
+    }
+
+    if (!props.walletClient) {
+      setStatus({ kind: 'error', message: 'Connect your wallet to submit withdrawals.' });
+      return;
+    }
+
+    if (!selectedToken) {
+      setStatus({ kind: 'error', message: 'Select a token to withdraw.' });
+      return;
+    }
+
+    const tokenDecimals = selectedToken.decimals ?? 18;
+
+    try {
+      setStatus({ kind: 'submitting' });
+
+      let hash: Hex;
+      if (isNativeToken(selectedToken)) {
+        hash = await props.walletClient.sendTransaction({
+          account: props.sourceAddress as Hex,
+          to: validated.destinationAddress as Hex,
+          value: parseUnits(amount, tokenDecimals),
+        });
+      } else {
+        hash = await props.walletClient.writeContract({
+          account: props.sourceAddress as Hex,
+          abi: erc20Abi,
+          address: selectedToken.tokenUid.address as Hex,
+          functionName: 'transfer',
+          args: [validated.destinationAddress as Hex, parseUnits(amount, tokenDecimals)],
+        });
+      }
+
+      setStatus({ kind: 'confirming', hash });
+      props.onWithdrawSubmitted?.(hash);
+
+      const chain = props.walletClient.chain ?? defaultEvmChain;
+      const rpcUrl = resolveRpcUrl(chain);
+      if (!rpcUrl) {
+        setStatus({ kind: 'error', message: 'Unable to track confirmation on the current chain.', hash });
+        return;
+      }
+
+      const publicClient = createPublicClient({
+        chain,
+        transport: http(rpcUrl),
+      });
+
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== 'success') {
+        setStatus({ kind: 'error', message: 'Transaction was submitted but did not confirm.', hash });
+        return;
+      }
+
+      setStatus({ kind: 'confirmed', hash });
+      await props.onWithdrawConfirmed?.(hash);
+    } catch (error) {
+      if (isUserRejectedTransactionError(error)) {
+        console.info('[wallet-withdraw] User rejected transaction request.');
+        setStatus({ kind: 'idle' });
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : 'Failed to submit withdraw transaction.';
+      setStatus({ kind: 'error', message });
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-[#2a2a2a] bg-[#121212] p-4">
+      <h2 className="text-lg font-semibold text-white mb-3">Withdraw</h2>
+      <p className="text-sm text-gray-400 mb-4">
+        Move funds from your MetaMask smart account to another wallet.
+      </p>
+
+      {status.kind !== 'idle' && (
+        <div className="mb-4 rounded-xl border border-[#252833] bg-[#111319] px-3 py-2.5">
+          {status.kind === 'submitting' && (
+            <div className="flex items-center gap-2 text-sm text-[#E7E7EC]">
+              <Loader2 className="h-4 w-4 animate-spin text-teal-300" />
+              <span>Submitting transaction...</span>
+            </div>
+          )}
+          {status.kind === 'confirming' && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 text-sm text-[#E7E7EC]">
+                <Loader2 className="h-4 w-4 animate-spin text-teal-300" />
+                <span>Transaction submitted. Waiting for confirmation...</span>
+              </div>
+              <div className="font-mono text-xs text-[#8D8D97] break-all">{status.hash}</div>
+            </div>
+          )}
+          {status.kind === 'confirmed' && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 text-sm text-[#D6F5E6]">
+                <CheckCircle className="h-4 w-4 text-green-400" />
+                <span>Confirmed: {formatHash(status.hash)}</span>
+              </div>
+              <div className="font-mono text-xs text-[#8D8D97] break-all">{status.hash}</div>
+            </div>
+          )}
+          {status.kind === 'error' && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 text-sm text-red-300">
+                <AlertCircle className="h-4 w-4 text-red-300" />
+                <span>{status.message}</span>
+              </div>
+              {status.hash && <div className="font-mono text-xs text-[#8D8D97] break-all">{status.hash}</div>}
+            </div>
+          )}
+        </div>
+      )}
+
+      <form className="space-y-3" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-gray-400">Destination</label>
+          <div className="flex flex-col gap-2 rounded-md border border-[#2a2a2a] bg-[#0f0f0f] p-3">
+            <label className="flex items-center gap-2 text-sm text-gray-200">
+              <input
+                type="radio"
+                name="destination-mode"
+                checked={mode === 'connected'}
+                onChange={() => setMode('connected')}
+                disabled={!props.connectedDestinationAddress}
+              />
+              <span>
+                Connected wallet
+                {props.connectedDestinationAddress && (
+                  <span className="ml-2 font-mono text-xs text-gray-400">
+                    {props.connectedDestinationAddress}
+                  </span>
+                )}
+              </span>
+            </label>
+            {!props.connectedDestinationAddress && (
+              <p className="text-xs text-gray-500">
+                No connected destination wallet detected. You can still withdraw to a custom address.
+              </p>
+            )}
+            <label className="flex items-center gap-2 text-sm text-gray-200">
+              <input
+                type="radio"
+                name="destination-mode"
+                checked={mode === 'custom'}
+                onChange={() => setMode('custom')}
+              />
+              Custom destination
+            </label>
+            {mode === 'custom' && (
+              <input
+                type="text"
+                value={customDestination}
+                onChange={(event) => setCustomDestination(event.target.value)}
+                placeholder="0x..."
+                className="w-full rounded-md border border-[#2a2a2a] bg-[#151515] px-3 py-2 text-sm text-gray-200"
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-gray-400" htmlFor="withdraw-token-select">
+            Token
+          </label>
+          <select
+            id="withdraw-token-select"
+            value={selectedTokenKey}
+            onChange={(event) => setUserSelectedTokenKey(event.target.value)}
+            className="w-full rounded-md border border-[#2a2a2a] bg-[#151515] px-3 py-2 text-sm text-gray-200"
+          >
+            {props.balances.length === 0 && <option value="">No tokens available</option>}
+            {props.balances.map((balance) => (
+              <option key={balanceKey(balance)} value={balanceKey(balance)}>
+                {tokenLabel(balance)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-gray-400" htmlFor="withdraw-amount-input">
+            Amount
+          </label>
+          <input
+            id="withdraw-amount-input"
+            type="text"
+            inputMode="decimal"
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            placeholder="0.0"
+            className="w-full rounded-md border border-[#2a2a2a] bg-[#151515] px-3 py-2 text-sm text-gray-200"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="w-full rounded-md bg-[#fd6731] px-3 py-2 text-sm font-medium text-white disabled:opacity-60"
+          disabled={!canSubmit || isWorking}
+        >
+          {status.kind === 'submitting'
+            ? 'Submitting...'
+            : status.kind === 'confirming'
+              ? 'Confirming...'
+              : 'Withdraw'}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+export type { WalletWithdrawPanelProps };

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletWithdrawPanel.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/WalletWithdrawPanel.unit.test.ts
@@ -1,0 +1,83 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getPreferredSelectedTokenKey, WalletWithdrawPanel } from './WalletWithdrawPanel';
+
+describe('WalletWithdrawPanel', () => {
+  it('defaults token selection to the first available balance when current selection is empty or stale', () => {
+    const balances = [
+      {
+        tokenUid: { chainId: '42161', address: '0x0000000000000000000000000000000000000000' },
+        symbol: 'ETH',
+        amount: '1000000000000000000',
+        decimals: 18,
+      },
+      {
+        tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+        symbol: 'USDC',
+        amount: '2000000',
+        decimals: 6,
+      },
+    ];
+
+    expect(getPreferredSelectedTokenKey({ currentKey: '', balances })).toBe(
+      '42161:0x0000000000000000000000000000000000000000',
+    );
+    expect(getPreferredSelectedTokenKey({ currentKey: 'stale-key', balances })).toBe(
+      '42161:0x0000000000000000000000000000000000000000',
+    );
+    expect(
+      getPreferredSelectedTokenKey({
+        currentKey: '42161:0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        balances,
+      }),
+    ).toBe('42161:0xaf88d065e77c8cc2239327c5edb3a432268e5831');
+  });
+
+  it('shows manual guidance when no connected destination wallet is available', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WalletWithdrawPanel, {
+        sourceAddress: '0x1111111111111111111111111111111111111111',
+        connectedDestinationAddress: null,
+        walletClient: null,
+        balances: [
+          {
+            tokenUid: { chainId: '42161', address: '0x0000000000000000000000000000000000000000' },
+            symbol: 'ETH',
+            amount: '1000000000000000000',
+            decimals: 18,
+          },
+        ],
+        onWithdrawSubmitted: vi.fn(),
+      }),
+    );
+
+    expect(html).toContain('Withdraw');
+    expect(html).toContain('No connected destination wallet detected');
+    expect(html).toContain('Custom destination');
+    expect(html).toContain('Amount');
+  });
+
+  it('shows the connected wallet destination address when available', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WalletWithdrawPanel, {
+        sourceAddress: '0x1111111111111111111111111111111111111111',
+        connectedDestinationAddress: '0x2222222222222222222222222222222222222222',
+        walletClient: null,
+        balances: [
+          {
+            tokenUid: { chainId: '42161', address: '0x0000000000000000000000000000000000000000' },
+            symbol: 'ETH',
+            amount: '1000000000000000000',
+            decimals: 18,
+          },
+        ],
+        onWithdrawSubmitted: vi.fn(),
+      }),
+    );
+
+    expect(html).toContain('Connected wallet');
+    expect(html).toContain('0x2222222222222222222222222222222222222222');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/withdraw.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/withdraw.ts
@@ -1,0 +1,93 @@
+export function isHexAddress(value: string): boolean {
+  return /^0x[a-fA-F0-9]{40}$/.test(value);
+}
+
+type ConnectedWalletLike = {
+  address: string;
+  walletClientType?: string | null;
+};
+
+export function selectConnectedDestinationWallet(input: {
+  sourceAddress: string;
+  wallets: ConnectedWalletLike[];
+}): string | null {
+  const sourceLower = input.sourceAddress.toLowerCase();
+
+  for (const wallet of input.wallets) {
+    if (wallet.walletClientType === 'privy') continue;
+    if (!isHexAddress(wallet.address)) continue;
+    if (wallet.address.toLowerCase() === sourceLower) continue;
+    return wallet.address;
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function includesUserRejectionText(value: string): boolean {
+  return /(user rejected|user denied|rejected the request|denied transaction signature)/i.test(value);
+}
+
+export function isUserRejectedTransactionError(error: unknown): boolean {
+  if (typeof error === 'string') {
+    return includesUserRejectionText(error);
+  }
+
+  if (!isRecord(error)) return false;
+
+  const code = error.code;
+  if (code === 4001 || code === 'ACTION_REJECTED') {
+    return true;
+  }
+
+  const candidateTexts: string[] = [];
+  for (const key of ['message', 'shortMessage', 'details']) {
+    const value = error[key];
+    if (typeof value === 'string') candidateTexts.push(value);
+  }
+
+  const cause = error.cause;
+  if (isRecord(cause)) {
+    const causeMessage = cause.message;
+    if (typeof causeMessage === 'string') candidateTexts.push(causeMessage);
+  }
+
+  return candidateTexts.some((text) => includesUserRejectionText(text));
+}
+
+type ValidateWithdrawRequestInput = {
+  mode: 'connected' | 'custom';
+  customDestination: string;
+  connectedDestination: string | null;
+  sourceAddress: string;
+  amount: string;
+};
+
+export function validateWithdrawRequest(
+  input: ValidateWithdrawRequestInput,
+): { ok: true; destinationAddress: string } | { ok: false; error: string } {
+  const amount = Number(input.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return { ok: false, error: 'Amount must be greater than 0.' };
+  }
+
+  const destinationAddress =
+    input.mode === 'connected' ? input.connectedDestination : input.customDestination.trim();
+
+  if (!destinationAddress || destinationAddress.length === 0) {
+    return { ok: false, error: 'No connected destination wallet available.' };
+  }
+
+  if (!isHexAddress(destinationAddress)) {
+    return { ok: false, error: 'Please enter a valid wallet address.' };
+  }
+
+  if (destinationAddress.toLowerCase() === input.sourceAddress.toLowerCase()) {
+    return { ok: false, error: 'Destination wallet must be different from source wallet.' };
+  }
+
+  return { ok: true, destinationAddress };
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/withdraw.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/withdraw.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isHexAddress,
+  isUserRejectedTransactionError,
+  selectConnectedDestinationWallet,
+  validateWithdrawRequest,
+} from './withdraw';
+
+describe('withdraw helpers', () => {
+  it('validates hex addresses', () => {
+    expect(isHexAddress('0x1111111111111111111111111111111111111111')).toBe(true);
+    expect(isHexAddress('0xabc')).toBe(false);
+    expect(isHexAddress('hello')).toBe(false);
+  });
+
+  it('rejects custom destination when address is invalid', () => {
+    const result = validateWithdrawRequest({
+      mode: 'custom',
+      customDestination: 'invalid',
+      connectedDestination: null,
+      sourceAddress: '0x1111111111111111111111111111111111111111',
+      amount: '1',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('valid wallet address');
+    }
+  });
+
+  it('rejects connected mode when no connected destination exists', () => {
+    const result = validateWithdrawRequest({
+      mode: 'connected',
+      customDestination: '',
+      connectedDestination: null,
+      sourceAddress: '0x1111111111111111111111111111111111111111',
+      amount: '1',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('No connected destination wallet');
+    }
+  });
+
+  it('rejects destination equal to source address', () => {
+    const result = validateWithdrawRequest({
+      mode: 'custom',
+      customDestination: '0x1111111111111111111111111111111111111111',
+      connectedDestination: null,
+      sourceAddress: '0x1111111111111111111111111111111111111111',
+      amount: '1',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('must be different');
+    }
+  });
+
+  it('returns parsed destination when request is valid', () => {
+    const result = validateWithdrawRequest({
+      mode: 'connected',
+      customDestination: '',
+      connectedDestination: '0x2222222222222222222222222222222222222222',
+      sourceAddress: '0x1111111111111111111111111111111111111111',
+      amount: '1.5',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      destinationAddress: '0x2222222222222222222222222222222222222222',
+    });
+  });
+
+  it('selects the first non-privy connected destination wallet that differs from source', () => {
+    const selected = selectConnectedDestinationWallet({
+      sourceAddress: '0x1111111111111111111111111111111111111111',
+      wallets: [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          walletClientType: 'metamask',
+        },
+        {
+          address: '0x2222222222222222222222222222222222222222',
+          walletClientType: 'privy',
+        },
+        {
+          address: '0x3333333333333333333333333333333333333333',
+          walletClientType: 'coinbase_wallet',
+        },
+      ],
+    });
+
+    expect(selected).toBe('0x3333333333333333333333333333333333333333');
+  });
+
+  it('detects user rejected transaction errors from message text', () => {
+    const rejected = new Error('User rejected the request.');
+    expect(isUserRejectedTransactionError(rejected)).toBe(true);
+  });
+
+  it('detects user rejected transaction errors from wallet error code', () => {
+    expect(
+      isUserRejectedTransactionError({
+        code: 4001,
+        message: 'Request rejected',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not classify unrelated errors as user-rejected', () => {
+    expect(isUserRejectedTransactionError(new Error('RPC timeout'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a secondary **Manage Wallet** entry in the sidebar wallet section
- add `/wallet` management page with portfolio balances/positions from onchain-actions
- add withdraw flow for MetaMask smart wallet with connected/custom destination handling
- track withdraw transaction receipts and only mark confirmed after on-chain confirmation
- refresh wallet balances/positions after confirmed withdraw receipts

## Details
- new API proxy route: `/api/onchain-actions/wallet/[walletAddress]/portfolio`
- new wallet UI components:
  - `WalletManagementView`
  - `WalletPortfolioPanel`
  - `WalletWithdrawPanel`
  - withdraw helpers in `withdraw.ts`
- sidebar chain selector now only shows Arbitrum + Ethereum
- token balances now show per-token USD values and wallet USD total
- user-rejected transaction errors are treated as info (not surfaced as noisy UI errors)
- withdraw status UI moved to a prominent activity-style status card

## Testing
- `pnpm --filter web test:unit`
- `pnpm --filter web lint`
- `pnpm --filter web build`

Closes #449
