### PR TITLE
refactor(agent-ember-lending): adopt minimal execution contract

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -23,6 +23,17 @@ portfolio manager owns onboarding and activation; this runtime reads the
 managed lane's current Shared Ember truth and projects the lending wallet,
 mandate, reservation, planning, execution, and escalation state into AG-UI.
 
+Current execution-context semantics:
+
+- onboarding completion is expected to materialize the initial `ember-lending`
+  lane for the first managed runtime pair
+- `owned_units` and `reservations` remain agent-scoped to that lending lane
+- `wallet_contents` reflects the full rooted wallet so the lending prompt can
+  see total wallet inventory even when agent-scoped delegation state is still
+  sparse
+- `subagent_wallet_address` can still be `null` until a later delegation
+  issuance path assigns a dedicated subagent wallet
+
 Like the portfolio manager app, this package should stay a thin downstream app.
 Shared Ember business logic and durable truth remain outside the app behind the
 Shared Ember Domain Service boundary.

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -14,7 +14,7 @@ The intended downstream role for this agent is to act on a bounded Shared Ember
 subagent surface for:
 
 - portfolio-state reads
-- candidate-plan materialization
+- planner-backed candidate-plan creation
 - transaction-plan execution
 - escalation requests
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -762,6 +762,16 @@ describe('agent-ember-lending AG-UI integration', () => {
         }),
       }),
     );
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.createTransactionPlan.v1',
+        params: expect.objectContaining({
+          handoff: expect.objectContaining({
+            payload_builder_output: expect.anything(),
+          }),
+        }),
+      }),
+    );
   });
 
   it('serves lending execution over real AG-UI HTTP endpoints', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -150,6 +150,10 @@ function createCandidatePlanInput() {
       required_control_path: 'lending.supply',
       network: 'arbitrum',
     },
+    handoff: {
+      handoff_id: 'handoff-stale-input-should-not-leak',
+      raw_reasoning_trace: 'planner requests must not forward raw model reasoning',
+    },
   };
 }
 
@@ -178,10 +182,12 @@ function createEscalationRequestInput() {
         required_control_path: 'lending.supply',
         network: 'arbitrum',
       },
+      raw_reasoning_trace: 'escalation requests must not forward raw model reasoning',
     },
     result: {
       phase: 'blocked',
       transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-blocked-001',
       request_result: {
         result: 'needs_release_or_transfer',
         request_id: 'req-ember-lending-blocked-001',
@@ -195,6 +201,33 @@ function createEscalationRequestInput() {
         owned_units: [],
         reservations: [],
       },
+    },
+  };
+}
+
+function createBlockedExecutionResult(input: {
+  result: 'needs_release_or_transfer' | 'denied';
+  requestId: string;
+  message: string;
+  blockingReasonCode: string;
+  nextAction: 'escalate_to_control_plane' | 'stop';
+}) {
+  return {
+    phase: 'blocked',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: input.requestId,
+    request_result: {
+      result: input.result,
+      request_id: input.requestId,
+      message: input.message,
+      reservation_id: 'reservation-ember-lending-001',
+      blocking_reason_code: input.blockingReasonCode,
+      next_action: input.nextAction,
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      owned_units: [],
+      reservations: [],
     },
   };
 }
@@ -339,6 +372,7 @@ describe('agent-ember-lending AG-UI integration', () => {
             committed_event_ids: ['evt-execution-1'],
             execution_result: {
               transaction_plan_id: 'txplan-ember-lending-001',
+              request_id: 'req-ember-lending-execution-001',
               execution: {
                 execution_id: 'exec-ember-lending-001',
                 status: 'confirmed',
@@ -791,6 +825,168 @@ describe('agent-ember-lending AG-UI integration', () => {
         }),
       }),
     );
+  });
+
+  it('serves blocked lending execution requests over real AG-UI HTTP endpoints without claiming execution success', async () => {
+    protocolHost.handleJsonRpc.mockImplementation(async (input: unknown) => {
+      const request =
+        typeof input === 'object' && input !== null
+          ? (input as { method?: unknown })
+          : {};
+
+      if (request.method === 'subagent.requestTransactionExecution.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-execute-transaction-plan',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-execution-blocked-1'],
+            execution_result: createBlockedExecutionResult({
+              result: 'needs_release_or_transfer',
+              requestId: 'req-ember-lending-blocked-001',
+              message: 'reserved capital is still claimed by another agent',
+              blockingReasonCode: 'reserved_for_other_agent',
+              nextAction: 'escalate_to_control_plane',
+            }),
+          },
+        };
+      }
+
+      return defaultHandleJsonRpc(input);
+    });
+
+    await runAgUiConnect({
+      baseUrl,
+      threadId: 'thread-execute-blocked-1',
+      runId: 'run-connect-execute-blocked',
+    });
+
+    await runAgUiCommand({
+      baseUrl,
+      threadId: 'thread-execute-blocked-1',
+      runId: 'run-plan-blocked',
+      command: {
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    const { snapshot: executeSnapshot } = await runAgUiCommand({
+      baseUrl,
+      threadId: 'thread-execute-blocked-1',
+      runId: 'run-execute-blocked',
+      command: {
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executeSnapshot).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        thread: {
+          lifecycle: {
+            phase: 'active',
+            lastReservationSummary:
+              'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
+          },
+          artifacts: {
+            current: {
+              data: {
+                type: 'shared-ember-execution-result',
+                revision: 9,
+                executionResult: {
+                  phase: 'blocked',
+                  transaction_plan_id: 'txplan-ember-lending-001',
+                  request_id: 'req-ember-lending-blocked-001',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('serves denied lending execution requests over real AG-UI HTTP endpoints with the denied admission artifact', async () => {
+    protocolHost.handleJsonRpc.mockImplementation(async (input: unknown) => {
+      const request =
+        typeof input === 'object' && input !== null
+          ? (input as { method?: unknown })
+          : {};
+
+      if (request.method === 'subagent.requestTransactionExecution.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-execute-transaction-plan',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-execution-denied-1'],
+            execution_result: createBlockedExecutionResult({
+              result: 'denied',
+              requestId: 'req-ember-lending-denied-001',
+              message: 'risk policy denied the requested lending path',
+              blockingReasonCode: 'policy_denied',
+              nextAction: 'stop',
+            }),
+          },
+        };
+      }
+
+      return defaultHandleJsonRpc(input);
+    });
+
+    await runAgUiConnect({
+      baseUrl,
+      threadId: 'thread-execute-denied-1',
+      runId: 'run-connect-execute-denied',
+    });
+
+    await runAgUiCommand({
+      baseUrl,
+      threadId: 'thread-execute-denied-1',
+      runId: 'run-plan-denied',
+      command: {
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    const { snapshot: executeSnapshot } = await runAgUiCommand({
+      baseUrl,
+      threadId: 'thread-execute-denied-1',
+      runId: 'run-execute-denied',
+      command: {
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executeSnapshot).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        thread: {
+          lifecycle: {
+            phase: 'active',
+            lastReservationSummary:
+              'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
+          },
+          artifacts: {
+            current: {
+              data: {
+                type: 'shared-ember-execution-result',
+                revision: 9,
+                executionResult: {
+                  phase: 'blocked',
+                  transaction_plan_id: 'txplan-ember-lending-001',
+                  request_id: 'req-ember-lending-denied-001',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   it('serves lending escalation requests over real AG-UI HTTP endpoints', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -339,6 +339,43 @@ describe('agent-ember-lending AG-UI integration', () => {
             },
           },
         };
+      case 'subagent.readExecutionContext.v1':
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-read-execution-context',
+          result: {
+            protocol_version: 'v1',
+            revision: 11,
+            execution_context: {
+              generated_at: '2026-04-01T06:00:00.000Z',
+              network: 'arbitrum',
+              mandate_ref: 'mandate-ember-lending-001',
+              mandate_summary:
+                'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+              mandate_context: {
+                network: 'arbitrum',
+                protocol: 'aave',
+              },
+              subagent_wallet_address: '0x00000000000000000000000000000000000000b1',
+              root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+              owned_units: [
+                {
+                  unit_id: 'unit-ember-lending-001',
+                  root_asset: 'USDC',
+                  amount: '10',
+                  benchmark_value_usd: '10.00',
+                },
+              ],
+              wallet_contents: [
+                {
+                  asset: 'USDC',
+                  amount: '10',
+                  benchmark_value_usd: '10.00',
+                },
+              ],
+            },
+          },
+        };
       case 'subagent.createTransactionPlan.v1':
         return {
           jsonrpc: '2.0',
@@ -564,6 +601,14 @@ describe('agent-ember-lending AG-UI integration', () => {
         },
       }),
     );
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.readExecutionContext.v1',
+        params: {
+          agent_id: 'ember-lending',
+        },
+      }),
+    );
   });
 
   it('does not fabricate handoff identity over AG-UI when the live portfolio payload omits it', async () => {
@@ -685,6 +730,82 @@ describe('agent-ember-lending AG-UI integration', () => {
     );
   });
 
+  it('hydrates a managed lending thread from execution context when the portfolio state is still empty', async () => {
+    protocolHost.handleJsonRpc.mockImplementation(async (input: unknown) => {
+      const request =
+        typeof input === 'object' && input !== null
+          ? (input as { method?: unknown })
+          : {};
+
+      switch (request.method) {
+        case 'subagent.readPortfolioState.v1':
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-execctx-read-portfolio-state',
+            result: {
+              protocol_version: 'v1',
+              revision: 9,
+              portfolio_state: {
+                agent_id: 'ember-lending',
+                owned_units: [],
+                reservations: [],
+              },
+            },
+          };
+        case 'subagent.readExecutionContext.v1':
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-execctx-read-execution-context',
+            result: {
+              protocol_version: 'v1',
+              revision: 10,
+              execution_context: {
+                generated_at: '2026-04-01T06:30:00.000Z',
+                network: 'arbitrum',
+                mandate_ref: 'mandate-ember-lending-001',
+                mandate_summary:
+                  'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+                mandate_context: null,
+                subagent_wallet_address: null,
+                root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+                owned_units: [],
+                wallet_contents: [],
+              },
+            },
+          };
+        default:
+          throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
+      }
+    });
+
+    const { snapshot } = await runAgUiConnect({
+      baseUrl,
+      threadId: 'thread-connect-execution-context-1',
+      runId: 'run-connect-execution-context-1',
+    });
+
+    expect(snapshot).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        thread: {
+          lifecycle: {
+            phase: 'active',
+            mandateRef: 'mandate-ember-lending-001',
+            mandateSummary:
+              'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+            mandateContext: {
+              network: 'arbitrum',
+            },
+            walletAddress: null,
+            rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+            rootedWalletContextId: null,
+            lastReservationSummary: null,
+          },
+        },
+      },
+    });
+  });
+
   it('serves lending candidate-plan materialization over real AG-UI HTTP endpoints after connect hydration', async () => {
     const { events: connectEvents, snapshot: connectSnapshot } = await runAgUiConnect({
       baseUrl,
@@ -709,7 +830,7 @@ describe('agent-ember-lending AG-UI integration', () => {
             current: {
               data: {
                 type: 'shared-ember-portfolio-state',
-                revision: 7,
+                revision: 11,
               },
             },
           },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -306,7 +306,7 @@ describe('agent-ember-lending AG-UI integration', () => {
             },
           },
         };
-      case 'subagent.materializeCandidatePlan.v1':
+      case 'subagent.createTransactionPlan.v1':
         return {
           jsonrpc: '2.0',
           id: 'shared-ember-thread-1-materialize-candidate-plan',
@@ -329,7 +329,7 @@ describe('agent-ember-lending AG-UI integration', () => {
             },
           },
         };
-      case 'subagent.executeTransactionPlan.v1':
+      case 'subagent.requestTransactionExecution.v1':
         return {
           jsonrpc: '2.0',
           id: 'shared-ember-thread-1-execute-transaction-plan',
@@ -569,7 +569,7 @@ describe('agent-ember-lending AG-UI integration', () => {
               },
             },
           };
-        case 'subagent.materializeCandidatePlan.v1':
+        case 'subagent.createTransactionPlan.v1':
           return {
             jsonrpc: '2.0',
             id: 'shared-ember-thread-lean-materialize-candidate-plan',
@@ -623,7 +623,7 @@ describe('agent-ember-lending AG-UI integration', () => {
       threadId: 'thread-lean-1',
       runId: 'run-plan-lean-1',
       command: {
-        name: 'materialize_candidate_plan',
+        name: 'create_transaction_plan',
         input: createCandidatePlanInput(),
       },
     });
@@ -646,21 +646,19 @@ describe('agent-ember-lending AG-UI integration', () => {
 
     expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'subagent.materializeCandidatePlan.v1',
+        method: 'subagent.createTransactionPlan.v1',
       }),
     );
   });
 
-  it('serves lending state refresh and candidate-plan materialization over real AG-UI HTTP endpoints', async () => {
-    const { events: refreshEvents, snapshot: refreshSnapshot } = await runAgUiCommand({
+  it('serves lending candidate-plan materialization over real AG-UI HTTP endpoints after connect hydration', async () => {
+    const { events: connectEvents, snapshot: connectSnapshot } = await runAgUiConnect({
       baseUrl,
-      runId: 'run-refresh',
-      command: {
-        name: 'read_portfolio_state',
-      },
+      threadId: 'thread-plan-1',
+      runId: 'run-connect-plan',
     });
 
-    expect(refreshSnapshot).toMatchObject({
+    expect(connectSnapshot).toMatchObject({
       type: 'STATE_SNAPSHOT',
       snapshot: {
         thread: {
@@ -687,9 +685,10 @@ describe('agent-ember-lending AG-UI integration', () => {
 
     const { events: planEvents, snapshot: planSnapshot } = await runAgUiCommand({
       baseUrl,
+      threadId: 'thread-plan-1',
       runId: 'run-plan',
       command: {
-        name: 'materialize_candidate_plan',
+        name: 'create_transaction_plan',
         input: createCandidatePlanInput(),
       },
     });
@@ -719,7 +718,7 @@ describe('agent-ember-lending AG-UI integration', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'subagent.materializeCandidatePlan.v1',
+        method: 'subagent.createTransactionPlan.v1',
         params: expect.objectContaining({
           handoff: expect.objectContaining({
             agent_id: 'ember-lending',
@@ -732,28 +731,28 @@ describe('agent-ember-lending AG-UI integration', () => {
   });
 
   it('serves lending execution over real AG-UI HTTP endpoints', async () => {
-    await runAgUiCommand({
+    await runAgUiConnect({
       baseUrl,
-      runId: 'run-refresh',
-      command: {
-        name: 'read_portfolio_state',
-      },
+      threadId: 'thread-execute-1',
+      runId: 'run-connect-execute',
     });
 
     await runAgUiCommand({
       baseUrl,
+      threadId: 'thread-execute-1',
       runId: 'run-plan',
       command: {
-        name: 'materialize_candidate_plan',
+        name: 'create_transaction_plan',
         input: createCandidatePlanInput(),
       },
     });
 
     const { snapshot: executeSnapshot } = await runAgUiCommand({
       baseUrl,
+      threadId: 'thread-execute-1',
       runId: 'run-execute',
       command: {
-        name: 'execute_transaction_plan',
+        name: 'request_transaction_execution',
       },
     });
 
@@ -785,7 +784,7 @@ describe('agent-ember-lending AG-UI integration', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'subagent.executeTransactionPlan.v1',
+        method: 'subagent.requestTransactionExecution.v1',
         params: expect.objectContaining({
           expected_revision: 8,
           transaction_plan_id: 'txplan-ember-lending-001',
@@ -795,16 +794,15 @@ describe('agent-ember-lending AG-UI integration', () => {
   });
 
   it('serves lending escalation requests over real AG-UI HTTP endpoints', async () => {
-    await runAgUiCommand({
+    await runAgUiConnect({
       baseUrl,
-      runId: 'run-refresh',
-      command: {
-        name: 'read_portfolio_state',
-      },
+      threadId: 'thread-escalation-1',
+      runId: 'run-connect-escalation',
     });
 
     const { snapshot: escalationSnapshot } = await runAgUiCommand({
       baseUrl,
+      threadId: 'thread-escalation-1',
       runId: 'run-escalation',
       command: {
         name: 'create_escalation_request',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -66,6 +66,11 @@ type ExecutionContextResponse = {
   };
 };
 
+type SharedEmberExecutionContextEnvelope = {
+  revision: number | null;
+  executionContext: NonNullable<SharedEmberExecutionContext>;
+};
+
 type PortfolioProjection = Pick<
   EmberLendingLifecycleState,
   | 'mandateRef'
@@ -142,7 +147,7 @@ async function readSharedEmberExecutionContext(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
   threadId: string;
   agentId: string;
-}): Promise<NonNullable<SharedEmberExecutionContext>> {
+}): Promise<SharedEmberExecutionContextEnvelope> {
   const response = (await input.protocolHost.handleJsonRpc({
     jsonrpc: '2.0',
     id: `shared-ember-${input.threadId}-read-execution-context`,
@@ -157,7 +162,10 @@ async function readSharedEmberExecutionContext(input: {
     throw new Error('Shared Ember execution context response was missing execution_context.');
   }
 
-  return executionContext;
+  return {
+    revision: response.result?.revision ?? null,
+    executionContext,
+  };
 }
 
 async function readCurrentSharedEmberRevision(input: {
@@ -175,6 +183,21 @@ async function readCurrentSharedEmberRevision(input: {
   })) as SharedEmberRevisionResponse;
 
   return response.result?.revision ?? 0;
+}
+
+function mergeKnownRevision(...revisions: Array<number | null | undefined>): number | null {
+  let highest: number | null = null;
+
+  for (const revision of revisions) {
+    if (typeof revision !== 'number') {
+      continue;
+    }
+    if (highest === null || revision > highest) {
+      highest = revision;
+    }
+  }
+
+  return highest;
 }
 
 async function runSharedEmberCommandWithResolvedRevision<T>(input: {
@@ -358,6 +381,74 @@ function mergePortfolioProjection(
   };
 }
 
+function readExecutionContextProjection(
+  executionContext: NonNullable<SharedEmberExecutionContext>,
+): Pick<
+  EmberLendingLifecycleState,
+  | 'mandateRef'
+  | 'mandateSummary'
+  | 'mandateContext'
+  | 'walletAddress'
+  | 'rootUserWalletAddress'
+  | 'rootedWalletContextId'
+  | 'lastReservationSummary'
+> {
+  const mandateContext =
+    (isRecord(executionContext.mandate_context) ? executionContext.mandate_context : null) ??
+    (() => {
+      const network = readString(executionContext.network);
+      return network ? { network } : null;
+    })();
+
+  return {
+    mandateRef: readString(executionContext.mandate_ref),
+    mandateSummary: readString(executionContext.mandate_summary),
+    mandateContext,
+    walletAddress: readHexAddress(executionContext.subagent_wallet_address),
+    rootUserWalletAddress: readHexAddress(executionContext.root_user_wallet_address),
+    rootedWalletContextId: null,
+    lastReservationSummary: null,
+  };
+}
+
+function mergeExecutionContextProjection(
+  state: EmberLendingLifecycleState,
+  executionContext: SharedEmberExecutionContext | null,
+): Pick<
+  EmberLendingLifecycleState,
+  | 'mandateRef'
+  | 'mandateSummary'
+  | 'mandateContext'
+  | 'walletAddress'
+  | 'rootUserWalletAddress'
+  | 'rootedWalletContextId'
+  | 'lastReservationSummary'
+> {
+  if (!executionContext || !isRecord(executionContext)) {
+    return {
+      mandateRef: state.mandateRef,
+      mandateSummary: state.mandateSummary,
+      mandateContext: state.mandateContext,
+      walletAddress: state.walletAddress,
+      rootUserWalletAddress: state.rootUserWalletAddress,
+      rootedWalletContextId: state.rootedWalletContextId,
+      lastReservationSummary: state.lastReservationSummary,
+    };
+  }
+
+  const projection = readExecutionContextProjection(executionContext);
+
+  return {
+    mandateRef: projection.mandateRef ?? state.mandateRef,
+    mandateSummary: projection.mandateSummary ?? state.mandateSummary,
+    mandateContext: projection.mandateContext ?? state.mandateContext,
+    walletAddress: projection.walletAddress ?? state.walletAddress,
+    rootUserWalletAddress: projection.rootUserWalletAddress ?? state.rootUserWalletAddress,
+    rootedWalletContextId: projection.rootedWalletContextId ?? state.rootedWalletContextId,
+    lastReservationSummary: projection.lastReservationSummary ?? state.lastReservationSummary,
+  };
+}
+
 function hasManagedPortfolioProjection(portfolioState: unknown): boolean {
   if (!isRecord(portfolioState)) {
     return false;
@@ -376,6 +467,20 @@ function hasManagedPortfolioProjection(portfolioState: unknown): boolean {
     readHexAddress(portfolioState['agent_wallet']) !== null ||
     readHexAddress(portfolioState['root_user_wallet']) !== null ||
     readString(portfolioState['rooted_wallet_context_id']) !== null
+  );
+}
+
+function hasManagedExecutionContextProjection(executionContext: SharedEmberExecutionContext | null): boolean {
+  if (!executionContext || !isRecord(executionContext)) {
+    return false;
+  }
+
+  return (
+    readString(executionContext.mandate_ref) !== null ||
+    readString(executionContext.mandate_summary) !== null ||
+    isRecord(executionContext.mandate_context) ||
+    readHexAddress(executionContext.subagent_wallet_address) !== null ||
+    readHexAddress(executionContext.root_user_wallet_address) !== null
   );
 }
 
@@ -857,7 +962,7 @@ export function createEmberLendingDomain(
         });
         return buildSharedEmberExecutionContextXml({
           status: 'live',
-          executionContext,
+          executionContext: executionContext.executionContext,
         });
       } catch (error) {
         return buildSharedEmberExecutionContextXml({
@@ -894,13 +999,39 @@ export function createEmberLendingDomain(
           };
 
           const portfolioState = response.result?.portfolio_state ?? null;
-          const projection = mergePortfolioProjection(currentState, portfolioState);
+          let executionContextEnvelope: SharedEmberExecutionContextEnvelope | null = null;
+          try {
+            executionContextEnvelope = await readSharedEmberExecutionContext({
+              protocolHost: options.protocolHost,
+              threadId,
+              agentId,
+            });
+          } catch {
+            executionContextEnvelope = null;
+          }
+
+          const portfolioProjection = mergePortfolioProjection(currentState, portfolioState);
+          const stateWithPortfolioProjection: EmberLendingLifecycleState = {
+            ...currentState,
+            ...portfolioProjection,
+          };
+          const projection = mergeExecutionContextProjection(
+            stateWithPortfolioProjection,
+            executionContextEnvelope?.executionContext ?? null,
+          );
           const nextState: EmberLendingLifecycleState = {
             ...currentState,
-            phase: hasManagedPortfolioProjection(portfolioState) ? 'active' : currentState.phase,
             ...projection,
+            phase:
+              hasManagedPortfolioProjection(portfolioState) ||
+              hasManagedExecutionContextProjection(executionContextEnvelope?.executionContext ?? null)
+                ? 'active'
+                : currentState.phase,
             lastPortfolioState: portfolioState,
-            lastSharedEmberRevision: response.result?.revision ?? null,
+            lastSharedEmberRevision: mergeKnownRevision(
+              response.result?.revision ?? null,
+              executionContextEnvelope?.revision ?? null,
+            ),
           };
 
           return {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -30,7 +30,6 @@ export type EmberLendingLifecycleState = {
 type CreateEmberLendingDomainOptions = {
   protocolHost?: EmberLendingSharedEmberProtocolHost;
   agentId?: string;
-  onboardingOwnerAgentId?: string;
 };
 
 type SharedEmberRevisionResponse = {
@@ -39,55 +38,31 @@ type SharedEmberRevisionResponse = {
   };
 };
 
-type OnboardingProofs = {
-  rooted_wallet_context_registered: boolean;
-  root_delegation_registered: boolean;
-  root_authority_active: boolean;
-  wallet_baseline_observed: boolean;
-  accounting_units_seeded: boolean;
-  mandate_inputs_configured: boolean;
-  reserve_policy_configured: boolean;
-  capital_reserved_for_agent: boolean;
-  policy_snapshot_recorded: boolean;
-  agent_active: boolean;
-};
-
-type OnboardingState = {
-  wallet_address: string;
-  network: string;
-  phase: string;
-  proofs: OnboardingProofs;
-  rooted_wallet_context?: {
-    rooted_wallet_context_id?: string;
-  } | null;
-  root_delegation?: {
-    root_delegation_id?: string;
-  } | null;
+type SharedEmberExecutionContext = {
+  generated_at?: string;
+  network?: string;
+  mandate_ref?: string;
+  mandate_summary?: string;
+  mandate_context?: Record<string, unknown> | null;
+  subagent_wallet_address?: string;
+  root_user_wallet_address?: string;
   owned_units?: Array<{
-    unit_id: string;
-    root_asset: string;
-    quantity: string;
-    status: string;
-    control_path: string;
-    reservation_id: string | null;
+    unit_id?: string;
+    root_asset?: string;
+    amount?: string;
+    benchmark_value_usd?: string;
   }>;
-  reservations?: Array<{
-    reservation_id: string;
-    agent_id: string;
-    purpose: string;
-    status: string;
-    control_path: string;
-    unit_allocations: Array<{
-      unit_id: string;
-      quantity: string;
-    }>;
+  wallet_contents?: Array<{
+    asset?: string;
+    amount?: string;
+    benchmark_value_usd?: string;
   }>;
 } | null;
 
-type OnboardingStateResponse = {
+type ExecutionContextResponse = {
   result?: {
     revision?: number;
-    onboarding_state?: OnboardingState;
+    execution_context?: SharedEmberExecutionContext;
   };
 };
 
@@ -106,7 +81,6 @@ const DIRECT_HIRE_MESSAGE =
   'Use the portfolio manager to onboard and activate the managed lending agent.';
 const DIRECT_FIRE_MESSAGE =
   'Use the portfolio manager to deactivate the managed lending agent.';
-const EMBER_LENDING_ONBOARDING_OWNER_AGENT_ID = 'portfolio-manager';
 const SHARED_EMBER_NETWORK = 'arbitrum';
 
 function buildDefaultLifecycleState(): EmberLendingLifecycleState {
@@ -164,34 +138,26 @@ function isSharedEmberRevisionConflict(error: unknown): boolean {
   );
 }
 
-async function readSharedEmberWalletAccountingState(input: {
+async function readSharedEmberExecutionContext(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
-  ownerAgentId: string;
-  walletAddress: `0x${string}`;
-}): Promise<{
-  revision: number;
-  onboardingState: NonNullable<OnboardingState>;
-}> {
+  threadId: string;
+  agentId: string;
+}): Promise<NonNullable<SharedEmberExecutionContext>> {
   const response = (await input.protocolHost.handleJsonRpc({
     jsonrpc: '2.0',
-    id: `shared-ember-wallet-accounting-${input.ownerAgentId}-${input.walletAddress}`,
-    method: 'orchestrator.readOnboardingState.v1',
+    id: `shared-ember-${input.threadId}-read-execution-context`,
+    method: 'subagent.readExecutionContext.v1',
     params: {
-      agent_id: input.ownerAgentId,
-      wallet_address: input.walletAddress,
-      network: SHARED_EMBER_NETWORK,
+      agent_id: input.agentId,
     },
-  })) as OnboardingStateResponse;
+  })) as ExecutionContextResponse;
 
-  const onboardingState = response.result?.onboarding_state;
-  if (!onboardingState) {
-    throw new Error('Shared Ember onboarding state response was missing onboarding_state.');
+  const executionContext = response.result?.execution_context;
+  if (!executionContext || !isRecord(executionContext)) {
+    throw new Error('Shared Ember execution context response was missing execution_context.');
   }
 
-  return {
-    revision: response.result?.revision ?? 0,
-    onboardingState,
-  };
+  return executionContext;
 }
 
 async function readCurrentSharedEmberRevision(input: {
@@ -428,81 +394,160 @@ export function hasEmberLendingRuntimeProjection(state: unknown): boolean {
   );
 }
 
-function buildSharedEmberAccountingContextXml(input:
-  | {
-      status: 'live';
-      revision: number;
-      onboardingState: NonNullable<OnboardingState>;
-    }
-  | {
-      status: 'unavailable';
-      walletAddress: `0x${string}`;
-      error: string;
-    }): string[] {
-  const generatedAt = new Date().toISOString();
+function readStateNetwork(state: EmberLendingLifecycleState): string | null {
+  return isRecord(state.mandateContext) ? readString(state.mandateContext['network']) : null;
+}
 
-  if (input.status === 'unavailable') {
-    return [
-      '<shared_ember_accounting_context status="unavailable">',
-      `  <generated_at>${escapeXml(generatedAt)}</generated_at>`,
-      `  <wallet_address>${escapeXml(input.walletAddress)}</wallet_address>`,
-      `  <network>${SHARED_EMBER_NETWORK}</network>`,
-      `  <error>${escapeXml(input.error)}</error>`,
-      '</shared_ember_accounting_context>',
-    ];
-  }
-
-  const unitsById = new Map(
-    (input.onboardingState.owned_units ?? []).map((ownedUnit) => [ownedUnit.unit_id, ownedUnit] as const),
+function shouldReadSharedEmberExecutionContext(state: EmberLendingLifecycleState): boolean {
+  return Boolean(
+    state.mandateRef ||
+      state.walletAddress ||
+      state.rootUserWalletAddress ||
+      state.lastSharedEmberRevision !== null ||
+      state.phase === 'active',
   );
+}
 
-  const lines = ['<shared_ember_accounting_context freshness="live">'];
+function buildFallbackExecutionContextXml(state: EmberLendingLifecycleState): string[] {
+  const lines = ['<ember_lending_execution_context freshness="cached">'];
+  lines.push(`  <generated_at>${escapeXml(new Date().toISOString())}</generated_at>`);
+  lines.push(`  <network>${escapeXml(readStateNetwork(state) ?? SHARED_EMBER_NETWORK)}</network>`);
+
+  if (state.mandateRef) {
+    lines.push(`  <mandate_ref>${escapeXml(state.mandateRef)}</mandate_ref>`);
+  }
+
+  if (state.mandateSummary) {
+    lines.push(`  <mandate_summary>${escapeXml(state.mandateSummary)}</mandate_summary>`);
+  }
+
+  if (state.mandateContext) {
+    lines.push(
+      `  <mandate_context_json>${escapeXml(JSON.stringify(state.mandateContext))}</mandate_context_json>`,
+    );
+  }
+
+  if (state.walletAddress) {
+    lines.push(`  <subagent_wallet_address>${state.walletAddress}</subagent_wallet_address>`);
+  }
+
+  if (state.rootUserWalletAddress) {
+    lines.push(
+      `  <root_user_wallet_address>${state.rootUserWalletAddress}</root_user_wallet_address>`,
+    );
+  }
+
+  lines.push('</ember_lending_execution_context>');
+  return lines;
+}
+
+function buildSharedEmberExecutionContextXml(
+  input:
+    | {
+        status: 'live';
+        executionContext: NonNullable<SharedEmberExecutionContext>;
+      }
+    | {
+        status: 'unavailable';
+        state: EmberLendingLifecycleState;
+        error: string;
+      },
+): string[] {
+  if (input.status === 'unavailable') {
+    const lines = buildFallbackExecutionContextXml(input.state);
+    lines[0] = '<ember_lending_execution_context status="unavailable">';
+    lines.splice(lines.length - 1, 0, `  <error>${escapeXml(input.error)}</error>`);
+    return lines;
+  }
+
+  const generatedAt = readString(input.executionContext.generated_at) ?? new Date().toISOString();
+  const network = readString(input.executionContext.network) ?? SHARED_EMBER_NETWORK;
+  const lines = ['<ember_lending_execution_context freshness="live">'];
   lines.push(`  <generated_at>${escapeXml(generatedAt)}</generated_at>`);
-  lines.push(`  <wallet_address>${escapeXml(input.onboardingState.wallet_address)}</wallet_address>`);
-  lines.push(`  <network>${escapeXml(input.onboardingState.network)}</network>`);
-  lines.push(`  <revision>${input.revision}</revision>`);
-  lines.push(`  <phase>${escapeXml(input.onboardingState.phase)}</phase>`);
-  lines.push('  <proofs>');
-  for (const [name, value] of Object.entries(input.onboardingState.proofs)) {
-    lines.push(`    <${name}>${value}</${name}>`);
+
+  const mandateRef = readString(input.executionContext.mandate_ref);
+  if (mandateRef) {
+    lines.push(`  <mandate_ref>${escapeXml(mandateRef)}</mandate_ref>`);
   }
-  lines.push('  </proofs>');
-  lines.push('  <assets>');
-  for (const asset of input.onboardingState.owned_units ?? []) {
-    lines.push(
-      `    <asset unit_id="${escapeXml(asset.unit_id)}"${
-        asset.reservation_id ? ` reservation_id="${escapeXml(asset.reservation_id)}"` : ''
-      }>`,
-    );
-    lines.push(`      <root_asset>${escapeXml(asset.root_asset)}</root_asset>`);
-    lines.push(`      <quantity>${escapeXml(asset.quantity)}</quantity>`);
-    lines.push(`      <status>${escapeXml(asset.status)}</status>`);
-    lines.push(`      <control_path>${escapeXml(asset.control_path)}</control_path>`);
-    lines.push('    </asset>');
+
+  const mandateSummary = readString(input.executionContext.mandate_summary);
+  if (mandateSummary) {
+    lines.push(`  <mandate_summary>${escapeXml(mandateSummary)}</mandate_summary>`);
   }
-  lines.push('  </assets>');
-  lines.push('  <reservations>');
-  for (const reservation of input.onboardingState.reservations ?? []) {
+
+  if (isRecord(input.executionContext.mandate_context)) {
     lines.push(
-      `    <reservation reservation_id="${escapeXml(reservation.reservation_id)}" agent_id="${escapeXml(reservation.agent_id)}">`,
+      `  <mandate_context_json>${escapeXml(
+        JSON.stringify(input.executionContext.mandate_context),
+      )}</mandate_context_json>`,
     );
-    lines.push(`      <purpose>${escapeXml(reservation.purpose)}</purpose>`);
-    lines.push(`      <status>${escapeXml(reservation.status)}</status>`);
-    lines.push(`      <control_path>${escapeXml(reservation.control_path)}</control_path>`);
-    lines.push('      <allocations>');
-    for (const allocation of reservation.unit_allocations) {
-      lines.push(`        <allocation unit_id="${escapeXml(allocation.unit_id)}">`);
-      lines.push(
-        `          <asset>${escapeXml(unitsById.get(allocation.unit_id)?.root_asset ?? 'unknown')}</asset>`,
-      );
-      lines.push(`          <quantity>${escapeXml(allocation.quantity)}</quantity>`);
-      lines.push('        </allocation>');
+  }
+
+  const subagentWalletAddress = readHexAddress(input.executionContext.subagent_wallet_address);
+  if (subagentWalletAddress) {
+    lines.push(`  <subagent_wallet_address>${subagentWalletAddress}</subagent_wallet_address>`);
+  }
+
+  const rootUserWalletAddress = readHexAddress(input.executionContext.root_user_wallet_address);
+  if (rootUserWalletAddress) {
+    lines.push(
+      `  <root_user_wallet_address>${rootUserWalletAddress}</root_user_wallet_address>`,
+    );
+  }
+
+  lines.push(`  <network>${escapeXml(network)}</network>`);
+
+  if (Array.isArray(input.executionContext.owned_units) && input.executionContext.owned_units.length > 0) {
+    lines.push('  <owned_units>');
+    for (const ownedUnit of input.executionContext.owned_units) {
+      const unitId = readString(ownedUnit.unit_id);
+      lines.push(`    <owned_unit${unitId ? ` unit_id="${escapeXml(unitId)}"` : ''}>`);
+
+      const rootAsset = readString(ownedUnit.root_asset);
+      if (rootAsset) {
+        lines.push(`      <root_asset>${escapeXml(rootAsset)}</root_asset>`);
+      }
+
+      const amount = readString(ownedUnit.amount);
+      if (amount) {
+        lines.push(`      <amount>${escapeXml(amount)}</amount>`);
+      }
+
+      const benchmarkValueUsd = readString(ownedUnit.benchmark_value_usd);
+      if (benchmarkValueUsd) {
+        lines.push(`      <benchmark_value_usd>${escapeXml(benchmarkValueUsd)}</benchmark_value_usd>`);
+      }
+
+      lines.push('    </owned_unit>');
     }
-    lines.push('      </allocations>');
-    lines.push('    </reservation>');
+    lines.push('  </owned_units>');
   }
-  lines.push('  </reservations>');
-  lines.push('</shared_ember_accounting_context>');
+
+  if (
+    Array.isArray(input.executionContext.wallet_contents) &&
+    input.executionContext.wallet_contents.length > 0
+  ) {
+    lines.push('  <wallet_contents>');
+    for (const walletBalance of input.executionContext.wallet_contents) {
+      const asset = readString(walletBalance.asset);
+      lines.push(`    <wallet_balance${asset ? ` asset="${escapeXml(asset)}"` : ''}>`);
+
+      const amount = readString(walletBalance.amount);
+      if (amount) {
+        lines.push(`      <amount>${escapeXml(amount)}</amount>`);
+      }
+
+      const benchmarkValueUsd = readString(walletBalance.benchmark_value_usd);
+      if (benchmarkValueUsd) {
+        lines.push(`      <benchmark_value_usd>${escapeXml(benchmarkValueUsd)}</benchmark_value_usd>`);
+      }
+
+      lines.push('    </wallet_balance>');
+    }
+    lines.push('  </wallet_contents>');
+  }
+
+  lines.push('</ember_lending_execution_context>');
   return lines;
 }
 
@@ -635,8 +680,6 @@ export function createEmberLendingDomain(
   options: CreateEmberLendingDomainOptions = {},
 ): AgentRuntimeDomainConfig<EmberLendingLifecycleState> {
   const agentId = options.agentId ?? 'ember-lending';
-  const onboardingOwnerAgentId =
-    options.onboardingOwnerAgentId ?? EMBER_LENDING_ONBOARDING_OWNER_AGENT_ID;
 
   return {
     lifecycle: {
@@ -653,16 +696,13 @@ export function createEmberLendingDomain(
           description: 'Route managed-agent deactivation back to the portfolio manager.',
         },
         {
-          name: 'read_portfolio_state',
-          description: 'Read the current Shared Ember portfolio state for this managed lending lane.',
+          name: 'create_transaction_plan',
+          description: 'Create or refresh a candidate transaction plan for the managed lending lane.',
         },
         {
-          name: 'materialize_candidate_plan',
-          description: 'Ask Shared Ember to materialize a candidate transaction plan for the lending lane.',
-        },
-        {
-          name: 'execute_transaction_plan',
-          description: 'Execute the admitted lending transaction plan through the bounded Shared Ember surface.',
+          name: 'request_transaction_execution',
+          description:
+            'Request admission and execution for the current lending transaction plan through the bounded Shared Ember surface.',
         },
         {
           name: 'create_escalation_request',
@@ -672,104 +712,29 @@ export function createEmberLendingDomain(
       transitions: [],
       interrupts: [],
     },
-    systemContext: async ({ state }) => {
+    systemContext: async ({ state, threadId }) => {
       const currentState = state ?? buildDefaultLifecycleState();
-      const context = ['<ember_lending_context>'];
-
-      context.push(`  <lifecycle_phase>${currentState.phase}</lifecycle_phase>`);
-
-      if (currentState.mandateRef) {
-        context.push(`  <mandate_ref>${escapeXml(currentState.mandateRef)}</mandate_ref>`);
+      if (!options.protocolHost || !shouldReadSharedEmberExecutionContext(currentState)) {
+        return buildFallbackExecutionContextXml(currentState);
       }
 
-      if (currentState.mandateSummary) {
-        context.push(`  <mandate_summary>${escapeXml(currentState.mandateSummary)}</mandate_summary>`);
+      try {
+        const executionContext = await readSharedEmberExecutionContext({
+          protocolHost: options.protocolHost,
+          threadId,
+          agentId,
+        });
+        return buildSharedEmberExecutionContextXml({
+          status: 'live',
+          executionContext,
+        });
+      } catch (error) {
+        return buildSharedEmberExecutionContextXml({
+          status: 'unavailable',
+          state: currentState,
+          error: error instanceof Error ? error.message : 'Unknown Shared Ember error.',
+        });
       }
-
-      if (currentState.walletAddress) {
-        context.push(
-          `  <subagent_wallet_address>${currentState.walletAddress}</subagent_wallet_address>`,
-        );
-      }
-
-      if (currentState.rootUserWalletAddress) {
-        context.push(
-          `  <root_user_wallet_address>${currentState.rootUserWalletAddress}</root_user_wallet_address>`,
-        );
-      }
-
-      if (currentState.rootedWalletContextId) {
-        context.push(
-          `  <rooted_wallet_context_id>${escapeXml(currentState.rootedWalletContextId)}</rooted_wallet_context_id>`,
-        );
-      }
-
-      if (currentState.mandateContext) {
-        context.push(
-          `  <mandate_context_json>${escapeXml(
-            JSON.stringify(currentState.mandateContext),
-          )}</mandate_context_json>`,
-        );
-      }
-
-      if (currentState.lastReservationSummary) {
-        context.push(
-          `  <last_reservation_summary>${escapeXml(
-            currentState.lastReservationSummary,
-          )}</last_reservation_summary>`,
-        );
-      }
-
-      if (currentState.lastCandidatePlanSummary) {
-        context.push(
-          `  <last_candidate_plan_summary>${escapeXml(
-            currentState.lastCandidatePlanSummary,
-          )}</last_candidate_plan_summary>`,
-        );
-      }
-
-      if (currentState.lastExecutionTxHash) {
-        context.push(
-          `  <last_execution_tx_hash>${currentState.lastExecutionTxHash}</last_execution_tx_hash>`,
-        );
-      }
-
-      if (currentState.lastEscalationSummary) {
-        context.push(
-          `  <last_escalation_summary>${escapeXml(
-            currentState.lastEscalationSummary,
-          )}</last_escalation_summary>`,
-        );
-      }
-
-      context.push('</ember_lending_context>');
-
-      if (currentState.rootUserWalletAddress && options.protocolHost) {
-        try {
-          const { revision, onboardingState } = await readSharedEmberWalletAccountingState({
-            protocolHost: options.protocolHost,
-            ownerAgentId: onboardingOwnerAgentId,
-            walletAddress: currentState.rootUserWalletAddress,
-          });
-          context.push(
-            ...buildSharedEmberAccountingContextXml({
-              status: 'live',
-              revision,
-              onboardingState,
-            }),
-          );
-        } catch (error) {
-          context.push(
-            ...buildSharedEmberAccountingContextXml({
-              status: 'unavailable',
-              walletAddress: currentState.rootUserWalletAddress,
-              error: error instanceof Error ? error.message : 'Unknown Shared Ember error.',
-            }),
-          );
-        }
-      }
-
-      return context;
     },
     handleOperation: async ({ operation, state, threadId }) => {
       const currentState = state ?? buildDefaultLifecycleState();
@@ -799,15 +764,31 @@ export function createEmberLendingDomain(
 
           const portfolioState = response.result?.portfolio_state ?? null;
           const projection = mergePortfolioProjection(currentState, portfolioState);
+          const nextState: EmberLendingLifecycleState = {
+            ...currentState,
+            phase: hasManagedPortfolioProjection(portfolioState) ? 'active' : currentState.phase,
+            ...projection,
+            lastPortfolioState: portfolioState,
+            lastSharedEmberRevision: response.result?.revision ?? null,
+          };
+
           return {
-            state: {
-              ...currentState,
-              phase: hasManagedPortfolioProjection(portfolioState) ? 'active' : currentState.phase,
-              ...projection,
-              lastPortfolioState: portfolioState,
-              lastSharedEmberRevision: response.result?.revision ?? null,
+            state: nextState,
+            outputs: {
+              status: {
+                executionStatus: 'completed',
+                statusMessage: 'Lending runtime projection hydrated from Shared Ember Domain Service.',
+              },
+              artifacts: [
+                {
+                  data: {
+                    type: 'shared-ember-portfolio-state',
+                    revision: nextState.lastSharedEmberRevision,
+                    portfolioState,
+                  },
+                },
+              ],
             },
-            outputs: {},
           };
         }
         case 'hire':
@@ -830,63 +811,7 @@ export function createEmberLendingDomain(
               },
             },
           };
-        case 'read_portfolio_state': {
-          if (!options.protocolHost) {
-            return {
-              state: currentState,
-              outputs: {
-                status: {
-                  executionStatus: 'failed',
-                  statusMessage: 'Shared Ember Domain Service host is not configured.',
-                },
-              },
-            };
-          }
-
-          const response = (await options.protocolHost.handleJsonRpc({
-            jsonrpc: '2.0',
-            id: `shared-ember-${threadId}-read-portfolio-state`,
-            method: 'subagent.readPortfolioState.v1',
-            params: {
-              agent_id: agentId,
-            },
-          })) as {
-            result?: {
-              revision?: number;
-              portfolio_state?: unknown;
-            };
-          };
-
-          const portfolioState = response.result?.portfolio_state ?? null;
-          const projection = mergePortfolioProjection(currentState, portfolioState);
-          const nextState: EmberLendingLifecycleState = {
-            ...currentState,
-            phase: hasManagedPortfolioProjection(portfolioState) ? 'active' : currentState.phase,
-            ...projection,
-            lastPortfolioState: portfolioState,
-            lastSharedEmberRevision: response.result?.revision ?? null,
-          };
-
-          return {
-            state: nextState,
-            outputs: {
-              status: {
-                executionStatus: 'completed',
-                statusMessage: 'Lending portfolio state refreshed from Shared Ember Domain Service.',
-              },
-              artifacts: [
-                {
-                  data: {
-                    type: 'shared-ember-portfolio-state',
-                    revision: nextState.lastSharedEmberRevision,
-                    portfolioState,
-                  },
-                },
-              ],
-            },
-          };
-        }
-        case 'materialize_candidate_plan': {
+        case 'create_transaction_plan': {
           if (!options.protocolHost) {
             return {
               state: currentState,
@@ -912,7 +837,7 @@ export function createEmberLendingDomain(
                 status: {
                   executionStatus: 'failed',
                   statusMessage:
-                    'Lending runtime context is incomplete. Refresh portfolio state before planning.',
+                    'Lending runtime context is incomplete. Wait for execution-context hydration before planning.',
                 },
               },
             };
@@ -935,7 +860,7 @@ export function createEmberLendingDomain(
             buildRequest: (expectedRevision) => ({
               jsonrpc: '2.0',
               id: `shared-ember-${threadId}-materialize-candidate-plan`,
-              method: 'subagent.materializeCandidatePlan.v1',
+              method: 'subagent.createTransactionPlan.v1',
               params: {
                 idempotency_key: idempotencyKey,
                 expected_revision: expectedRevision,
@@ -973,7 +898,7 @@ export function createEmberLendingDomain(
             },
           };
         }
-        case 'execute_transaction_plan': {
+        case 'request_transaction_execution': {
           if (!options.protocolHost) {
             return {
               state: currentState,
@@ -1017,7 +942,7 @@ export function createEmberLendingDomain(
             buildRequest: (expectedRevision) => ({
               jsonrpc: '2.0',
               id: `shared-ember-${threadId}-execute-transaction-plan`,
-              method: 'subagent.executeTransactionPlan.v1',
+              method: 'subagent.requestTransactionExecution.v1',
               params: {
                 idempotency_key: idempotencyKey,
                 expected_revision: expectedRevision,
@@ -1085,7 +1010,7 @@ export function createEmberLendingDomain(
                 status: {
                   executionStatus: 'failed',
                   statusMessage:
-                    'Lending runtime context is incomplete. Refresh portfolio state before escalating.',
+                    'Lending runtime context is incomplete. Wait for execution-context hydration before escalating.',
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -694,7 +694,6 @@ function buildTransactionPlanningHandoff(input: {
     'action_summary',
     'candidate_unit_ids',
     'requested_quantities',
-    'payload_builder_output',
   ] as const) {
     if (key in commandInput) {
       handoff[key] = commandInput[key];
@@ -977,7 +976,7 @@ export function createEmberLendingDomain(
 
           const idempotencyKey =
             readStringKey(operation.input, 'idempotencyKey') ??
-            `idem-materialize-candidate-plan-${threadId}`;
+            `idem-create-transaction-plan-${threadId}`;
           const response = await runSharedEmberCommandWithResolvedRevision<{
             result?: {
               revision?: number;
@@ -991,7 +990,7 @@ export function createEmberLendingDomain(
             currentRevision: currentState.lastSharedEmberRevision,
             buildRequest: (expectedRevision) => ({
               jsonrpc: '2.0',
-              id: `shared-ember-${threadId}-materialize-candidate-plan`,
+              id: `shared-ember-${threadId}-create-transaction-plan`,
               method: 'subagent.createTransactionPlan.v1',
               params: {
                 idempotency_key: idempotencyKey,
@@ -1015,7 +1014,7 @@ export function createEmberLendingDomain(
             outputs: {
               status: {
                 executionStatus: 'completed',
-                statusMessage: 'Candidate lending plan materialized through Shared Ember.',
+                statusMessage: 'Candidate lending plan created through the Shared Ember planner.',
               },
               artifacts: [
                 {
@@ -1051,7 +1050,7 @@ export function createEmberLendingDomain(
                 status: {
                   executionStatus: 'failed',
                   statusMessage:
-                    'No lending transaction plan is available to execute. Materialize a candidate plan first.',
+                    'No lending transaction plan is available to execute. Create a candidate plan first.',
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -576,6 +576,44 @@ function readExecutionPortfolioState(executionResult: unknown): unknown {
   return isRecord(executionResult) ? executionResult['portfolio_state'] : null;
 }
 
+function readExecutionRequestResult(executionResult: unknown): Record<string, unknown> | null {
+  if (!isRecord(executionResult) || !isRecord(executionResult['request_result'])) {
+    return null;
+  }
+
+  return executionResult['request_result'];
+}
+
+function ensureSentence(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
+function readExecutionStatusMessage(executionResult: unknown): {
+  executionStatus: 'completed' | 'failed';
+  statusMessage: string;
+} {
+  const phase = isRecord(executionResult) ? readString(executionResult['phase']) : null;
+  if (phase !== 'blocked') {
+    return {
+      executionStatus: 'completed',
+      statusMessage: 'Lending transaction plan admitted and executed through Shared Ember.',
+    };
+  }
+
+  const requestResult = readExecutionRequestResult(executionResult);
+  const requestOutcome = readString(requestResult?.['result']);
+  const requestMessage = readString(requestResult?.['message']);
+  const prefix =
+    requestOutcome === 'denied'
+      ? 'Lending transaction execution request was denied by Shared Ember'
+      : 'Lending transaction execution request was blocked by Shared Ember';
+
+  return {
+    executionStatus: 'failed',
+    statusMessage: requestMessage ? `${prefix}: ${ensureSentence(requestMessage)}` : `${prefix}.`,
+  };
+}
+
 function readEscalationSummary(escalationRequest: unknown): string | null {
   if (!isRecord(escalationRequest)) {
     return null;
@@ -597,11 +635,10 @@ function readStringKey(
   return isRecord(input) ? readString(input[key]) : null;
 }
 
-function buildManagedSubagentHandoff(input: {
+function buildManagedSubagentHandoffBase(input: {
   state: EmberLendingLifecycleState;
   threadId: string;
   agentId: string;
-  operationInput: unknown;
 }): Record<string, unknown> | null {
   if (!input.state.walletAddress || !input.state.rootUserWalletAddress || !input.state.mandateRef) {
     return null;
@@ -611,41 +648,136 @@ function buildManagedSubagentHandoff(input: {
     return null;
   }
 
-  const commandInput = isRecord(input.operationInput) ? input.operationInput : {};
-  const explicitHandoff =
-    'handoff' in commandInput && isRecord(commandInput['handoff']) ? commandInput['handoff'] : null;
-  const source =
-    explicitHandoff ??
-    Object.fromEntries(
-      Object.entries(commandInput).filter(
-        ([key]) => key !== 'idempotencyKey' && key !== 'result' && key !== 'transactionPlanId',
-      ),
-    );
-
-  const decisionContext =
-    'decision_context' in source && isRecord(source['decision_context'])
-      ? {
-          ...source['decision_context'],
-        }
-      : {};
-  if (input.state.mandateSummary) {
-    decisionContext['mandate_summary'] = input.state.mandateSummary;
-  }
-
-  const handoff: Record<string, unknown> = {
-    ...source,
-    handoff_id: readString(source['handoff_id']) ?? `handoff-${input.threadId}`,
+  return {
     agent_id: input.agentId,
     agent_wallet: input.state.walletAddress,
     root_user_wallet: input.state.rootUserWalletAddress,
     mandate_ref: input.state.mandateRef,
   };
+}
 
-  if (Object.keys(decisionContext).length > 0) {
+function buildManagedSubagentDecisionContext(input: {
+  source: Record<string, unknown>;
+  mandateSummary: string | null;
+}): Record<string, unknown> | null {
+  const decisionContext =
+    'decision_context' in input.source && isRecord(input.source['decision_context'])
+      ? {
+          ...input.source['decision_context'],
+        }
+      : {};
+  if (input.mandateSummary) {
+    decisionContext['mandate_summary'] = input.mandateSummary;
+  }
+
+  return Object.keys(decisionContext).length > 0 ? decisionContext : null;
+}
+
+function buildTransactionPlanningHandoff(input: {
+  state: EmberLendingLifecycleState;
+  threadId: string;
+  agentId: string;
+  operationInput: unknown;
+}): Record<string, unknown> | null {
+  const base = buildManagedSubagentHandoffBase(input);
+  if (!base) {
+    return null;
+  }
+
+  const commandInput = isRecord(input.operationInput) ? input.operationInput : {};
+  const handoff: Record<string, unknown> = {
+    handoff_id: readString(commandInput['handoff_id']) ?? `handoff-${input.threadId}`,
+    ...base,
+  };
+  for (const key of [
+    'intent',
+    'action_summary',
+    'candidate_unit_ids',
+    'requested_quantities',
+    'payload_builder_output',
+  ] as const) {
+    if (key in commandInput) {
+      handoff[key] = commandInput[key];
+    }
+  }
+
+  const decisionContext = buildManagedSubagentDecisionContext({
+    source: commandInput,
+    mandateSummary: input.state.mandateSummary,
+  });
+  if (decisionContext) {
     handoff['decision_context'] = decisionContext;
   }
 
   return handoff;
+}
+
+function buildEscalationHandoff(input: {
+  state: EmberLendingLifecycleState;
+  threadId: string;
+  agentId: string;
+  operationInput: unknown;
+}): Record<string, unknown> | null {
+  const base = buildManagedSubagentHandoffBase(input);
+  if (!base) {
+    return null;
+  }
+
+  const commandInput = isRecord(input.operationInput) ? input.operationInput : {};
+  const source =
+    'handoff' in commandInput && isRecord(commandInput['handoff']) ? commandInput['handoff'] : commandInput;
+
+  const handoff: Record<string, unknown> = {
+    handoff_id: readString(source['handoff_id']) ?? `handoff-${input.threadId}`,
+    ...base,
+  };
+  for (const key of [
+    'intent',
+    'action_summary',
+    'candidate_unit_ids',
+    'requested_quantities',
+    'payload_builder_output',
+  ] as const) {
+    if (key in source) {
+      handoff[key] = source[key];
+    }
+  }
+
+  const decisionContext = buildManagedSubagentDecisionContext({
+    source,
+    mandateSummary: input.state.mandateSummary,
+  });
+  if (decisionContext) {
+    handoff['decision_context'] = decisionContext;
+  }
+
+  return handoff;
+}
+
+function mergePortfolioProjectionPreservingKnownContext(
+  state: EmberLendingLifecycleState,
+  portfolioState: unknown,
+): Pick<
+  EmberLendingLifecycleState,
+  | 'mandateRef'
+  | 'mandateSummary'
+  | 'mandateContext'
+  | 'walletAddress'
+  | 'rootUserWalletAddress'
+  | 'rootedWalletContextId'
+  | 'lastReservationSummary'
+> {
+  const projection = mergePortfolioProjection(state, portfolioState);
+
+  return {
+    mandateRef: projection.mandateRef ?? state.mandateRef,
+    mandateSummary: projection.mandateSummary ?? state.mandateSummary,
+    mandateContext: projection.mandateContext ?? state.mandateContext,
+    walletAddress: projection.walletAddress ?? state.walletAddress,
+    rootUserWalletAddress: projection.rootUserWalletAddress ?? state.rootUserWalletAddress,
+    rootedWalletContextId: projection.rootedWalletContextId ?? state.rootedWalletContextId,
+    lastReservationSummary: projection.lastReservationSummary ?? state.lastReservationSummary,
+  };
 }
 
 function readTransactionPlanId(
@@ -824,7 +956,7 @@ export function createEmberLendingDomain(
             };
           }
 
-          const handoff = buildManagedSubagentHandoff({
+          const handoff = buildTransactionPlanningHandoff({
             state: currentState,
             threadId,
             agentId,
@@ -953,7 +1085,11 @@ export function createEmberLendingDomain(
 
           const executionResult = response.result?.execution_result ?? null;
           const executionPortfolioState = readExecutionPortfolioState(executionResult);
-          const projection = mergePortfolioProjection(currentState, executionPortfolioState);
+          const projection = mergePortfolioProjectionPreservingKnownContext(
+            currentState,
+            executionPortfolioState,
+          );
+          const executionStatus = readExecutionStatusMessage(executionResult);
           const nextState: EmberLendingLifecycleState = {
             ...currentState,
             ...projection,
@@ -968,8 +1104,8 @@ export function createEmberLendingDomain(
             state: nextState,
             outputs: {
               status: {
-                executionStatus: 'completed',
-                statusMessage: 'Lending transaction plan executed through Shared Ember.',
+                executionStatus: executionStatus.executionStatus,
+                statusMessage: executionStatus.statusMessage,
               },
               artifacts: [
                 {
@@ -997,7 +1133,7 @@ export function createEmberLendingDomain(
             };
           }
 
-          const handoff = buildManagedSubagentHandoff({
+          const handoff = buildEscalationHandoff({
             state: currentState,
             threadId,
             agentId,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -832,7 +832,7 @@ describe('createEmberLendingDomain', () => {
       outputs: {
         status: {
           executionStatus: 'completed',
-          statusMessage: 'Candidate lending plan materialized through Shared Ember.',
+          statusMessage: 'Candidate lending plan created through the Shared Ember planner.',
         },
         artifacts: [
           {
@@ -850,7 +850,7 @@ describe('createEmberLendingDomain', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
-      id: 'shared-ember-thread-1-materialize-candidate-plan',
+      id: 'shared-ember-thread-1-create-transaction-plan',
       method: 'subagent.createTransactionPlan.v1',
       params: {
         idempotency_key: 'idem-candidate-plan-001',
@@ -879,11 +879,6 @@ describe('createEmberLendingDomain', () => {
             why_this_path_is_best: 'lending.supply is the admitted path for this reservation',
             consequence_if_delayed: 'reserved capital remains idle',
             alternatives_considered: ['leave the unit idle'],
-          },
-          payload_builder_output: {
-            transaction_payload_ref: 'tx-lending-supply-001',
-            required_control_path: 'lending.supply',
-            network: 'arbitrum',
           },
         },
       },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -172,6 +172,51 @@ function createExecutionContextResponse() {
   };
 }
 
+function createMandatedExecutionContextResponse() {
+  return {
+    jsonrpc: '2.0',
+    id: 'shared-ember-thread-1-read-execution-context',
+    result: {
+      protocol_version: 'v1',
+      revision: 10,
+      execution_context: {
+        generated_at: '2026-04-01T06:30:00.000Z',
+        network: 'arbitrum',
+        mandate_ref: 'mandate-ember-lending-001',
+        mandate_summary:
+          'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+        mandate_context: null,
+        subagent_wallet_address: null,
+        root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+        owned_units: [],
+        wallet_contents: [],
+      },
+    },
+  };
+}
+
+function createEmptyExecutionContextResponse() {
+  return {
+    jsonrpc: '2.0',
+    id: 'shared-ember-thread-1-read-execution-context',
+    result: {
+      protocol_version: 'v1',
+      revision: 9,
+      execution_context: {
+        generated_at: '2026-04-01T06:45:00.000Z',
+        network: 'arbitrum',
+        mandate_ref: null,
+        mandate_summary: null,
+        mandate_context: null,
+        subagent_wallet_address: null,
+        root_user_wallet_address: null,
+        owned_units: [],
+        wallet_contents: [],
+      },
+    },
+  };
+}
+
 function createEmptyPortfolioStateResponse() {
   return {
     jsonrpc: '2.0',
@@ -420,7 +465,7 @@ describe('createEmberLendingDomain', () => {
         walletAddress: '0x00000000000000000000000000000000000000b1',
         rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
         rootedWalletContextId: 'rwc-ember-lending-thread-001',
-        lastSharedEmberRevision: 7,
+        lastSharedEmberRevision: 11,
         lastReservationSummary:
           'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
       },
@@ -433,7 +478,7 @@ describe('createEmberLendingDomain', () => {
           {
             data: {
               type: 'shared-ember-portfolio-state',
-              revision: 7,
+              revision: 11,
             },
           },
         ],
@@ -444,6 +489,14 @@ describe('createEmberLendingDomain', () => {
       jsonrpc: '2.0',
       id: 'shared-ember-thread-1-hydrate-runtime-projection',
       method: 'subagent.readPortfolioState.v1',
+      params: {
+        agent_id: 'ember-lending',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-read-execution-context',
+      method: 'subagent.readExecutionContext.v1',
       params: {
         agent_id: 'ember-lending',
       },
@@ -596,7 +649,17 @@ describe('createEmberLendingDomain', () => {
 
   it('does not promote the thread to active when Shared Ember returns no managed-lane execution context', async () => {
     const protocolHost = {
-      handleJsonRpc: vi.fn(async () => createEmptyPortfolioStateResponse()),
+      handleJsonRpc: vi.fn(async (input: unknown) => {
+        const request = input as { method?: unknown };
+        if (request.method === 'subagent.readPortfolioState.v1') {
+          return createEmptyPortfolioStateResponse();
+        }
+        if (request.method === 'subagent.readExecutionContext.v1') {
+          return createEmptyExecutionContextResponse();
+        }
+
+        throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
+      }),
       readCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
         revision: 9,
@@ -649,6 +712,85 @@ describe('createEmberLendingDomain', () => {
           reservations: [],
         },
         lastSharedEmberRevision: 9,
+      },
+    });
+  });
+
+  it('promotes the thread to active from execution context when the managed portfolio is still empty', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (input: unknown) => {
+        const request = input as { method?: unknown };
+        if (request.method === 'subagent.readPortfolioState.v1') {
+          return createEmptyPortfolioStateResponse();
+        }
+        if (request.method === 'subagent.readExecutionContext.v1') {
+          return createMandatedExecutionContextResponse();
+        }
+
+        throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        phase: 'prehire',
+        mandateRef: null,
+        mandateSummary: null,
+        mandateContext: null,
+        walletAddress: null,
+        rootUserWalletAddress: null,
+        rootedWalletContextId: null,
+        lastPortfolioState: null,
+        lastSharedEmberRevision: null,
+        lastReservationSummary: null,
+        lastCandidatePlan: null,
+        lastCandidatePlanSummary: null,
+        lastExecutionResult: null,
+        lastExecutionTxHash: null,
+        lastEscalationRequest: null,
+        lastEscalationSummary: null,
+      },
+      operation: {
+        source: 'tool',
+        name: EMBER_LENDING_INTERNAL_HYDRATE_COMMAND,
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        mandateRef: 'mandate-ember-lending-001',
+        mandateSummary:
+          'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+        mandateContext: {
+          network: 'arbitrum',
+        },
+        walletAddress: null,
+        rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+        rootedWalletContextId: null,
+        lastPortfolioState: {
+          agent_id: 'ember-lending',
+          owned_units: [],
+          reservations: [],
+        },
+        lastSharedEmberRevision: 10,
+        lastReservationSummary: null,
       },
     });
   });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -212,6 +212,10 @@ function createCandidatePlanInput() {
       required_control_path: 'lending.supply',
       network: 'arbitrum',
     },
+    handoff: {
+      handoff_id: 'handoff-stale-input-should-not-leak',
+      raw_reasoning_trace: 'planner requests must not forward raw model reasoning',
+    },
   };
 }
 
@@ -240,10 +244,12 @@ function createEscalationRequestInput() {
         required_control_path: 'lending.supply',
         network: 'arbitrum',
       },
+      raw_reasoning_trace: 'escalation requests must not forward raw model reasoning',
     },
     result: {
       phase: 'blocked',
       transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-blocked-001',
       request_result: {
         result: 'needs_release_or_transfer',
         request_id: 'req-ember-lending-blocked-001',
@@ -257,6 +263,33 @@ function createEscalationRequestInput() {
         owned_units: [],
         reservations: [],
       },
+    },
+  };
+}
+
+function createBlockedExecutionResult(input: {
+  result: 'needs_release_or_transfer' | 'denied';
+  requestId: string;
+  message: string;
+  blockingReasonCode: string;
+  nextAction: 'escalate_to_control_plane' | 'stop';
+}) {
+  return {
+    phase: 'blocked',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: input.requestId,
+    request_result: {
+      result: input.result,
+      request_id: input.requestId,
+      message: input.message,
+      reservation_id: 'reservation-ember-lending-001',
+      blocking_reason_code: input.blockingReasonCode,
+      next_action: input.nextAction,
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      owned_units: [],
+      reservations: [],
     },
   };
 }
@@ -869,6 +902,7 @@ describe('createEmberLendingDomain', () => {
           execution_result: {
             phase: 'completed',
             transaction_plan_id: 'txplan-ember-lending-001',
+            request_id: 'req-ember-lending-execution-001',
             execution: {
               execution_id: 'exec-ember-lending-001',
               status: 'confirmed',
@@ -945,7 +979,7 @@ describe('createEmberLendingDomain', () => {
       outputs: {
         status: {
           executionStatus: 'completed',
-          statusMessage: 'Lending transaction plan executed through Shared Ember.',
+          statusMessage: 'Lending transaction plan admitted and executed through Shared Ember.',
         },
         artifacts: [
           {
@@ -969,6 +1003,185 @@ describe('createEmberLendingDomain', () => {
         idempotency_key: 'idem-execute-transaction-plan-thread-1',
         expected_revision: 7,
         transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+  });
+
+  it('surfaces blocked execution requests without claiming the transaction plan executed', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-execute-transaction-plan',
+        result: {
+          protocol_version: 'v1',
+          revision: 9,
+          committed_event_ids: ['evt-request-execution-blocked-1'],
+          execution_result: createBlockedExecutionResult({
+            result: 'needs_release_or_transfer',
+            requestId: 'req-ember-lending-blocked-001',
+            message: 'reserved capital is still claimed by another agent',
+            blockingReasonCode: 'reserved_for_other_agent',
+            nextAction: 'escalate_to_control_plane',
+          }),
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        mandateRef: 'mandate-ember-lending-001',
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+        lastSharedEmberRevision: 9,
+        lastExecutionTxHash: null,
+        lastReservationSummary:
+          'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
+        lastExecutionResult: {
+          phase: 'blocked',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-blocked-001',
+          request_result: {
+            result: 'needs_release_or_transfer',
+          },
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending transaction execution request was blocked by Shared Ember: reserved capital is still claimed by another agent.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-execution-result',
+              revision: 9,
+              executionResult: {
+                phase: 'blocked',
+                transaction_plan_id: 'txplan-ember-lending-001',
+                request_id: 'req-ember-lending-blocked-001',
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('surfaces denied execution requests with the denied admission reason', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-execute-transaction-plan',
+        result: {
+          protocol_version: 'v1',
+          revision: 9,
+          committed_event_ids: ['evt-request-execution-denied-1'],
+          execution_result: createBlockedExecutionResult({
+            result: 'denied',
+            requestId: 'req-ember-lending-denied-001',
+            message: 'risk policy denied the requested lending path',
+            blockingReasonCode: 'policy_denied',
+            nextAction: 'stop',
+          }),
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 9,
+        lastExecutionTxHash: null,
+        lastExecutionResult: {
+          phase: 'blocked',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-denied-001',
+          request_result: {
+            result: 'denied',
+          },
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending transaction execution request was denied by Shared Ember: risk policy denied the requested lending path.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-execution-result',
+              revision: 9,
+              executionResult: {
+                phase: 'blocked',
+                transaction_plan_id: 'txplan-ember-lending-001',
+                request_id: 'req-ember-lending-denied-001',
+              },
+            },
+          },
+        ],
       },
     });
   });
@@ -1040,10 +1253,12 @@ describe('createEmberLendingDomain', () => {
               required_control_path: 'lending.supply',
               network: 'arbitrum',
             },
+            raw_reasoning_trace: 'escalation requests must not forward raw model reasoning',
           },
           result: {
             phase: 'blocked',
             transaction_plan_id: 'txplan-ember-lending-001',
+            request_id: 'req-ember-lending-blocked-001',
             request_result: {
               result: 'needs_release_or_transfer',
               request_id: 'req-ember-lending-blocked-001',
@@ -1126,6 +1341,7 @@ describe('createEmberLendingDomain', () => {
         result: {
           phase: 'blocked',
           transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-blocked-001',
           request_result: {
             result: 'needs_release_or_transfer',
             request_id: 'req-ember-lending-blocked-001',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createEmberLendingDomain } from './sharedEmberAdapter.js';
+import {
+  createEmberLendingDomain,
+  EMBER_LENDING_INTERNAL_HYDRATE_COMMAND,
+} from './sharedEmberAdapter.js';
 
 function createManagedLifecycleState() {
   return {
@@ -125,66 +128,43 @@ function createLeanPortfolioStateResponse() {
   };
 }
 
-function createWalletAccountingResponse() {
+function createExecutionContextResponse() {
   return {
     jsonrpc: '2.0',
-    id: 'shared-ember-wallet-accounting-portfolio-manager-0x00000000000000000000000000000000000000a1',
+    id: 'shared-ember-thread-1-read-execution-context',
     result: {
       protocol_version: 'v1',
       revision: 11,
-      onboarding_state: {
-        wallet_address: '0x00000000000000000000000000000000000000a1',
+      execution_context: {
+        generated_at: '2026-04-01T06:00:00.000Z',
         network: 'arbitrum',
-        phase: 'active',
-        proofs: {
-          rooted_wallet_context_registered: true,
-          root_delegation_registered: true,
-          root_authority_active: true,
-          wallet_baseline_observed: true,
-          accounting_units_seeded: true,
-          mandate_inputs_configured: true,
-          reserve_policy_configured: true,
-          capital_reserved_for_agent: true,
-          policy_snapshot_recorded: true,
-          agent_active: true,
+        mandate_ref: 'mandate-ember-lending-001',
+        mandate_summary:
+          'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+        mandate_context: {
+          network: 'arbitrum',
+          protocol: 'aave',
+          allowedCollateralAssets: ['USDC'],
+          allowedBorrowAssets: ['USDC'],
+          maxAllocationPct: 35,
+          maxLtvBps: 7000,
+          minHealthFactor: '1.25',
         },
-        rooted_wallet_context: {
-          rooted_wallet_context_id: 'rwc-ember-lending-thread-001',
-        },
-        root_delegation: {
-          root_delegation_id: 'root-delegation-001',
-        },
+        subagent_wallet_address: '0x00000000000000000000000000000000000000b1',
+        root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
         owned_units: [
           {
             unit_id: 'unit-unreserved-001',
             root_asset: 'USDC',
-            quantity: '90',
-            status: 'available',
-            control_path: 'unassigned',
-            reservation_id: null,
-          },
-          {
-            unit_id: 'unit-ember-lending-001',
-            root_asset: 'USDC',
-            quantity: '10',
-            status: 'reserved',
-            control_path: 'lending.supply',
-            reservation_id: 'reservation-ember-lending-001',
+            amount: '90',
+            benchmark_value_usd: '90.00',
           },
         ],
-        reservations: [
+        wallet_contents: [
           {
-            reservation_id: 'reservation-ember-lending-001',
-            agent_id: 'ember-lending',
-            purpose: 'deploy',
-            status: 'active',
-            control_path: 'lending.supply',
-            unit_allocations: [
-              {
-                unit_id: 'unit-ember-lending-001',
-                quantity: '10',
-              },
-            ],
+            asset: 'USDC',
+            amount: '100',
+            benchmark_value_usd: '100.00',
           },
         ],
       },
@@ -282,6 +262,20 @@ function createEscalationRequestInput() {
 }
 
 describe('createEmberLendingDomain', () => {
+  it('exposes only the three model-visible lending tools plus managed lifecycle controls', () => {
+    const domain = createEmberLendingDomain({
+      agentId: 'ember-lending',
+    });
+
+    expect(domain.lifecycle.commands.map((command) => command.name)).toEqual([
+      'hire',
+      'fire',
+      'create_transaction_plan',
+      'request_transaction_execution',
+      'create_escalation_request',
+    ]);
+  });
+
   it('does not allow direct hire onboarding from the lending agent runtime', async () => {
     const domain = createEmberLendingDomain({
       agentId: 'ember-lending',
@@ -327,9 +321,20 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
-  it('reads portfolio state from Shared Ember and projects mandate, wallet, and reservation context', async () => {
+  it('hydrates runtime projection from Shared Ember and projects mandate, wallet, and reservation context', async () => {
     const protocolHost = {
-      handleJsonRpc: vi.fn(async () => createPortfolioStateResponse()),
+      handleJsonRpc: vi.fn(async (input: unknown) => {
+        const request = input as { method?: unknown };
+        if (request.method === 'subagent.readPortfolioState.v1') {
+          return createPortfolioStateResponse();
+        }
+
+        if (request.method === 'subagent.readExecutionContext.v1') {
+          return createExecutionContextResponse();
+        }
+
+        throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
+      }),
       readCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
         revision: 7,
@@ -369,7 +374,7 @@ describe('createEmberLendingDomain', () => {
       },
       operation: {
         source: 'tool',
-        name: 'read_portfolio_state',
+        name: EMBER_LENDING_INTERNAL_HYDRATE_COMMAND,
       },
     });
 
@@ -389,7 +394,7 @@ describe('createEmberLendingDomain', () => {
       outputs: {
         status: {
           executionStatus: 'completed',
-          statusMessage: 'Lending portfolio state refreshed from Shared Ember Domain Service.',
+          statusMessage: 'Lending runtime projection hydrated from Shared Ember Domain Service.',
         },
         artifacts: [
           {
@@ -404,7 +409,7 @@ describe('createEmberLendingDomain', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
-      id: 'shared-ember-thread-1-read-portfolio-state',
+      id: 'shared-ember-thread-1-hydrate-runtime-projection',
       method: 'subagent.readPortfolioState.v1',
       params: {
         agent_id: 'ember-lending',
@@ -418,16 +423,24 @@ describe('createEmberLendingDomain', () => {
 
     expect(context).toEqual(
       expect.arrayContaining([
-        '  <lifecycle_phase>active</lifecycle_phase>',
+        '<ember_lending_execution_context freshness="live">',
+        '  <generated_at>2026-04-01T06:00:00.000Z</generated_at>',
         '  <mandate_ref>mandate-ember-lending-001</mandate_ref>',
+        '  <mandate_summary>lend USDC on Aave within medium-risk allocation and health-factor guardrails</mandate_summary>',
         '  <subagent_wallet_address>0x00000000000000000000000000000000000000b1</subagent_wallet_address>',
         '  <root_user_wallet_address>0x00000000000000000000000000000000000000a1</root_user_wallet_address>',
-        '  <rooted_wallet_context_id>rwc-ember-lending-thread-001</rooted_wallet_context_id>',
+        '  <network>arbitrum</network>',
+        '      <benchmark_value_usd>90.00</benchmark_value_usd>',
+        '      <benchmark_value_usd>100.00</benchmark_value_usd>',
       ]),
+    );
+    expect(context).not.toContain('  <lifecycle_phase>active</lifecycle_phase>');
+    expect(context).not.toContain(
+      '  <rooted_wallet_context_id>rwc-ember-lending-thread-001</rooted_wallet_context_id>',
     );
   });
 
-  it('keeps wallet identity unset for lean portfolio-state payloads that omit authoritative handoff fields', async () => {
+  it('keeps wallet identity unset for lean execution-context payloads that omit authoritative handoff fields', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => createLeanPortfolioStateResponse()),
       readCommittedEventOutbox: vi.fn(async () => ({
@@ -469,7 +482,7 @@ describe('createEmberLendingDomain', () => {
       },
       operation: {
         source: 'tool',
-        name: 'read_portfolio_state',
+        name: EMBER_LENDING_INTERNAL_HYDRATE_COMMAND,
       },
     });
 
@@ -492,12 +505,12 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
-  it('injects broader wallet accounting context into system context for escalation decisions', async () => {
+  it('injects minimal execution context into system context with benchmark-aware wallet data', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async (input: unknown) => {
         const request = input as { method?: unknown };
-        if (request.method === 'orchestrator.readOnboardingState.v1') {
-          return createWalletAccountingResponse();
+        if (request.method === 'subagent.readExecutionContext.v1') {
+          return createExecutionContextResponse();
         }
 
         throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
@@ -526,26 +539,29 @@ describe('createEmberLendingDomain', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
-      id: 'shared-ember-wallet-accounting-portfolio-manager-0x00000000000000000000000000000000000000a1',
-      method: 'orchestrator.readOnboardingState.v1',
+      id: 'shared-ember-thread-1-read-execution-context',
+      method: 'subagent.readExecutionContext.v1',
       params: {
-        agent_id: 'portfolio-manager',
-        wallet_address: '0x00000000000000000000000000000000000000a1',
-        network: 'arbitrum',
+        agent_id: 'ember-lending',
       },
     });
 
     expect(context).toEqual(
       expect.arrayContaining([
-        '<shared_ember_accounting_context freshness="live">',
-        '  <wallet_address>0x00000000000000000000000000000000000000a1</wallet_address>',
+        '<ember_lending_execution_context freshness="live">',
+        '  <generated_at>2026-04-01T06:00:00.000Z</generated_at>',
         '  <network>arbitrum</network>',
-        '    <reservation reservation_id="reservation-ember-lending-001" agent_id="ember-lending">',
+        '  <subagent_wallet_address>0x00000000000000000000000000000000000000b1</subagent_wallet_address>',
+        '  <root_user_wallet_address>0x00000000000000000000000000000000000000a1</root_user_wallet_address>',
+        '      <benchmark_value_usd>100.00</benchmark_value_usd>',
       ]),
     );
+    expect(context?.join('\n')).not.toContain('shared_ember_accounting_context');
+    expect(context?.join('\n')).not.toContain('<proofs>');
+    expect(context?.join('\n')).not.toContain('<reservations>');
   });
 
-  it('does not promote the thread to active when Shared Ember returns no managed-lane projection', async () => {
+  it('does not promote the thread to active when Shared Ember returns no managed-lane execution context', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => createEmptyPortfolioStateResponse()),
       readCommittedEventOutbox: vi.fn(async () => ({
@@ -587,7 +603,7 @@ describe('createEmberLendingDomain', () => {
       },
       operation: {
         source: 'tool',
-        name: 'read_portfolio_state',
+        name: EMBER_LENDING_INTERNAL_HYDRATE_COMMAND,
       },
     });
 
@@ -608,7 +624,7 @@ describe('createEmberLendingDomain', () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async (input: unknown) => {
         const request = input as { method?: string };
-        if (request.method === 'subagent.materializeCandidatePlan.v1') {
+        if (request.method === 'subagent.createTransactionPlan.v1') {
           return {
             jsonrpc: '2.0',
             id: 'shared-ember-thread-1-materialize-candidate-plan',
@@ -688,7 +704,7 @@ describe('createEmberLendingDomain', () => {
       },
       operation: {
         source: 'tool',
-        name: 'materialize_candidate_plan',
+        name: 'create_transaction_plan',
         input: createCandidatePlanInput(),
       },
     });
@@ -706,7 +722,7 @@ describe('createEmberLendingDomain', () => {
         status: {
           executionStatus: 'failed',
           statusMessage:
-            'Lending runtime context is incomplete. Refresh portfolio state before planning.',
+            'Lending runtime context is incomplete. Wait for execution-context hydration before planning.',
         },
       },
     });
@@ -718,7 +734,7 @@ describe('createEmberLendingDomain', () => {
     );
     expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'subagent.materializeCandidatePlan.v1',
+        method: 'subagent.createTransactionPlan.v1',
       }),
     );
   });
@@ -769,7 +785,7 @@ describe('createEmberLendingDomain', () => {
       state: createManagedLifecycleState(),
       operation: {
         source: 'tool',
-        name: 'materialize_candidate_plan',
+        name: 'create_transaction_plan',
         input: createCandidatePlanInput(),
       },
     });
@@ -802,7 +818,7 @@ describe('createEmberLendingDomain', () => {
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
       id: 'shared-ember-thread-1-materialize-candidate-plan',
-      method: 'subagent.materializeCandidatePlan.v1',
+      method: 'subagent.createTransactionPlan.v1',
       params: {
         idempotency_key: 'idem-candidate-plan-001',
         expected_revision: 7,
@@ -913,7 +929,7 @@ describe('createEmberLendingDomain', () => {
       },
       operation: {
         source: 'tool',
-        name: 'execute_transaction_plan',
+        name: 'request_transaction_execution',
       },
     });
 
@@ -948,7 +964,7 @@ describe('createEmberLendingDomain', () => {
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
       id: 'shared-ember-thread-1-execute-transaction-plan',
-      method: 'subagent.executeTransactionPlan.v1',
+      method: 'subagent.requestTransactionExecution.v1',
       params: {
         idempotency_key: 'idem-execute-transaction-plan-thread-1',
         expected_revision: 7,
@@ -1222,7 +1238,7 @@ describe('createEmberLendingDomain', () => {
         status: {
           executionStatus: 'failed',
           statusMessage:
-            'Lending runtime context is incomplete. Refresh portfolio state before escalating.',
+            'Lending runtime context is incomplete. Wait for execution-context hydration before escalating.',
         },
       },
     });
@@ -1270,7 +1286,7 @@ describe('createEmberLendingDomain', () => {
       },
       operation: {
         source: 'tool',
-        name: 'materialize_candidate_plan',
+        name: 'create_transaction_plan',
         input: createCandidatePlanInput(),
       },
     });
@@ -1280,14 +1296,14 @@ describe('createEmberLendingDomain', () => {
         status: {
           executionStatus: 'failed',
           statusMessage:
-            'Lending runtime context is incomplete. Refresh portfolio state before planning.',
+            'Lending runtime context is incomplete. Wait for execution-context hydration before planning.',
         },
       },
     });
 
     expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'subagent.materializeCandidatePlan.v1',
+        method: 'subagent.createTransactionPlan.v1',
       }),
     );
   });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
@@ -5,6 +5,21 @@ implementation for the first Shared Ember Domain Service integration slice.
 
 This package is expected to remain a thin `agent-runtime` consumer.
 
+## Managed onboarding semantics
+
+For the current Portfolio Manager -> Ember Lending pair, this app owns:
+
+- user-facing mandate approval
+- rooted-delegation signing handoff
+- submission of the minimal onboarding activation contract to Shared Ember
+
+Shared Ember remains the durable owner of wallet observation, accounting-unit
+ingestion, reservation truth, and managed-lane materialization. The current
+bootstrap path targets the managed lending mandate during onboarding
+completion, so Shared Ember creates the initial `ember-lending` lane during
+rooted bootstrap instead of reserving that capital under the portfolio-manager
+agent id.
+
 ## Shared Ember sidecar testing
 
 This package does not vendor or commit private `ember-orchestration-v1-spec`

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -467,7 +467,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
               }),
             ]),
             activation: {
-              agentId: 'portfolio-manager',
+              agentId: 'ember-lending',
               purpose: 'deploy',
               controlPath: 'unassigned',
             },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -466,12 +466,11 @@ describe('agent-portfolio-manager AG-UI integration', () => {
                 agent_id: 'ember-lending',
               }),
             ]),
-            reservations: expect.arrayContaining([
-              expect.objectContaining({
-                agent_id: 'ember-lending',
-                control_path: 'lending.supply',
-              }),
-            ]),
+            activation: {
+              agentId: 'portfolio-manager',
+              purpose: 'deploy',
+              controlPath: 'unassigned',
+            },
           }),
           handoff: expect.objectContaining({
             user_wallet: '0x00000000000000000000000000000000000000a1',
@@ -480,6 +479,23 @@ describe('agent-portfolio-manager AG-UI integration', () => {
         }),
       }),
     );
+
+    const rootedBootstrapRequest = protocolHost.handleJsonRpc.mock.calls.find(
+      ([request]) =>
+        typeof request === 'object' &&
+        request !== null &&
+        'method' in request &&
+        request.method === 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+    )?.[0] as {
+      params?: {
+        onboarding?: Record<string, unknown>;
+      };
+    };
+
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('capitalObservation');
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('ownedUnits');
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('reservations');
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('policySnapshots');
   });
 
   it('clears wallet-local onboarding state when delegation signing is rejected', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -127,7 +127,7 @@ function createOnboardingBootstrap() {
     ],
     userReservePolicies: [],
     activation: {
-      agentId: 'portfolio-manager',
+      agentId: 'ember-lending',
       purpose: 'deploy',
       controlPath: 'unassigned',
     },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -14,6 +14,10 @@ type StartedSharedEmberTarget = {
 
 const runSharedEmberIntegration = process.env['RUN_SHARED_EMBER_INT']?.trim() === '1';
 const describeSharedEmberIntegration = runSharedEmberIntegration ? describe : describe.skip;
+const TEST_SIGNING_INTERRUPT_WALLET = '0x00000000000000000000000000000000000000a1' as const;
+const TEST_USER_WALLET = '0x00000000000000000000000000000000000000b1' as const;
+const TEST_ORCHESTRATOR_WALLET = '0x00000000000000000000000000000000000000b2' as const;
+const TEST_DELEGATION_MANAGER = '0x00000000000000000000000000000000000000b3' as const;
 
 async function resolveSharedEmberTarget(): Promise<StartedSharedEmberTarget> {
   const explicitBaseUrl = process.env['SHARED_EMBER_BASE_URL']?.trim();
@@ -51,16 +55,53 @@ function createRootDelegationHandoff(suffix: string) {
     handoff_id: `handoff-root-portfolio-int-${suffix}`,
     root_delegation_id: `root-user-portfolio-int-${suffix}`,
     user_id: 'user_idle',
-    user_wallet: '0xUSERPROTO1',
-    orchestrator_wallet: '0xORCHPORTFOLIO1',
+    user_wallet: TEST_USER_WALLET,
+    orchestrator_wallet: TEST_ORCHESTRATOR_WALLET,
     network: 'base',
     artifact_ref: `artifact-root-portfolio-int-${suffix}`,
     issued_at: '2026-03-29T00:00:00Z',
     activated_at: '2026-03-29T00:00:05Z',
     signer_kind: 'delegation_toolkit',
     metadata: {
-      delegation_manager: '0xDELEGATIONMANAGERPORTFOLIO1',
+      delegation_manager: TEST_DELEGATION_MANAGER,
     },
+  };
+}
+
+function createPortfolioManagerSetupInput(walletAddress: `0x${string}`) {
+  return {
+    walletAddress,
+    portfolioMandate: {
+      approved: true,
+      riskLevel: 'medium' as const,
+    },
+    managedAgentMandates: [
+      {
+        agentKey: 'ember-lending-primary',
+        agentType: 'ember-lending' as const,
+        approved: true,
+        settings: {
+          network: 'arbitrum' as const,
+          protocol: 'aave' as const,
+          allowedCollateralAssets: ['USDC'],
+          allowedBorrowAssets: ['USDC'],
+          maxAllocationPct: 35,
+          maxLtvBps: 7000,
+          minHealthFactor: '1.25',
+        },
+      },
+    ],
+  };
+}
+
+function createSignedDelegation(walletAddress: `0x${string}`) {
+  return {
+    delegate: '0x2222222222222222222222222222222222222222' as const,
+    delegator: walletAddress,
+    authority: '0x0000000000000000000000000000000000000000000000000000000000000000' as const,
+    caveats: [],
+    salt: '0x1111111111111111111111111111111111111111111111111111111111111111' as const,
+    signature: '0x1234' as const,
   };
 }
 
@@ -70,7 +111,7 @@ function createOnboardingBootstrap() {
     rootedWalletContext: {
       rooted_wallet_context_id: 'rwc-user-protocol-001',
       user_id: 'user_idle',
-      wallet_address: '0xUSERPROTO1',
+      wallet_address: TEST_USER_WALLET,
       network: 'base',
       registered_at: '2026-03-29T00:00:00Z',
       metadata: {
@@ -360,6 +401,137 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
               control_paths: ['unassigned'],
             }),
           ],
+        },
+      },
+    });
+  });
+
+  it('completes rooted bootstrap from the signing interrupt through the real Shared Ember HTTP boundary', async () => {
+    const protocolHost = createPortfolioManagerSharedEmberHttpHost({
+      baseUrl: target.baseUrl,
+    });
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+    });
+
+    const suffix = Date.now().toString(16);
+    const walletAddress = TEST_SIGNING_INTERRUPT_WALLET;
+    const threadId = `thread-rooted-bootstrap-signing-int-${suffix}`;
+    const setupInput = createPortfolioManagerSetupInput(walletAddress);
+
+    const setupResult = await domain.handleOperation?.({
+      threadId,
+      state: {
+        phase: 'prehire',
+        lastPortfolioState: null,
+        lastSharedEmberRevision: null,
+        lastRootDelegation: null,
+        lastOnboardingBootstrap: null,
+        lastRootedWalletContextId: null,
+        activeWalletAddress: null,
+        pendingOnboardingWalletAddress: null,
+      },
+      operation: {
+        source: 'interrupt',
+        name: 'portfolio-manager-setup-request',
+        input: setupInput,
+      },
+    });
+
+    expect(setupResult).toMatchObject({
+      state: {
+        phase: 'onboarding',
+        activeWalletAddress: walletAddress,
+        pendingOnboardingWalletAddress: walletAddress,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'interrupted',
+          statusMessage: 'Review and sign the delegation needed to activate your portfolio manager.',
+        },
+        interrupt: {
+          type: 'portfolio-manager-delegation-signing-request',
+        },
+      },
+    });
+
+    const signingResult = await domain.handleOperation?.({
+      threadId,
+      state: setupResult?.state,
+      operation: {
+        source: 'interrupt',
+        name: 'portfolio-manager-delegation-signing-request',
+        input: {
+          outcome: 'signed',
+          signedDelegations: [createSignedDelegation(walletAddress)],
+        },
+      },
+    });
+
+    expect(signingResult).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: expect.any(Number),
+        lastRootDelegation: {
+          user_wallet: walletAddress,
+          status: 'active',
+        },
+        lastRootedWalletContextId: expect.any(String),
+        activeWalletAddress: walletAddress,
+        pendingOnboardingWalletAddress: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'working',
+          statusMessage: 'Portfolio manager onboarding complete. Agent is active.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-rooted-bootstrap',
+              rootedWalletContextId: expect.any(String),
+              rootDelegation: {
+                user_wallet: walletAddress,
+                status: 'active',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      protocolHost.handleJsonRpc({
+        jsonrpc: '2.0',
+        id: `rpc-shared-ember-int-read-onboarding-signing-${suffix}`,
+        method: 'orchestrator.readOnboardingState.v1',
+        params: {
+          agent_id: 'portfolio-manager',
+          wallet_address: walletAddress,
+          network: 'arbitrum',
+        },
+      }),
+    ).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      id: `rpc-shared-ember-int-read-onboarding-signing-${suffix}`,
+      result: {
+        protocol_version: 'v1',
+        onboarding_state: {
+          phase: 'active',
+          rooted_wallet_context: {
+            rooted_wallet_context_id: expect.any(String),
+          },
+          reservations: expect.arrayContaining([
+            expect.objectContaining({
+              control_path: 'unassigned',
+            }),
+          ]),
+          policy_snapshots: expect.arrayContaining([
+            expect.objectContaining({
+              control_paths: ['unassigned'],
+            }),
+          ]),
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -522,6 +522,9 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
   const rootedWalletContextId = `rwc-${identity}`;
   const portfolioMandateRef = `mandate-portfolio-${identity}`;
   const firstManagedAgentMandate = params.approvedMandateEnvelope.managedAgentMandates[0];
+  if (!firstManagedAgentMandate) {
+    throw new Error('portfolio manager onboarding requires at least one managed agent mandate');
+  }
   const managedAgentKeySegment = sanitizeIdentitySegment(firstManagedAgentMandate.agentKey);
   const managedAgentMandateRef = `mandate-${managedAgentKeySegment}-${identity}`;
 
@@ -554,7 +557,7 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
     ],
     userReservePolicies: [],
     activation: {
-      agentId: params.agentId,
+      agentId: firstManagedAgentMandate.agentType,
       purpose: PORTFOLIO_MANAGER_ACTIVATION_PURPOSE,
       controlPath: PORTFOLIO_MANAGER_CONTROL_PATH,
     },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -158,11 +158,11 @@ const PORTFOLIO_MANAGER_DELEGATION_SALT =
 const PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP = '2026-03-30T00:00:00.000Z';
 const PORTFOLIO_MANAGER_PROTOCOL_SOURCE = 'onboarding_scan';
 const PORTFOLIO_MANAGER_DEFAULT_RISK_LEVEL = 'medium';
+const PORTFOLIO_MANAGER_ACTIVATION_PURPOSE = 'deploy';
+const PORTFOLIO_MANAGER_CONTROL_PATH = 'unassigned';
 const FIRST_MANAGED_AGENT_TYPE = 'ember-lending';
 const FIRST_MANAGED_AGENT_PROTOCOL = 'aave';
 const FIRST_MANAGED_AGENT_ROOT_ASSET = 'USDC';
-const FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY = '10';
-const FIRST_MANAGED_AGENT_CONTROL_PATH = 'lending.supply';
 
 type PortfolioManagerPortfolioMandate = {
   approved: true;
@@ -520,15 +520,10 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
   const identity = sanitizeIdentitySegment(`${params.threadId}-${params.walletAddress}`);
   const userId = `user-${identity}`;
   const rootedWalletContextId = `rwc-${identity}`;
-  const valuationRef = `valuation-${identity}`;
-  const capitalObservationId = `observation-${identity}`;
   const portfolioMandateRef = `mandate-portfolio-${identity}`;
   const firstManagedAgentMandate = params.approvedMandateEnvelope.managedAgentMandates[0];
   const managedAgentKeySegment = sanitizeIdentitySegment(firstManagedAgentMandate.agentKey);
   const managedAgentMandateRef = `mandate-${managedAgentKeySegment}-${identity}`;
-  const seededUnitId = `unit-${managedAgentKeySegment}-${identity}`;
-  const seededReservationId = `reservation-${managedAgentKeySegment}-${identity}`;
-  const seededPolicySnapshotRef = `policy-${managedAgentKeySegment}-${identity}`;
 
   return {
     occurredAt: PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP,
@@ -557,83 +552,12 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
         mandate_summary: buildManagedAgentMandateSummary(firstManagedAgentMandate),
       },
     ],
-    capitalObservation: {
-      observation_id: capitalObservationId,
-      kind: 'onboarding_scan',
-      wallet_address: params.walletAddress,
-      network: PORTFOLIO_MANAGER_NETWORK,
-      observed_at: PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP,
-      benchmark_asset: 'USD',
-      valuation_ref: valuationRef,
-      asset_deltas: [
-        {
-          root_asset: FIRST_MANAGED_AGENT_ROOT_ASSET,
-          quantity_delta: FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY,
-        },
-      ],
-      affected_unit_ids: [seededUnitId],
-    },
     userReservePolicies: [],
-    ownedUnits: [
-      {
-        unit_id: seededUnitId,
-        root_asset: FIRST_MANAGED_AGENT_ROOT_ASSET,
-        network: PORTFOLIO_MANAGER_NETWORK,
-        wallet_address: params.walletAddress,
-        quantity: FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY,
-        owner_type: 'user_idle',
-        owner_id: userId,
-        status: 'reserved',
-        reservation_id: seededReservationId,
-        delegation_id: null,
-        control_path: 'unassigned',
-        position_kind: 'spot',
-        benchmark_asset: 'USD',
-        benchmark_value: FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY,
-        valuation_ref: valuationRef,
-        cost_basis: FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY,
-        opened_at: PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP,
-        closed_at: null,
-        parent_unit_ids: [],
-        metadata: {
-          source: PORTFOLIO_MANAGER_PROTOCOL_SOURCE,
-        },
-      },
-    ],
-    reservations: [
-      {
-        reservation_id: seededReservationId,
-        agent_id: FIRST_MANAGED_AGENT_TYPE,
-        owner_id: userId,
-        purpose: 'deploy',
-        control_path: FIRST_MANAGED_AGENT_CONTROL_PATH,
-        unit_allocations: [
-          {
-            unit_id: seededUnitId,
-            quantity: FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY,
-          },
-        ],
-        status: 'active',
-        created_at: PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP,
-        released_at: null,
-        superseded_by: null,
-      },
-    ],
-    policySnapshots: [
-      {
-        policy_snapshot_ref: seededPolicySnapshotRef,
-        agent_id: FIRST_MANAGED_AGENT_TYPE,
-        network: PORTFOLIO_MANAGER_NETWORK,
-        control_paths: [FIRST_MANAGED_AGENT_CONTROL_PATH],
-        unit_bounds: [
-          {
-            unit_id: seededUnitId,
-            quantity: FIRST_MANAGED_AGENT_ALLOCATION_QUANTITY,
-          },
-        ],
-        created_at: PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP,
-      },
-    ],
+    activation: {
+      agentId: params.agentId,
+      purpose: PORTFOLIO_MANAGER_ACTIVATION_PURPOSE,
+      controlPath: PORTFOLIO_MANAGER_CONTROL_PATH,
+    },
   };
 }
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -6,17 +6,17 @@ function createPortfolioManagerSetupInput() {
   return {
     walletAddress: '0x00000000000000000000000000000000000000a1' as const,
     portfolioMandate: {
-      approved: true,
+      approved: true as const,
       riskLevel: 'medium' as const,
     },
     managedAgentMandates: [
       {
         agentKey: 'ember-lending-primary',
-        agentType: 'ember-lending',
-        approved: true,
+        agentType: 'ember-lending' as const,
+        approved: true as const,
         settings: {
-          network: 'arbitrum',
-          protocol: 'aave',
+          network: 'arbitrum' as const,
+          protocol: 'aave' as const,
           allowedCollateralAssets: ['USDC'],
           allowedBorrowAssets: ['USDC'],
           maxAllocationPct: 35,
@@ -77,7 +77,7 @@ function createOnboardingBootstrap() {
     ],
     userReservePolicies: [],
     activation: {
-      agentId: 'portfolio-manager',
+      agentId: 'ember-lending',
       purpose: 'deploy',
       controlPath: 'unassigned',
     },
@@ -334,7 +334,7 @@ describe('createPortfolioManagerDomain', () => {
               },
             ],
             activation: {
-              agentId: 'portfolio-manager',
+              agentId: 'ember-lending',
               purpose: 'deploy',
               controlPath: 'unassigned',
             },
@@ -348,7 +348,15 @@ describe('createPortfolioManagerDomain', () => {
       }),
     );
 
-    const rootedBootstrapRequest = protocolHost.handleJsonRpc.mock.calls[0]?.[0] as {
+    const rootedBootstrapCall = (protocolHost.handleJsonRpc.mock.calls as unknown as Array<
+      [unknown]
+    >)[0];
+    expect(rootedBootstrapCall).toBeDefined();
+    if (!rootedBootstrapCall) {
+      throw new Error('expected rooted bootstrap Shared Ember request');
+    }
+
+    const rootedBootstrapRequest = rootedBootstrapCall[0] as {
       params?: {
         onboarding?: Record<string, unknown>;
       };

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -75,83 +75,12 @@ function createOnboardingBootstrap() {
         mandate_summary: 'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
       },
     ],
-    capitalObservation: {
-      observation_id: 'observation-portfolio-protocol-001',
-      kind: 'onboarding_scan',
-      wallet_address: '0xUSERPROTO1',
-      network: 'base',
-      observed_at: '2026-03-29T00:00:00Z',
-      benchmark_asset: 'USD',
-      valuation_ref: 'valuation-portfolio-protocol-001',
-      asset_deltas: [
-        {
-          root_asset: 'USDC',
-          quantity_delta: '10',
-        },
-      ],
-      affected_unit_ids: ['unit-portfolio-protocol-001'],
-    },
     userReservePolicies: [],
-    ownedUnits: [
-      {
-        unit_id: 'unit-portfolio-protocol-001',
-        root_asset: 'USDC',
-        network: 'base',
-        wallet_address: '0xUSERPROTO1',
-        quantity: '10',
-        owner_type: 'user_idle',
-        owner_id: 'user_idle',
-        status: 'reserved',
-        reservation_id: 'reservation-ember-lending-protocol-001',
-        delegation_id: null,
-        control_path: 'unassigned',
-        position_kind: 'spot',
-        benchmark_asset: 'USD',
-        benchmark_value: '10',
-        valuation_ref: 'valuation-portfolio-protocol-001',
-        cost_basis: '10',
-        opened_at: '2026-03-29T00:00:00Z',
-        closed_at: null,
-        parent_unit_ids: [],
-        metadata: {
-          source: 'onboarding_scan',
-        },
-      },
-    ],
-    reservations: [
-      {
-        reservation_id: 'reservation-ember-lending-protocol-001',
-        agent_id: 'ember-lending',
-        owner_id: 'user_idle',
-        purpose: 'deploy',
-        control_path: 'lending.supply',
-        unit_allocations: [
-          {
-            unit_id: 'unit-portfolio-protocol-001',
-            quantity: '10',
-          },
-        ],
-        status: 'active',
-        created_at: '2026-03-29T00:00:00Z',
-        released_at: null,
-        superseded_by: null,
-      },
-    ],
-    policySnapshots: [
-      {
-        policy_snapshot_ref: 'policy-ember-lending-protocol-001',
-        agent_id: 'ember-lending',
-        network: 'base',
-        control_paths: ['lending.supply'],
-        unit_bounds: [
-          {
-            unit_id: 'unit-portfolio-protocol-001',
-            quantity: '10',
-          },
-        ],
-        created_at: '2026-03-29T00:00:00Z',
-      },
-    ],
+    activation: {
+      agentId: 'portfolio-manager',
+      purpose: 'deploy',
+      controlPath: 'unassigned',
+    },
   };
 }
 
@@ -404,27 +333,11 @@ describe('createPortfolioManagerDomain', () => {
                   'lend USDC on Aave within medium-risk allocation, LTV, and health-factor guardrails',
               },
             ],
-            capitalObservation: expect.objectContaining({
-              wallet_address: '0x00000000000000000000000000000000000000a1',
-            }),
-            ownedUnits: [
-              expect.objectContaining({
-                root_asset: 'USDC',
-                control_path: 'unassigned',
-              }),
-            ],
-            reservations: [
-              expect.objectContaining({
-                agent_id: 'ember-lending',
-                control_path: 'lending.supply',
-              }),
-            ],
-            policySnapshots: [
-              expect.objectContaining({
-                agent_id: 'ember-lending',
-                control_paths: ['lending.supply'],
-              }),
-            ],
+            activation: {
+              agentId: 'portfolio-manager',
+              purpose: 'deploy',
+              controlPath: 'unassigned',
+            },
           }),
           handoff: expect.objectContaining({
             user_wallet: '0x00000000000000000000000000000000000000a1',
@@ -434,6 +347,17 @@ describe('createPortfolioManagerDomain', () => {
         }),
       }),
     );
+
+    const rootedBootstrapRequest = protocolHost.handleJsonRpc.mock.calls[0]?.[0] as {
+      params?: {
+        onboarding?: Record<string, unknown>;
+      };
+    };
+
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('capitalObservation');
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('ownedUnits');
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('reservations');
+    expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('policySnapshots');
   });
 
   it('returns to prehire and clears wallet-local state when delegation signing is rejected', async () => {

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -156,8 +156,8 @@ Container responsibilities:
 - Agent domain module: pluggable layer for agent-family-specific lifecycle, interrupt, command, and semantic A2UI content
 - Operator control plane: scheduler health, maintenance, replay/recreate, inspection, and archival workflows that are not model-facing tools
 - Current managed-runtime example:
-  - `agent-portfolio-manager` owns onboarding approval, reservation creation, and managed-agent control-plane projection.
-  - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember.
+  - `agent-portfolio-manager` owns onboarding approval, rooted-signing collection, and managed-agent control-plane projection, but Shared Ember owns the durable reservation and owned-unit truth created during onboarding completion.
+  - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember and consumes agent-scoped lane data plus rooted-wallet-wide wallet contents from Shared Ember execution context.
 
 Important web constraint:
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -98,6 +98,7 @@ Container responsibilities:
 - CopilotKit endpoint: protocol boundary and routing to agents.
 - Agent runtimes: workflow execution and state emission.
 - Managed downstream note: `agent-portfolio-manager` owns managed onboarding/control-plane flows, while `agent-ember-lending` stays on the bounded subagent read/plan/execute/escalate surface against Shared Ember.
+  - Shared Ember, not the portfolio-manager runtime, owns the durable wallet observation, managed-lane owned units, reservations, and policy snapshots produced during onboarding completion.
 
 Explicit non-goal container:
 
@@ -183,7 +184,8 @@ Target factorization:
 Current concrete managed-path specialization:
 
 - `agent-portfolio-manager`
-  - owns onboarding approval, reservation creation, managed-agent activation/deactivation, and managed-lane summary projection
+  - owns onboarding approval, rooted-signing collection, and managed-agent activation/deactivation intent submission
+  - submits the minimal rooted-bootstrap activation contract that tells Shared Ember which managed mandate should materialize the initial lane
   - consumes Shared Ember through a thin app-local adapter without owning Ember business logic
 
 - `agent-ember-lending`
@@ -192,6 +194,7 @@ Current concrete managed-path specialization:
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
   - treats execution as admit-and-execute or blocked/denied admission rather than an execution-only success path
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
+  - treats `owned_units` and `reservations` as lending-lane truth while treating `wallet_contents` as rooted-wallet-wide context for prompt visibility
 
 ## 6. Dynamic views (sequence)
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -186,7 +186,7 @@ Current concrete managed-path specialization:
 
 - `agent-ember-lending`
   - owns the first bounded managed-subagent runtime
-  - consumes the Shared Ember subagent surface for `read_portfolio_state`, `materialize_candidate_plan`, `execute_transaction_plan`, and `create_escalation_request`
+  - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
 
 ## 6. Dynamic views (sequence)

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -189,7 +189,8 @@ Current concrete managed-path specialization:
 - `agent-ember-lending`
   - owns the first bounded managed-subagent runtime
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
-  - keeps planning on the bounded Shared Ember planner contract and treats execution as admit-and-execute or blocked/denied admission rather than an execution-only success path
+  - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
+  - treats execution as admit-and-execute or blocked/denied admission rather than an execution-only success path
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
 
 ## 6. Dynamic views (sequence)

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -8,6 +8,8 @@ See also:
 - `docs/c4-pi-runtime-architecture-and-boundaries.md` for the Pi-backed runtime specialization of this target architecture
 - `docs/ag-ui-client-runtime-invariants.md`
 - `docs/ag-ui-frontend-backend-contract-ui-stability.md`
+- `docs/source-traced-portfolio-manager-ember-lending-sequence.mdd`
+- `docs/target-state-portfolio-manager-ember-lending-sequence.mdd`
 
 ## 1. Why this document exists
 
@@ -187,6 +189,7 @@ Current concrete managed-path specialization:
 - `agent-ember-lending`
   - owns the first bounded managed-subagent runtime
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
+  - keeps planning on the bounded Shared Ember planner contract and treats execution as admit-and-execute or blocked/denied admission rather than an execution-only success path
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
 
 ## 6. Dynamic views (sequence)

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -11,14 +11,14 @@ Traced from:
 
 ## Boundary summary
 
-- Portfolio Manager owns mandate approval, reservation creation, and control-plane follow-up.
+- Portfolio Manager owns mandate approval, rooted-signing collection, and submission of the managed-agent activation intent.
 - Ember Lending exposes exactly three model-visible tools:
   - `create_transaction_plan`
   - `request_transaction_execution`
   - `create_escalation_request`
 - Runtime-internal reads stay hidden from the model:
   - `subagent.readPortfolioState.v1` for connect-time hydration
-  - `subagent.readExecutionContext.v1` during system-context assembly
+  - `subagent.readExecutionContext.v1` for connect-time hydration and system-context assembly
 
 ```mermaid
 sequenceDiagram
@@ -29,15 +29,17 @@ sequenceDiagram
   participant EL as agent-ember-lending
   participant SE as Shared Ember
 
-  PM->>SE: approve lending mandate + reserve capital
+  PM->>SE: orchestrator.completeRootedBootstrapFromUserSigning.v1(portfolio + lending mandates, activation.agentId=ember-lending)
+  Note over SE: Observe rooted wallet and materialize the initial ember-lending lane internally
   User->>Web: Open Ember Lending detail
   Web->>Runtime: connect(agent-ember-lending, threadId)
   Runtime->>EL: hydrate_runtime_projection (internal)
   EL->>SE: subagent.readPortfolioState.v1
-  SE-->>EL: portfolio_state + revision
+  EL->>SE: subagent.readExecutionContext.v1
+  SE-->>EL: agent-scoped portfolio_state + revision
   Runtime->>EL: build system context (internal)
   EL->>SE: subagent.readExecutionContext.v1
-  SE-->>EL: minimal execution_context
+  SE-->>EL: execution_context with lane-scoped owned_units and rooted-wallet-wide wallet_contents
   EL-->>Runtime: UI-ready state snapshot
 
   User->>Web: create_transaction_plan
@@ -76,3 +78,4 @@ sequenceDiagram
 - Blocked execution responses preserve the already-hydrated mandate and wallet context even when the blocked portfolio payload is sparse.
 - Nested raw `handoff` payloads, planner-owned `payload_builder_output`, and reasoning-trace fields are not forwarded on planning calls.
 - Escalation calls still forward only the bounded escalation handoff fields plus the blocked result.
+- In the current implementation, onboarding bootstrap creates the initial lending `owned_units`, `reservations`, and policy snapshot for `activation.agentId`, but `subagent_wallet_address` can still remain `null` until later delegation issuance.

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -43,8 +43,9 @@ sequenceDiagram
   User->>Web: create_transaction_plan
   Web->>Runtime: run(create_transaction_plan)
   Runtime->>EL: handleOperation(create_transaction_plan)
-  Note over EL: Build a bounded planning handoff from top-level planner fields only
+  Note over EL: Build a bounded planning handoff from top-level planner fields only; do not forward planner-owned payload_builder_output
   EL->>SE: subagent.createTransactionPlan.v1
+  Note over SE: Resolve planner-owned payload_builder_output through the Shared Ember planner path before materializing the candidate plan
   SE-->>EL: candidate_plan + revision
   EL-->>Runtime: candidate plan artifact + summary
 
@@ -73,4 +74,5 @@ sequenceDiagram
 
 - The model never sees `read_portfolio_state` or a refresh/sync bootstrap tool.
 - Blocked execution responses preserve the already-hydrated mandate and wallet context even when the blocked portfolio payload is sparse.
-- Nested raw `handoff` payloads and reasoning-trace fields are not forwarded on planning or escalation calls.
+- Nested raw `handoff` payloads, planner-owned `payload_builder_output`, and reasoning-trace fields are not forwarded on planning calls.
+- Escalation calls still forward only the bounded escalation handoff fields plus the blocked result.

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -1,0 +1,76 @@
+# Source-Traced Portfolio Manager -> Ember Lending Sequence
+
+Status: Source-traced current implementation
+Scope: `typescript/clients/web-ag-ui/apps/agent-portfolio-manager` and `typescript/clients/web-ag-ui/apps/agent-ember-lending`
+
+Traced from:
+
+- `apps/agent-portfolio-manager/src/sharedEmberAdapter.ts`
+- `apps/agent-ember-lending/src/sharedEmberAdapter.ts`
+- `apps/agent-ember-lending/src/agUiServer.ts`
+
+## Boundary summary
+
+- Portfolio Manager owns mandate approval, reservation creation, and control-plane follow-up.
+- Ember Lending exposes exactly three model-visible tools:
+  - `create_transaction_plan`
+  - `request_transaction_execution`
+  - `create_escalation_request`
+- Runtime-internal reads stay hidden from the model:
+  - `subagent.readPortfolioState.v1` for connect-time hydration
+  - `subagent.readExecutionContext.v1` during system-context assembly
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Web
+  participant Runtime as AG-UI Runtime
+  participant PM as agent-portfolio-manager
+  participant EL as agent-ember-lending
+  participant SE as Shared Ember
+
+  PM->>SE: approve lending mandate + reserve capital
+  User->>Web: Open Ember Lending detail
+  Web->>Runtime: connect(agent-ember-lending, threadId)
+  Runtime->>EL: hydrate_runtime_projection (internal)
+  EL->>SE: subagent.readPortfolioState.v1
+  SE-->>EL: portfolio_state + revision
+  Runtime->>EL: build system context (internal)
+  EL->>SE: subagent.readExecutionContext.v1
+  SE-->>EL: minimal execution_context
+  EL-->>Runtime: UI-ready state snapshot
+
+  User->>Web: create_transaction_plan
+  Web->>Runtime: run(create_transaction_plan)
+  Runtime->>EL: handleOperation(create_transaction_plan)
+  Note over EL: Build a bounded planning handoff from top-level planner fields only
+  EL->>SE: subagent.createTransactionPlan.v1
+  SE-->>EL: candidate_plan + revision
+  EL-->>Runtime: candidate plan artifact + summary
+
+  User->>Web: request_transaction_execution
+  Web->>Runtime: run(request_transaction_execution)
+  Runtime->>EL: handleOperation(request_transaction_execution)
+  EL->>SE: subagent.requestTransactionExecution.v1
+  alt admit and execute
+    SE-->>EL: phase=completed + execution + portfolio_state
+    EL-->>Runtime: completed status + tx hash + artifact
+  else block or deny admission
+    SE-->>EL: phase=blocked + request_result + portfolio_state
+    EL-->>Runtime: failed status + blocked artifact
+    User->>Web: create_escalation_request
+    Web->>Runtime: run(create_escalation_request)
+    Runtime->>EL: handleOperation(create_escalation_request)
+    Note over EL: Reuse only the bounded escalation handoff fields plus the blocked result
+    EL->>SE: subagent.createEscalationRequest.v1
+    SE-->>EL: escalation_request
+    SE-->>PM: control-plane follow-up happens outside the lending runtime
+    EL-->>Runtime: escalation artifact + summary
+  end
+```
+
+## Notes
+
+- The model never sees `read_portfolio_state` or a refresh/sync bootstrap tool.
+- Blocked execution responses preserve the already-hydrated mandate and wallet context even when the blocked portfolio payload is sparse.
+- Nested raw `handoff` payloads and reasoning-trace fields are not forwarded on planning or escalation calls.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -5,7 +5,7 @@ Scope: managed Portfolio Manager -> Ember Lending coordination over Shared Ember
 
 ## Contract summary
 
-- Portfolio Manager remains the owner of onboarding, reservations, and control-plane interventions.
+- Portfolio Manager remains the owner of onboarding approval, rooted-signing collection, and control-plane interventions.
 - Ember Lending keeps exactly three model-visible tools:
   - `create_transaction_plan`
   - `request_transaction_execution`
@@ -17,6 +17,9 @@ Scope: managed Portfolio Manager -> Ember Lending coordination over Shared Ember
 - Planner note:
   - `subagent.createTransactionPlan.v1` accepts a bounded planning handoff without planner-owned `payload_builder_output`.
   - Shared Ember routes that request through the `ember-cli` planner path and returns the planner-generated payload output in `candidate_plan.handoff`.
+- Execution-context note:
+  - `owned_units` and `reservations` are agent-scoped to the managed lending lane.
+  - `wallet_contents` is rooted-wallet-wide so every managed agent can see the full wallet inventory in prompt context.
 
 ```mermaid
 sequenceDiagram
@@ -28,13 +31,14 @@ sequenceDiagram
   participant SE as Shared Ember
   participant Planner as ember-cli planner path
 
-  PM->>SE: approve mandate + reserve capital + activate lending lane
+  PM->>SE: complete rooted bootstrap with activation targeted to ember-lending
+  Note over SE: Wallet observation, accounting-unit ingestion, reservation creation, and policy snapshot materialization happen inside Shared Ember
   User->>Web: Open Ember Lending detail
   Web->>Runtime: connect(agent-ember-lending, threadId)
   Runtime->>EL: runtime-owned hydrate + system-context assembly
   EL->>SE: subagent.readPortfolioState.v1
   EL->>SE: subagent.readExecutionContext.v1
-  SE-->>EL: managed projection + minimal execution_context
+  SE-->>EL: lending-lane projection + execution_context(rooted-wallet-wide wallet_contents)
   EL-->>Runtime: ready snapshot with minimal execution contract
 
   User->>Web: create_transaction_plan
@@ -71,3 +75,4 @@ sequenceDiagram
 - There is no model-visible `read_portfolio_state` tool.
 - There is no model-visible onboarding-context read or manual sync/bootstrap step.
 - `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.
+- In the current reference implementation, bootstrap-created lending lanes can still have `subagent_wallet_address = null` until a later delegation issuance step assigns a dedicated subagent wallet.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -1,0 +1,72 @@
+# Target-State Portfolio Manager -> Ember Lending Sequence
+
+Status: Target-state contract for issue `#555`
+Scope: managed Portfolio Manager -> Ember Lending coordination over Shared Ember
+
+## Contract summary
+
+- Portfolio Manager remains the owner of onboarding, reservations, and control-plane interventions.
+- Ember Lending keeps exactly three model-visible tools:
+  - `create_transaction_plan`
+  - `request_transaction_execution`
+  - `create_escalation_request`
+- Runtime-only behavior remains hidden:
+  - connect-time projection hydration
+  - `subagent.readExecutionContext.v1` during system-context assembly
+  - revision refresh / retry handling after Shared Ember conflicts
+- Planner note:
+  - `subagent.createTransactionPlan.v1` is the downstream planning contract and is expected to route upstream through the `ember-cli` planner path rather than the retired generic materialization wrapper.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Web
+  participant Runtime as AG-UI Runtime
+  participant PM as agent-portfolio-manager
+  participant EL as agent-ember-lending
+  participant SE as Shared Ember
+  participant Planner as ember-cli planner path
+
+  PM->>SE: approve mandate + reserve capital + activate lending lane
+  User->>Web: Open Ember Lending detail
+  Web->>Runtime: connect(agent-ember-lending, threadId)
+  Runtime->>EL: runtime-owned hydrate + system-context assembly
+  EL->>SE: subagent.readPortfolioState.v1
+  EL->>SE: subagent.readExecutionContext.v1
+  SE-->>EL: managed projection + minimal execution_context
+  EL-->>Runtime: ready snapshot with minimal execution contract
+
+  User->>Web: create_transaction_plan
+  Web->>Runtime: run(create_transaction_plan)
+  Runtime->>EL: handleOperation(create_transaction_plan)
+  EL->>SE: subagent.createTransactionPlan.v1(bounded planning handoff)
+  SE->>Planner: plan from mandate + execution context
+  Planner-->>SE: candidate plan
+  SE-->>EL: candidate_plan + revision
+  EL-->>Runtime: candidate plan artifact
+
+  User->>Web: request_transaction_execution
+  Web->>Runtime: run(request_transaction_execution)
+  Runtime->>EL: handleOperation(request_transaction_execution)
+  EL->>SE: subagent.requestTransactionExecution.v1(transaction_plan_id)
+  alt admit and execute now
+    SE-->>EL: phase=completed + execution + portfolio_state
+    EL-->>Runtime: completed status + tx hash + artifact
+  else block or deny admission
+    SE-->>EL: phase=blocked + request_result + portfolio_state
+    EL-->>Runtime: failed status + blocked artifact
+    User->>Web: create_escalation_request
+    Web->>Runtime: run(create_escalation_request)
+    Runtime->>EL: handleOperation(create_escalation_request)
+    EL->>SE: subagent.createEscalationRequest.v1(bounded escalation handoff, blocked result)
+    SE-->>PM: control-plane resolution request
+    SE-->>EL: escalation_request
+    EL-->>Runtime: escalation artifact + summary
+  end
+```
+
+## Notes
+
+- There is no model-visible `read_portfolio_state` tool.
+- There is no model-visible onboarding-context read or manual sync/bootstrap step.
+- `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -15,7 +15,8 @@ Scope: managed Portfolio Manager -> Ember Lending coordination over Shared Ember
   - `subagent.readExecutionContext.v1` during system-context assembly
   - revision refresh / retry handling after Shared Ember conflicts
 - Planner note:
-  - `subagent.createTransactionPlan.v1` is the downstream planning contract and is expected to route upstream through the `ember-cli` planner path rather than the retired generic materialization wrapper.
+  - `subagent.createTransactionPlan.v1` accepts a bounded planning handoff without planner-owned `payload_builder_output`.
+  - Shared Ember routes that request through the `ember-cli` planner path and returns the planner-generated payload output in `candidate_plan.handoff`.
 
 ```mermaid
 sequenceDiagram
@@ -39,7 +40,7 @@ sequenceDiagram
   User->>Web: create_transaction_plan
   Web->>Runtime: run(create_transaction_plan)
   Runtime->>EL: handleOperation(create_transaction_plan)
-  EL->>SE: subagent.createTransactionPlan.v1(bounded planning handoff)
+  EL->>SE: subagent.createTransactionPlan.v1(bounded planning handoff without planner-owned payload output)
   SE->>Planner: plan from mandate + execution context
   Planner-->>SE: candidate plan
   SE-->>EL: candidate_plan + revision


### PR DESCRIPTION
## Summary
- route `create_transaction_plan` through the real Shared Ember planner flow instead of forwarding planner-owned `payload_builder_output`
- keep the downstream request bounded to mandate, wallet, reservation, and decision fields while receiving planner-generated payload output back in `candidate_plan.handoff`
- refresh the Ember Lending docs so the current-source and target-state artifacts both describe the planner-backed planning contract accurately

## Testing
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent-ember-lending test`
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent-ember-lending build`
- `pnpm --dir typescript/clients/web-ag-ui lint`

## Related
- Parent issue: #538
- Part of #555
- Depends on EmberAGI/ember-orchestration-v1-spec#200
