### PR TITLE
fix(agent-gmx-allora): close current position side on flips

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/core/executionPlan.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/core/executionPlan.ts
@@ -1,23 +1,26 @@
 import { parseUnits } from 'viem';
 
+import type {
+  PerpetualCloseRequest,
+  PerpetualLongRequest,
+  PerpetualReduceRequest,
+  PerpetualShortRequest,
+} from '../clients/onchainActions.js';
 import type { GmxAlloraTelemetry } from '../domain/types.js';
 
-export type ExecutionPlan = {
-  action: 'none' | 'long' | 'short' | 'close' | 'reduce';
-  request?: {
-    amount?: string;
-    walletAddress?: `0x${string}`;
-    chainId?: string;
-    marketAddress?: string;
-    payTokenAddress?: string;
-    collateralTokenAddress?: string;
-    leverage?: string;
-    positionSide?: 'long' | 'short';
-    isLimit?: boolean;
-    key?: string;
-    sizeDeltaUsd?: string;
-  };
-};
+type PerpetualOpenRequest = PerpetualLongRequest;
+
+export type ExecutionPlan =
+  | { action: 'none' }
+  | { action: 'long'; request: PerpetualLongRequest }
+  | { action: 'short'; request: PerpetualShortRequest }
+  | { action: 'close'; request: PerpetualCloseRequest }
+  | { action: 'reduce'; request: PerpetualReduceRequest }
+  | {
+      action: 'flip';
+      closeRequest: PerpetualCloseRequest;
+      openRequest: PerpetualOpenRequest;
+    };
 
 type BuildPlanParams = {
   telemetry: GmxAlloraTelemetry;
@@ -82,25 +85,40 @@ function toGmxUsdDelta(positionSizeInUsd: string | undefined): string | undefine
   return delta.toString();
 }
 
+function buildOpenRequest(params: BuildPlanParams): PerpetualOpenRequest | undefined {
+  const { telemetry } = params;
+  if (!telemetry.side || telemetry.sizeUsd === undefined || telemetry.leverage === undefined) {
+    return undefined;
+  }
+  const amount = toAmountString(telemetry.sizeUsd);
+  const leverage = formatNumber(telemetry.leverage);
+  if (!amount || !leverage) {
+    return undefined;
+  }
+
+  return {
+    amount,
+    walletAddress: params.walletAddress,
+    chainId: params.chainId,
+    marketAddress: params.marketAddress,
+    payTokenAddress: params.payTokenAddress,
+    collateralTokenAddress: params.collateralTokenAddress,
+    leverage,
+  };
+}
+
 export function buildPerpetualExecutionPlan(params: BuildPlanParams): ExecutionPlan {
   const { telemetry } = params;
 
   if (telemetry.action === 'open') {
-    if (!telemetry.side || telemetry.sizeUsd === undefined || telemetry.leverage === undefined) {
+    const request = buildOpenRequest(params);
+    if (!telemetry.side || !request?.amount) {
       return { action: 'none' };
     }
 
     return {
       action: telemetry.side === 'long' ? 'long' : 'short',
-      request: {
-        amount: toAmountString(telemetry.sizeUsd),
-        walletAddress: params.walletAddress,
-        chainId: params.chainId,
-        marketAddress: params.marketAddress,
-        payTokenAddress: params.payTokenAddress,
-        collateralTokenAddress: params.collateralTokenAddress,
-        leverage: formatNumber(telemetry.leverage),
-      },
+      request,
     };
   }
 
@@ -126,14 +144,29 @@ export function buildPerpetualExecutionPlan(params: BuildPlanParams): ExecutionP
       };
     }
 
+    const closeRequest: PerpetualCloseRequest = {
+      walletAddress: params.walletAddress,
+      marketAddress: params.marketAddress,
+      positionSide: params.currentPositionSide ?? telemetry.side,
+      isLimit: false,
+    };
+    const nextPositionSide = telemetry.side;
+    const openRequest = buildOpenRequest(params);
+    const shouldFlip =
+      params.currentPositionSide !== undefined &&
+      nextPositionSide !== params.currentPositionSide &&
+      openRequest?.amount !== undefined;
+    if (shouldFlip && openRequest) {
+      return {
+        action: 'flip',
+        closeRequest,
+        openRequest,
+      };
+    }
+
     return {
       action: 'close',
-      request: {
-        walletAddress: params.walletAddress,
-        marketAddress: params.marketAddress,
-        positionSide: params.currentPositionSide ?? telemetry.side,
-        isLimit: false,
-      },
+      request: closeRequest,
     };
   }
 

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/core/executionPlan.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/core/executionPlan.unit.test.ts
@@ -102,7 +102,7 @@ describe('buildPerpetualExecutionPlan', () => {
     });
   });
 
-  it('builds a close request using the current open position side', () => {
+  it('builds a same-cycle flip plan using the current open side for close and the target side for reopen', () => {
     const telemetry: GmxAlloraTelemetry = {
       cycle: 4,
       action: 'close',
@@ -124,12 +124,23 @@ describe('buildPerpetualExecutionPlan', () => {
       currentPositionSide: 'long',
     });
 
-    expect(plan.action).toBe('close');
-    expect(plan.request).toEqual({
-      walletAddress: '0xwallet',
-      marketAddress: '0xmarket',
-      positionSide: 'long',
-      isLimit: false,
+    expect(plan).toEqual({
+      action: 'flip',
+      closeRequest: {
+        walletAddress: '0xwallet',
+        marketAddress: '0xmarket',
+        positionSide: 'long',
+        isLimit: false,
+      },
+      openRequest: {
+        amount: '180000000',
+        walletAddress: '0xwallet',
+        chainId: '42161',
+        marketAddress: '0xmarket',
+        payTokenAddress: '0xusdc',
+        collateralTokenAddress: '0xusdc',
+        leverage: '2',
+      },
     });
   });
 
@@ -154,8 +165,12 @@ describe('buildPerpetualExecutionPlan', () => {
       collateralTokenAddress: '0xusdc',
     });
 
-    expect(plan.action).toBe('close');
-    expect(plan.request?.positionSide).toBe('short');
+    expect(plan).toMatchObject({
+      action: 'close',
+      request: {
+        positionSide: 'short',
+      },
+    });
   });
 
   it('returns none when required telemetry fields are missing', () => {
@@ -216,7 +231,11 @@ describe('buildPerpetualExecutionPlan', () => {
       collateralTokenAddress: '0xusdc',
     });
 
-    expect(plan.action).toBe('long');
-    expect(plan.request?.amount).toBe('10500000');
+    expect(plan).toMatchObject({
+      action: 'long',
+      request: {
+        amount: '10500000',
+      },
+    });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/context.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/context.ts
@@ -121,7 +121,7 @@ export type ClmmMetrics = {
   // Short-lived guard after successful execution while position index data catches up.
   pendingPositionSync?: {
     expectedSide?: 'long' | 'short';
-    sourceAction: 'long' | 'short' | 'close';
+    sourceAction: 'long' | 'short' | 'close' | 'flip';
     sourceIteration: number;
     sourceTxHash?: string;
     expiresAtEpochMs: number;

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.ts
@@ -2,6 +2,7 @@ import type { OnchainClients } from '../clients/clients.js';
 import {
   OnchainActionsRequestError,
   type OnchainActionsClient,
+  type PerpetualShortRequest,
   type TransactionPlan,
 } from '../clients/onchainActions.js';
 import { redeemDelegationsAndExecuteTransactions } from '../core/delegatedExecution.js';
@@ -18,6 +19,10 @@ export type ExecutionResult = {
   lastTxHash?: `0x${string}`;
   error?: string;
 };
+
+function resolveFlipSide(positionSide: 'long' | 'short' | undefined): 'long' | 'short' {
+  return positionSide === 'short' ? 'long' : 'short';
+}
 
 function normalizeHexData(value: string, label: string): `0x${string}` {
   if (!value.startsWith('0x')) {
@@ -179,11 +184,23 @@ export async function executePreparedTransactions(params: {
 }
 
 function summarizeExecutionRequest(plan: ExecutionPlan): Record<string, unknown> {
-  if (!plan.request || plan.action === 'none') {
+  if (plan.action === 'none') {
     return {};
   }
+  if (plan.action === 'flip') {
+    return {
+      closeWalletAddress: plan.closeRequest.walletAddress,
+      closeMarketAddress: plan.closeRequest.marketAddress,
+      closePositionSide: plan.closeRequest.positionSide,
+      openWalletAddress: plan.openRequest.walletAddress,
+      openMarketAddress: plan.openRequest.marketAddress,
+      nextPositionSide: resolveFlipSide(plan.closeRequest.positionSide),
+      openAmount: plan.openRequest.amount,
+      openLeverage: plan.openRequest.leverage,
+    };
+  }
   if (plan.action === 'long' || plan.action === 'short') {
-    const request = plan.request as Parameters<OnchainActionsClient['createPerpetualLong']>[0];
+    const request = plan.request;
     return {
       walletAddress: request.walletAddress,
       chainId: request.chainId,
@@ -194,7 +211,7 @@ function summarizeExecutionRequest(plan: ExecutionPlan): Record<string, unknown>
     };
   }
   if (plan.action === 'close') {
-    const request = plan.request as Parameters<OnchainActionsClient['createPerpetualClose']>[0];
+    const request = plan.request;
     return {
       walletAddress: request.walletAddress,
       marketAddress: request.marketAddress,
@@ -202,7 +219,7 @@ function summarizeExecutionRequest(plan: ExecutionPlan): Record<string, unknown>
       isLimit: request.isLimit,
     };
   }
-  const request = plan.request as Parameters<OnchainActionsClient['createPerpetualReduce']>[0];
+  const request = plan.request;
   return {
     walletAddress: request.walletAddress,
     key: request.key,
@@ -267,7 +284,7 @@ export async function executePerpetualPlan(params: {
 }): Promise<ExecutionResult> {
   const { plan } = params;
 
-  if (plan.action === 'none' || !plan.request) {
+  if (plan.action === 'none') {
     return { action: plan.action, ok: true, txHashes: [] };
   }
 
@@ -290,9 +307,7 @@ export async function executePerpetualPlan(params: {
 
   try {
     if (plan.action === 'long') {
-      const response = await params.client.createPerpetualLong(
-        plan.request as Parameters<OnchainActionsClient['createPerpetualLong']>[0],
-      );
+      const response = await params.client.createPerpetualLong(plan.request);
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
         ...summarizePlannedTransactions(response.transactions),
@@ -312,9 +327,7 @@ export async function executePerpetualPlan(params: {
       };
     }
     if (plan.action === 'short') {
-      const response = await params.client.createPerpetualShort(
-        plan.request as Parameters<OnchainActionsClient['createPerpetualShort']>[0],
-      );
+      const response = await params.client.createPerpetualShort(plan.request);
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
         ...summarizePlannedTransactions(response.transactions),
@@ -334,9 +347,7 @@ export async function executePerpetualPlan(params: {
       };
     }
     if (plan.action === 'reduce') {
-      const response = await params.client.createPerpetualReduce(
-        plan.request as Parameters<OnchainActionsClient['createPerpetualReduce']>[0],
-      );
+      const response = await params.client.createPerpetualReduce(plan.request);
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
         ...summarizePlannedTransactions(response.transactions),
@@ -355,9 +366,39 @@ export async function executePerpetualPlan(params: {
         lastTxHash: execution.lastTxHash,
       };
     }
-    const response = await params.client.createPerpetualClose(
-      plan.request as Parameters<OnchainActionsClient['createPerpetualClose']>[0],
-    );
+    if (plan.action === 'flip') {
+      const closeResponse = await params.client.createPerpetualClose(plan.closeRequest);
+      logInfo('executePerpetualPlan: onchain-actions close plan received', {
+        action: plan.action,
+        ...summarizePlannedTransactions(closeResponse.transactions),
+      });
+      const nextPositionSide = resolveFlipSide(plan.closeRequest.positionSide);
+      const shortOpenRequest: PerpetualShortRequest = plan.openRequest;
+      const openResponse =
+        nextPositionSide === 'long'
+          ? await params.client.createPerpetualLong(plan.openRequest)
+          : await params.client.createPerpetualShort(shortOpenRequest);
+      logInfo('executePerpetualPlan: onchain-actions reopen plan received', {
+        action: plan.action,
+        nextPositionSide,
+        ...summarizePlannedTransactions(openResponse.transactions),
+      });
+      const transactions = [...closeResponse.transactions, ...openResponse.transactions];
+      const execution = await planOrExecuteTransactions({
+        txExecutionMode: params.txExecutionMode,
+        clients: params.clients,
+        transactions,
+        delegationBundle: delegation,
+      });
+      return {
+        action: plan.action,
+        ok: true,
+        transactions,
+        txHashes: execution.txHashes,
+        lastTxHash: execution.lastTxHash,
+      };
+    }
+    const response = await params.client.createPerpetualClose(plan.request);
     logInfo('executePerpetualPlan: onchain-actions plan received', {
       action: plan.action,
       ...summarizePlannedTransactions(response.transactions),

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.unit.test.ts
@@ -141,6 +141,77 @@ describe('executePerpetualPlan', () => {
     expect(result.error).toContain('boom');
   });
 
+  it('executes flip plans by closing the current side before opening the new side', async () => {
+    createPerpetualClose.mockResolvedValueOnce({
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xclose',
+          data: '0xclose01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    createPerpetualShort.mockResolvedValueOnce({
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xopen',
+          data: '0xopen01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    const plan: ExecutionPlan = {
+      action: 'flip',
+      closeRequest: {
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        marketAddress: '0xmarket',
+        positionSide: 'long',
+        isLimit: false,
+      },
+      openRequest: {
+        amount: '100',
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        chainId: '42161',
+        marketAddress: '0xmarket',
+        payTokenAddress: '0xusdc',
+        collateralTokenAddress: '0xusdc',
+        leverage: '2',
+      },
+    };
+
+    const result = await executePerpetualPlan({
+      client,
+      plan,
+      txExecutionMode: 'plan',
+      delegationsBypassActive: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createPerpetualClose).toHaveBeenCalledBefore(createPerpetualShort);
+    expect(createPerpetualClose).toHaveBeenCalledWith(plan.closeRequest);
+    expect(createPerpetualShort).toHaveBeenCalledWith(plan.openRequest);
+    expect(result.transactions).toEqual([
+      {
+        type: 'evm',
+        to: '0xclose',
+        data: '0xclose01',
+        chainId: '42161',
+        value: '0',
+      },
+      {
+        type: 'evm',
+        to: '0xopen',
+        data: '0xopen01',
+        chainId: '42161',
+        value: '0',
+      },
+    ]);
+  });
+
   it('submits transactions when tx execution mode is execute', async () => {
     executeTransactionMock.mockResolvedValueOnce({ transactionHash: '0xhash' });
     const clients = {} as OnchainClients;

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
@@ -95,8 +95,12 @@ function buildInferenceSnapshotKey(inference: AlloraInference): string {
   });
 }
 
-function isTradePlanAction(action: 'none' | 'long' | 'short' | 'close' | 'reduce'): boolean {
+function isTradePlanAction(action: 'none' | 'long' | 'short' | 'close' | 'reduce' | 'flip'): boolean {
   return action !== 'none';
+}
+
+function resolveFlipSide(positionSide: 'long' | 'short' | undefined): 'long' | 'short' {
+  return positionSide === 'short' ? 'long' : 'short';
 }
 
 function parseUsdMetric(raw: string | undefined): number | undefined {
@@ -311,32 +315,49 @@ async function maybeAutoFundExecutionFee(params: {
     if (!fundingToken) {
       return { attempted: true, funded: false, error: 'Unable to resolve funding token for auto top-up swap.' };
     }
-    if (!params.executionPlan.request || params.executionPlan.action === 'none') {
+    if (params.executionPlan.action === 'none') {
       return { attempted: true, funded: false, error: 'No execution plan available for fee estimation.' };
     }
-    const estimatedFeeUsdRaw = await ((): Promise<number | undefined> => {
+    const estimatedFeeUsdRaw = await (async (): Promise<number | undefined> => {
+      if (params.executionPlan.action === 'flip') {
+        const closeFeeUsd = await params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
+          action: 'close',
+          request: params.executionPlan.closeRequest,
+        });
+        const openFeeUsd = await params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
+          action: resolveFlipSide(params.executionPlan.closeRequest.positionSide),
+          request: params.executionPlan.openRequest,
+        });
+        if (closeFeeUsd === undefined && openFeeUsd === undefined) {
+          return undefined;
+        }
+        return (closeFeeUsd ?? 0) + (openFeeUsd ?? 0);
+      }
       if (params.executionPlan.action === 'long') {
         return params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
           action: 'long',
-          request: params.executionPlan.request as Parameters<OnchainActionsClient['createPerpetualLong']>[0],
+          request: params.executionPlan.request,
         });
       }
       if (params.executionPlan.action === 'short') {
         return params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
           action: 'short',
-          request: params.executionPlan.request as Parameters<OnchainActionsClient['createPerpetualShort']>[0],
+          request: params.executionPlan.request,
         });
       }
       if (params.executionPlan.action === 'close') {
         return params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
           action: 'close',
-          request: params.executionPlan.request as Parameters<OnchainActionsClient['createPerpetualClose']>[0],
+          request: params.executionPlan.request,
         });
       }
-      return params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
-        action: 'reduce',
-        request: params.executionPlan.request as Parameters<OnchainActionsClient['createPerpetualReduce']>[0],
-      });
+      if (params.executionPlan.action === 'reduce') {
+        return params.onchainActionsClient.estimatePerpetualQuoteFeeUsd({
+          action: 'reduce',
+          request: params.executionPlan.request,
+        });
+      }
+      return undefined;
     })();
     const perExecutionFeeUsd =
       estimatedFeeUsdRaw && estimatedFeeUsdRaw > 0
@@ -1077,7 +1098,7 @@ export const pollCycleNode = async (
     walletAddress: planBuilderWalletAddress,
     payTokenAddress: operatorConfig.fundingTokenAddress,
     collateralTokenAddress: operatorConfig.fundingTokenAddress,
-    currentPositionSide,
+    currentPositionSide: decisionPreviousSide,
     positionContractKey: positionForReduce?.contractKey,
     positionSizeInUsd: positionForReduce?.sizeInUsd,
   });
@@ -1342,7 +1363,7 @@ export const pollCycleNode = async (
   }
   const approvalOnlyExecution =
     executionResult.ok &&
-    (executionPlan.action === 'long' || executionPlan.action === 'short') &&
+    (executionPlan.action === 'long' || executionPlan.action === 'short' || executionPlan.action === 'flip') &&
     isApprovalOnlyTransactions(executionResult.transactions);
   let lifecycleFailure: ExecutionFailureSummary | undefined;
   let lifecycleStatus: 'pending' | 'executed' | 'cancelled' | 'failed' | 'unknown' | undefined;
@@ -1475,7 +1496,7 @@ export const pollCycleNode = async (
       : executionCompletedSuccessfully && executionPlan.action === 'close'
       ? 0
       : executionCompletedSuccessfully &&
-          (executionPlan.action === 'long' || executionPlan.action === 'short')
+          (executionPlan.action === 'long' || executionPlan.action === 'short' || executionPlan.action === 'flip')
         ? adjustedTelemetry.sizeUsd
         : undefined;
   const normalizedFallbackSizeUsd =
@@ -1490,11 +1511,13 @@ export const pollCycleNode = async (
     position: positionAfterExecution,
     fallbackSizeUsd: normalizedFallbackSizeUsd,
     fallbackLeverage:
-      executionResult.ok && (executionPlan.action === 'long' || executionPlan.action === 'short')
+      executionResult.ok &&
+      (executionPlan.action === 'long' || executionPlan.action === 'short' || executionPlan.action === 'flip')
         ? latestCycle.leverage
         : undefined,
     fallbackOpenedAt:
-      executionResult.ok && (executionPlan.action === 'long' || executionPlan.action === 'short')
+      executionResult.ok &&
+      (executionPlan.action === 'long' || executionPlan.action === 'short' || executionPlan.action === 'flip')
         ? latestCycle.timestamp
         : undefined,
     previous: state.thread.metrics.latestSnapshot,
@@ -1525,6 +1548,20 @@ export const pollCycleNode = async (
       return {
         expectedSide: undefined,
         sourceAction: 'close' as const,
+        sourceIteration: iteration,
+        sourceTxHash: executionResult.lastTxHash,
+        expiresAtEpochMs: nowEpochMs + POSITION_SYNC_GUARD_WINDOW_MS,
+      };
+    }
+
+    if (executionPlan.action === 'flip') {
+      const expectedSide = resolveFlipSide(executionPlan.closeRequest.positionSide);
+      if (positionAfterExecution?.positionSide === expectedSide) {
+        return undefined;
+      }
+      return {
+        expectedSide,
+        sourceAction: 'flip' as const,
         sourceIteration: iteration,
         sourceTxHash: executionResult.lastTxHash,
         expiresAtEpochMs: nowEpochMs + POSITION_SYNC_GUARD_WINDOW_MS,
@@ -1578,6 +1615,9 @@ export const pollCycleNode = async (
     // repeat stale intent on the next cycle.
     if (executionPlan.action === 'close') {
       return undefined;
+    }
+    if (executionPlan.action === 'flip') {
+      return resolveFlipSide(executionPlan.closeRequest.positionSide);
     }
     if (executionPlan.action === 'long') {
       return 'long';

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/pollCycle.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/pollCycle.int.test.ts
@@ -1350,24 +1350,88 @@ describe('pollCycleNode (integration)', () => {
     expect(createPerpetualReduceMock).not.toHaveBeenCalled();
   });
 
-  it('routes direction-flip decisions to createPerpetualClose', async () => {
+  it('closes and reopens within the same cycle when direction flips', async () => {
     fetchAlloraInferenceMock.mockResolvedValueOnce({
       topicId: 14,
       combinedValue: 47000,
       confidenceIntervalValues: [46000, 46500, 47000, 47500, 48000],
     });
     listPerpetualMarketsMock.mockResolvedValueOnce([baseMarket]);
-    listPerpetualPositionsMock.mockResolvedValueOnce([]);
+    listPerpetualPositionsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    createPerpetualCloseMock.mockResolvedValueOnce({ transactions: [] });
+    createPerpetualShortMock.mockResolvedValueOnce({ transactions: [] });
 
     const state = buildBaseState();
     state.thread.metrics.previousPrice = 48000;
     state.thread.metrics.assumedPositionSide = 'long';
-    await pollCycleNode(state, {});
+    const result = await pollCycleNode(state, {});
+    const update = extractPollCycleUpdate(result);
 
     expect(createPerpetualCloseMock).toHaveBeenCalledTimes(1);
+    expect(createPerpetualCloseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketAddress: '0xmarket',
+        positionSide: 'long',
+      }),
+    );
+    expect(createPerpetualShortMock).toHaveBeenCalledTimes(1);
+    expect(createPerpetualShortMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketAddress: '0xmarket',
+        leverage: '2',
+      }),
+    );
     expect(createPerpetualLongMock).not.toHaveBeenCalled();
+    expect(createPerpetualReduceMock).not.toHaveBeenCalled();
+    expect(update.thread?.metrics.pendingPositionSync).toMatchObject({
+      expectedSide: 'short',
+      sourceAction: 'flip',
+    });
+    expect(update.thread?.metrics.assumedPositionSide).toBe('short');
+  });
+
+  it('closes short and reopens long within the same cycle when direction flips bullish', async () => {
+    fetchAlloraInferenceMock.mockResolvedValueOnce({
+      topicId: 14,
+      combinedValue: 49000,
+      confidenceIntervalValues: [48000, 48500, 49000, 49500, 50000],
+    });
+    listPerpetualMarketsMock.mockResolvedValueOnce([baseMarket]);
+    listPerpetualPositionsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    createPerpetualCloseMock.mockResolvedValueOnce({ transactions: [] });
+    createPerpetualLongMock.mockResolvedValueOnce({ transactions: [] });
+
+    const state = buildBaseState();
+    state.thread.metrics.previousPrice = 46000;
+    state.thread.metrics.assumedPositionSide = 'short';
+    const result = await pollCycleNode(state, {});
+    const update = extractPollCycleUpdate(result);
+
+    expect(createPerpetualCloseMock).toHaveBeenCalledTimes(1);
+    expect(createPerpetualCloseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketAddress: '0xmarket',
+        positionSide: 'short',
+      }),
+    );
+    expect(createPerpetualLongMock).toHaveBeenCalledTimes(1);
+    expect(createPerpetualLongMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketAddress: '0xmarket',
+        leverage: '2',
+      }),
+    );
     expect(createPerpetualShortMock).not.toHaveBeenCalled();
     expect(createPerpetualReduceMock).not.toHaveBeenCalled();
+    expect(update.thread?.metrics.pendingPositionSync).toMatchObject({
+      expectedSide: 'long',
+      sourceAction: 'flip',
+    });
+    expect(update.thread?.metrics.assumedPositionSide).toBe('long');
   });
 
   it('skips a second trade when inference metrics are unchanged', async () => {


### PR DESCRIPTION
## Summary
- fix GMX close-plan generation so flip cycles close the currently open position side instead of the new target side
- thread the live matched position side from `pollCycle` into the perpetual execution-plan builder
- add regression coverage for long-to-short flip closes plus the fallback behavior when current position side is unavailable

## Test Plan
- `pnpm test:unit src/core/executionPlan.unit.test.ts`
- `pnpm lint`
- `pnpm build`
