### PR TITLE
fix: disable resumable background run streams

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/agent.ts
@@ -170,7 +170,7 @@ async function createRun(params: {
       },
       metadata: { source: 'cron' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/agentCron.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/agentCron.unit.test.ts
@@ -57,4 +57,32 @@ describe('runGraphOnce cron state update payload', () => {
     expect(calledUrls).toEqual([`http://localhost:8124/threads/${threadId}/state`]);
   });
 
+  it('creates cron runs with non-resumable streams', async () => {
+    const threadId = 'thread-1';
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ thread_id: threadId }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ thread_id: threadId }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ checkpoint_id: 'cp-1' }));
+
+    let runCreateBody: Record<string, unknown> | undefined;
+    fetchMock.mockImplementationOnce((_url: string | URL | globalThis.Request, init?: RequestInit) => {
+      const requestBody = typeof init?.body === 'string' ? init.body : '{}';
+      runCreateBody = JSON.parse(requestBody) as Record<string, unknown>;
+      return jsonResponse({ run_id: 'run-1', status: 'running' });
+    });
+
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ run_id: 'run-1', status: 'success' }));
+
+    await runGraphOnce(threadId);
+
+    expect(runCreateBody).toBeDefined();
+    expect(runCreateBody).toMatchObject({
+      stream_mode: ['events', 'values', 'messages'],
+      stream_resumable: false,
+    });
+  });
+
 });

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/tests/workflow/agent-clmm.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/tests/workflow/agent-clmm.e2e.test.ts
@@ -48,7 +48,7 @@ const createRun = async (params: {
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'e2e' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
   const payload = await parseJson(response);

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
@@ -433,7 +433,7 @@ async function createRun(params: {
       },
       metadata: { source: 'cron' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/cronApiRunner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/cronApiRunner.ts
@@ -111,7 +111,7 @@ const buildRunPayload = (params: { graphId: string; threadId: string }): RunCrea
     source: 'starter-cron',
   },
   stream_mode: ['events', 'values', 'messages'],
-  stream_resumable: true,
+  stream_resumable: false,
 });
 
 const buildThreadPayload = (threadId: string): ThreadCreatePayload => ({

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/runGraphOnceBusy.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/runGraphOnceBusy.int.test.ts
@@ -162,6 +162,54 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('creates non-resumable streams for successful runs', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: unknown) => {
+      const url = getUrl(input);
+      const method = getMethod(init);
+
+      if (url.endsWith('/threads') && method === 'POST') {
+        return jsonResponse({ thread_id: 'thread-1' });
+      }
+      if (url.endsWith('/threads/thread-1') && method === 'PATCH') {
+        return jsonResponse({ thread_id: 'thread-1' });
+      }
+      if (url.endsWith('/threads/thread-1/state') && method === 'GET') {
+        return jsonResponse({ values: { thread: {} } });
+      }
+      if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        return jsonResponse({ checkpoint_id: 'cp-1' });
+      }
+      if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
+        return jsonResponse({ run_id: 'run-1' });
+      }
+      if (url.endsWith('/threads/thread-1/runs/run-1/stream') && method === 'GET') {
+        return new Response('event: done\n\n', { status: 200 });
+      }
+      if (url.endsWith('/threads/thread-1/runs/run-1') && method === 'GET') {
+        return jsonResponse({ run_id: 'run-1', status: 'success' });
+      }
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(runGraphOnce('thread-1')).resolves.toBeUndefined();
+
+    const runCreateCall = fetchMock.mock.calls.find(([input]) =>
+      getUrl(input as string | URL | Request).endsWith('/threads/thread-1/runs'),
+    );
+    expect(runCreateCall).toBeDefined();
+    const runCreateInit = runCreateCall?.[1];
+    if (!runCreateInit || typeof runCreateInit !== 'object' || !('body' in runCreateInit)) {
+      throw new Error('Missing run create request body');
+    }
+    const bodyText = (runCreateInit as { body?: unknown }).body;
+    if (typeof bodyText !== 'string') {
+      throw new Error('Expected string run create request body');
+    }
+    const body = JSON.parse(bodyText) as { stream_resumable?: boolean };
+    expect(body.stream_resumable).toBe(false);
+  });
+
   it('preserves inactive lifecycle for fire-terminal snapshots even when setup signals persist', async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: unknown) => {
       const url = getUrl(input);

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/workflow/agent-gmx-allora.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/workflow/agent-gmx-allora.e2e.test.ts
@@ -48,7 +48,7 @@ const createRun = async (params: {
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'e2e' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
   const payload = await parseJson(response);

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/scripts/smoke/pendle-fire-smoke.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/scripts/smoke/pendle-fire-smoke.ts
@@ -167,7 +167,7 @@ const createRun = async (params: {
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'smoke' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
   const payload = await parseJson(response);

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/agent.ts
@@ -258,7 +258,7 @@ async function createRun(params: {
     },
     metadata: { source: 'cron' },
     stream_mode: ['events', 'values', 'messages'],
-    stream_resumable: true,
+    stream_resumable: false,
   });
   if (!body) {
     throw new Error('[cron] Failed to serialize LangGraph run create request body');

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/cronApiRunner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/cronApiRunner.ts
@@ -114,7 +114,7 @@ const buildRunPayload = (params: {
     source: 'starter-cron',
   },
   stream_mode: ['events', 'values', 'messages'],
-  stream_resumable: true,
+  stream_resumable: false,
 });
 
 const buildThreadPayload = (threadId: string): ThreadCreatePayload => ({

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/runGraphOnceBusy.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/runGraphOnceBusy.int.test.ts
@@ -131,6 +131,57 @@ describe('runGraphOnce busy handling integration (Pendle)', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('creates non-resumable streams for successful runs', async () => {
+    const fetchMock = vi.fn((input: string | URL | Request, init?: unknown) => {
+      const url = getUrl(input);
+      const method = getMethod(init);
+
+      if (url.endsWith('/threads') && method === 'POST') {
+        return jsonResponse({ thread_id: 'thread-1' });
+      }
+      if (url.endsWith('/threads/thread-1') && method === 'PATCH') {
+        return jsonResponse({ thread_id: 'thread-1' });
+      }
+      if (url.endsWith('/threads/thread-1/state') && method === 'GET') {
+        return jsonResponse({ values: { thread: READY_THREAD } });
+      }
+      if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        return jsonResponse({ checkpoint_id: 'cp-1' });
+      }
+      if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
+        return jsonResponse({ run_id: 'run-1' });
+      }
+      if (url.endsWith('/threads/thread-1/runs/run-1/stream') && method === 'GET') {
+        return new Response('event: done\n\n', { status: 200 });
+      }
+      if (url.endsWith('/threads/thread-1/runs/run-1') && method === 'GET') {
+        return jsonResponse({ run_id: 'run-1', status: 'success' });
+      }
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    vi.resetModules();
+    const { runGraphOnce } = await import('./agent.js');
+
+    await expect(runGraphOnce('thread-1')).resolves.toBeUndefined();
+
+    const runCreateCall = fetchMock.mock.calls.find((call) =>
+      getCallUrl(call).endsWith('/threads/thread-1/runs'),
+    );
+    expect(runCreateCall).toBeDefined();
+    const runCreateInit = runCreateCall?.[1];
+    if (!runCreateInit || typeof runCreateInit !== 'object' || !('body' in runCreateInit)) {
+      throw new Error('Missing run create request body');
+    }
+    const bodyText = (runCreateInit as { body?: unknown }).body;
+    if (typeof bodyText !== 'string') {
+      throw new Error('Expected string run create request body');
+    }
+    const body = JSON.parse(bodyText) as { stream_resumable?: boolean };
+    expect(body.stream_resumable).toBe(false);
+  });
+
   it('normalizes stale onboarding input-required task state when projecting cycle command to thread state', async () => {
     const fetchMock = vi.fn((input: string | URL | Request, init?: unknown) => {
       const url = getUrl(input);

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/tests/workflow/agent-pendle.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/tests/workflow/agent-pendle.e2e.test.ts
@@ -48,7 +48,7 @@ const createRun = async (params: {
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'e2e' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
   const payload = await parseJson(response);

--- a/typescript/clients/web-ag-ui/apps/agent/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/agent.ts
@@ -239,7 +239,7 @@ async function createRun(params: {
       },
       metadata: { source: 'cron' },
       stream_mode: ['events', 'values', 'messages'],
-      stream_resumable: true,
+      stream_resumable: false,
     }),
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent/src/cronApiRunner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/cronApiRunner.ts
@@ -114,7 +114,7 @@ const buildRunPayload = (params: {
     source: 'starter-cron',
   },
   stream_mode: ['events', 'values', 'messages'],
-  stream_resumable: true,
+  stream_resumable: false,
 });
 
 const buildThreadPayload = (threadId: string): ThreadCreatePayload => ({

--- a/typescript/clients/web-ag-ui/apps/agent/tests/runGraphOnce.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/tests/runGraphOnce.int.test.ts
@@ -145,6 +145,16 @@ describe('runGraphOnce integration', () => {
       getUrl(input as string | URL | Request).endsWith('/threads/thread-1/runs/run-1'),
     );
     expect(runCreateCalls).toHaveLength(1);
+    const runCreateInit = runCreateCalls[0]?.[1];
+    if (!runCreateInit || typeof runCreateInit !== 'object' || !('body' in runCreateInit)) {
+      throw new Error('Missing run create request body');
+    }
+    const bodyText = (runCreateInit as { body?: unknown }).body;
+    if (typeof bodyText !== 'string') {
+      throw new Error('Expected string run create request body');
+    }
+    const body = JSON.parse(bodyText) as { stream_resumable?: boolean };
+    expect(body.stream_resumable).toBe(false);
     expect(runStreamCalls).toHaveLength(1);
     expect(runFetchCalls).toHaveLength(1);
   });

--- a/typescript/clients/web-ag-ui/pnpm-lock.yaml
+++ b/typescript/clients/web-ag-ui/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       '@ag-ui/client':
         specifier: 0.0.42
         version: 0.0.42(patch_hash=g3vb6i4qg2banxpgna3ko3w63m)
+      '@ag-ui/langgraph':
+        specifier: 0.0.20
+        version: 0.0.20(patch_hash=oqffzjgwq57lc3cv6i3nhtuuwe)(@ag-ui/client@0.0.42(patch_hash=g3vb6i4qg2banxpgna3ko3w63m))(@ag-ui/core@0.0.42)(@opentelemetry/api@1.9.0)(openai@6.17.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@copilotkitnext/core':
         specifier: 0.0.33
         version: 0.0.33(patch_hash=xuedn7hxakcsv22g6465qile5e)
@@ -16894,7 +16897,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.8
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -16928,7 +16931,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -16969,13 +16972,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -17019,7 +17022,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- disable `stream_resumable` for server-side background `/stream` runs in CLMM, starter, Pendle, and GMX agents
- add focused regression coverage to prove successful background runs now create non-resumable streams
- update duplicate cron/e2e/smoke run creators so all background run entry points use the same contract

## Context
Closes #477.

These server-side background runs still use `/stream`, but they no longer ask LangGraph to retain resumable replay state. This is intended to stop the per-run in-memory stream retention that was crashing the CLMM worker after processing the affected wallet thread.

## Test Plan
- `pnpm --dir typescript/clients/web-ag-ui --filter agent-clmm test:unit src/agentCron.unit.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui --filter agent test:int tests/runGraphOnce.int.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui --filter agent-pendle test:int src/runGraphOnceBusy.int.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui --filter agent-gmx-allora test:int tests/runGraphOnceBusy.int.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui lint`
- `pnpm --dir typescript/clients/web-ag-ui build`

## Notes
- `typescript/clients/web-ag-ui/pnpm-lock.yaml` changed because this checkout required a `pnpm install` before tests would run and the existing lockfile on `next` was already stale.
