### PR TITLE
fix(web): reset app session on privy wallet change

### DIFF
--- a/typescript/clients/web-ag-ui/apps/web/src/components/Providers.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/Providers.int.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { act, useEffect, useState, type ReactNode } from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Providers } from './Providers';
+
+type TestWallet = {
+  address: string;
+  walletClientType: string;
+};
+
+const mocks = vi.hoisted(() => ({
+  wallets: [] as TestWallet[],
+}));
+
+vi.mock('@privy-io/react-auth', () => ({
+  useWallets: () => ({
+    wallets: mocks.wallets,
+  }),
+}));
+
+vi.mock('./PrivyClientProvider', () => ({
+  PrivyClientProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../contexts/AgentListContext', () => ({
+  AgentListProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+let sessionMountCounter = 0;
+
+function SessionProbe(params: {
+  onMount: (mountId: number) => void;
+  onUnmount: (mountId: number) => void;
+}) {
+  const [mountId] = useState(() => {
+    sessionMountCounter += 1;
+    return sessionMountCounter;
+  });
+
+  useEffect(() => {
+    params.onMount(mountId);
+    return () => {
+      params.onUnmount(mountId);
+    };
+  }, [mountId, params]);
+
+  return <div data-testid={`session-${mountId}`} />;
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('Providers', () => {
+  let clearQueryClientSpy: ReturnType<typeof vi.spyOn>;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    sessionMountCounter = 0;
+    mocks.wallets = [];
+    clearQueryClientSpy = vi.spyOn(QueryClient.prototype, 'clear');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    clearQueryClientSpy.mockRestore();
+  });
+
+  it('resets app memory and clears query cache when the selected privy wallet signs out and a new wallet signs in', async () => {
+    const mountedIds: number[] = [];
+    const unmountedIds: number[] = [];
+
+    mocks.wallets = [
+      {
+        address: '0xbD70792F773a39f88b43d35bb5Aa3d5e098EfeA4',
+        walletClientType: 'privy',
+      },
+    ];
+
+    await act(async () => {
+      root.render(
+        <Providers>
+          <SessionProbe
+            onMount={(mountId) => {
+              mountedIds.push(mountId);
+            }}
+            onUnmount={(mountId) => {
+              unmountedIds.push(mountId);
+            }}
+          />
+        </Providers>,
+      );
+    });
+    await flushEffects();
+
+    expect(mountedIds).toEqual([1]);
+    expect(unmountedIds).toEqual([]);
+    expect(clearQueryClientSpy).not.toHaveBeenCalled();
+
+    mocks.wallets = [];
+    await act(async () => {
+      root.render(
+        <Providers>
+          <SessionProbe
+            onMount={(mountId) => {
+              mountedIds.push(mountId);
+            }}
+            onUnmount={(mountId) => {
+              unmountedIds.push(mountId);
+            }}
+          />
+        </Providers>,
+      );
+    });
+    await flushEffects();
+
+    expect(mountedIds).toEqual([1, 2]);
+    expect(unmountedIds).toEqual([1]);
+    expect(clearQueryClientSpy).toHaveBeenCalledTimes(1);
+
+    mocks.wallets = [
+      {
+        address: '0xaD53eC51a70e9a17df6752fdA80cd465457c258d',
+        walletClientType: 'privy',
+      },
+    ];
+    await act(async () => {
+      root.render(
+        <Providers>
+          <SessionProbe
+            onMount={(mountId) => {
+              mountedIds.push(mountId);
+            }}
+            onUnmount={(mountId) => {
+              unmountedIds.push(mountId);
+            }}
+          />
+        </Providers>,
+      );
+    });
+    await flushEffects();
+
+    expect(mountedIds).toEqual([1, 2, 3]);
+    expect(unmountedIds).toEqual([1, 2]);
+    expect(clearQueryClientSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/Providers.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/Providers.tsx
@@ -1,10 +1,39 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useWallets } from '@privy-io/react-auth';
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { PrivyClientProvider } from './PrivyClientProvider';
 import { AgentListProvider } from '../contexts/AgentListContext';
+import { normalizeWalletAddress, selectPrivyWallet } from '../hooks/usePrivyWalletClient';
+
+function WalletSessionProvider({ children }: { children: ReactNode }) {
+  const { wallets } = useWallets();
+  const queryClient = useQueryClient();
+  const previousSessionKeyRef = useRef<string | null>(null);
+
+  const sessionKey = useMemo(() => {
+    const selectedWallet = selectPrivyWallet({ wallets });
+    return normalizeWalletAddress(selectedWallet?.address) ?? 'signed-out';
+  }, [wallets]);
+
+  useEffect(() => {
+    if (previousSessionKeyRef.current === null) {
+      previousSessionKeyRef.current = sessionKey;
+      return;
+    }
+
+    if (previousSessionKeyRef.current === sessionKey) {
+      return;
+    }
+
+    previousSessionKeyRef.current = sessionKey;
+    queryClient.clear();
+  }, [queryClient, sessionKey]);
+
+  return <AgentListProvider key={sessionKey}>{children}</AgentListProvider>;
+}
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -12,7 +41,7 @@ export function Providers({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <PrivyClientProvider>
-        <AgentListProvider>{children}</AgentListProvider>
+        <WalletSessionProvider>{children}</WalletSessionProvider>
       </PrivyClientProvider>
     </QueryClientProvider>
   );

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -240,6 +240,39 @@ describe('useAgentConnection integration', () => {
     expect(mocks.agent.threadId).toBe(expectedThreadId);
   });
 
+  it('disconnects the old deterministic thread and reconnects when the privy wallet changes', async () => {
+    mocks.threadId = 'generic-copilot-thread';
+    mocks.privyWalletAddress = '0xbD70792F773a39f88b43d35bb5Aa3d5e098EfeA4';
+
+    const oldThreadId = getAgentThreadId('agent-clmm', mocks.privyWalletAddress);
+
+    await act(async () => {
+      root.render(<TestHarness agentId="agent-clmm" />);
+    });
+    await flushEffects();
+
+    expect(oldThreadId).toBeTruthy();
+    expect(mocks.connectAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.agent.threadId).toBe(oldThreadId);
+
+    mocks.privyWalletAddress = '0xaD53eC51a70e9a17df6752fdA80cd465457c258d';
+    const newThreadId = getAgentThreadId('agent-clmm', mocks.privyWalletAddress);
+
+    await act(async () => {
+      root.render(<TestHarness agentId="agent-clmm" />);
+    });
+    await flushEffects();
+
+    expect(newThreadId).toBeTruthy();
+    expect(mocks.connectAgent).toHaveBeenCalledTimes(2);
+    expect(mocks.agent.threadId).toBe(newThreadId);
+    expect(mocks.disconnectFetch).toHaveBeenCalledTimes(1);
+    expect(readDisconnectPayload()).toEqual({
+      agentId: 'agent-clmm',
+      threadId: oldThreadId,
+    });
+  });
+
   it('falls back to the copilot context thread when no deterministic hired-agent thread is available', async () => {
     mocks.threadId = 'generic-copilot-thread';
     mocks.privyWalletAddress = null;

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/usePrivyWalletClient.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/usePrivyWalletClient.ts
@@ -45,7 +45,7 @@ export function selectPrivyWallet(params: {
   if (preferredAddress) {
     return params.wallets.find((wallet) => wallet.address.toLowerCase() === preferredAddress) ?? null;
   }
-  return params.wallets.find((wallet) => wallet.walletClientType === 'privy') ?? null;
+  return [...params.wallets].reverse().find((wallet) => wallet.walletClientType === 'privy') ?? null;
 }
 
 export function resolveWalletClientError(params: {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/usePrivyWalletClient.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/usePrivyWalletClient.unit.test.ts
@@ -57,6 +57,20 @@ describe('usePrivyWalletClient helpers', () => {
     ).toBeNull();
   });
 
+  it('prefers the most recent privy wallet when multiple privy wallets are present', () => {
+    const wallets = [
+      wallet({ address: '0xold', type: 'privy' }),
+      wallet({ address: '0x1111', type: 'metamask' }),
+      wallet({ address: '0xnew', type: 'privy' }),
+    ];
+
+    expect(
+      selectPrivyWallet({
+        wallets,
+      }),
+    ).toBe(wallets[2]);
+  });
+
   it('resolves query errors with provider > chain > wallet precedence', () => {
     const providerError = new Error('provider failed');
     const chainError = new Error('chain failed');


### PR DESCRIPTION
## Summary
- select the most recent Privy wallet during sign-out/sign-in transitions so the UI derives the current wallet thread
- reset the in-memory web app session when the selected Privy wallet changes or disappears by clearing the React Query cache and remounting the wallet-scoped provider subtree
- add regression coverage for both wallet selection and runtime/app-session reset behavior

## Testing
- pnpm test:unit src/hooks/usePrivyWalletClient.unit.test.ts src/hooks/usePrivyWalletClient.render.unit.test.ts
- pnpm test:int src/hooks/useAgentConnection.int.test.tsx src/components/Providers.int.test.tsx
- pnpm lint
- pnpm build

Closes #470
