### PR TITLE
fix(web-ag-ui): add public traefik cert resolver

### DIFF
--- a/typescript/clients/web-ag-ui/compose.yaml
+++ b/typescript/clients/web-ag-ui/compose.yaml
@@ -11,6 +11,9 @@ services:
       - --certificatesresolvers.cloudflare.acme.email=${ACME_EMAIL}
       - --certificatesresolvers.cloudflare.acme.storage=/acme/acme.json
       - --certificatesresolvers.cloudflare.acme.dnschallenge.provider=cloudflare
+      - --certificatesresolvers.public.acme.email=${ACME_EMAIL}
+      - --certificatesresolvers.public.acme.storage=/acme/acme.json
+      - --certificatesresolvers.public.acme.tlschallenge=true
       - --experimental.plugins.trauth.moduleName=github.com/leonjza/trauth
       - --experimental.plugins.trauth.version=v1.6.7
     ports:


### PR DESCRIPTION
## Summary
- add a `public` Traefik ACME certificate resolver to `web-ag-ui` compose config
- keep the existing Cloudflare DNS-challenge resolver while adding a TLS-challenge path for public certificates
- bring the server-side `compose.yaml` change under source control so deploys can sync cleanly from `next`

## Test Plan
- `pnpm lint`
- `pnpm build`
