### PR TITLE
[Task] Carry structured managed mandates into Shared Ember onboarding activation

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -494,9 +494,23 @@ describe('agent-portfolio-manager AG-UI integration', () => {
         request.method === 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
     )?.[0] as {
       params?: {
-        onboarding?: Record<string, unknown>;
+        onboarding?: {
+          mandates?: Array<{
+            mandate_ref?: string;
+            agent_id?: string;
+          }>;
+          activation?: {
+            mandateRef?: string;
+          };
+        } & Record<string, unknown>;
       };
     };
+
+    const managedMandateRef = rootedBootstrapRequest.params?.onboarding?.mandates?.find(
+      (mandate) => mandate.agent_id === 'ember-lending',
+    )?.mandate_ref;
+    expect(managedMandateRef).toEqual(expect.any(String));
+    expect(rootedBootstrapRequest.params?.onboarding?.activation?.mandateRef).toBe(managedMandateRef);
 
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('capitalObservation');
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('ownedUnits');

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -461,15 +461,21 @@ describe('agent-portfolio-manager AG-UI integration', () => {
             mandates: expect.arrayContaining([
               expect.objectContaining({
                 agent_id: 'portfolio-manager',
+                managed_onboarding: null,
               }),
               expect.objectContaining({
                 agent_id: 'ember-lending',
+                managed_onboarding: {
+                  root_asset: 'USDC',
+                  benchmark_asset: 'USD',
+                  allocation_mode: 'allocable_idle',
+                  intent: 'deploy',
+                  control_path: 'lending.supply',
+                },
               }),
             ]),
             activation: {
-              agentId: 'ember-lending',
-              purpose: 'deploy',
-              controlPath: 'unassigned',
+              mandateRef: expect.stringContaining('mandate-'),
             },
           }),
           handoff: expect.objectContaining({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -10,6 +10,7 @@ import {
 } from './sharedEmberHttpHost.js';
 import { createPortfolioManagerDiagnosticTool } from './diagnosticTool.js';
 import { createPortfolioManagerWalletAccountingTool } from './walletAccountingTool.js';
+import { PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID } from './sharedEmberOnboardingState.js';
 
 const DEFAULT_PORTFOLIO_MANAGER_MODEL = 'openai/gpt-5.4-mini';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
@@ -87,7 +88,7 @@ export function createPortfolioManagerAgentConfig(
         ? [
             createPortfolioManagerWalletAccountingTool({
               protocolHost,
-              agentId: 'portfolio-manager',
+              agentId: PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID,
             }),
           ]
         : []),

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -123,13 +123,25 @@ function createOnboardingBootstrap() {
         mandate_ref: 'mandate-portfolio-protocol-001',
         agent_id: 'portfolio-manager',
         mandate_summary: 'preserve direct-user liquidity',
+        managed_onboarding: null,
+      },
+      {
+        mandate_ref: 'mandate-ember-lending-protocol-001',
+        agent_id: 'ember-lending',
+        mandate_summary:
+          'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+        managed_onboarding: {
+          root_asset: 'USDC',
+          benchmark_asset: 'USD',
+          allocation_mode: 'allocable_idle',
+          intent: 'deploy',
+          control_path: 'lending.supply',
+        },
       },
     ],
     userReservePolicies: [],
     activation: {
-      agentId: 'ember-lending',
-      purpose: 'deploy',
-      controlPath: 'unassigned',
+      mandateRef: 'mandate-ember-lending-protocol-001',
     },
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -1,16 +1,11 @@
-import { existsSync } from 'node:fs';
-import path from 'node:path';
-import { pathToFileURL } from 'node:url';
-
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createPortfolioManagerDomain } from './sharedEmberAdapter.js';
 import { createPortfolioManagerSharedEmberHttpHost } from './sharedEmberHttpHost.js';
-
-type StartedSharedEmberTarget = {
-  baseUrl: string;
-  close: () => Promise<void>;
-};
+import {
+  resolveSharedEmberTarget,
+  type StartedSharedEmberTarget,
+} from './sharedEmberIntegrationHarness.js';
 
 const runSharedEmberIntegration = process.env['RUN_SHARED_EMBER_INT']?.trim() === '1';
 const describeSharedEmberIntegration = runSharedEmberIntegration ? describe : describe.skip;
@@ -19,37 +14,6 @@ const TEST_USER_WALLET = '0x00000000000000000000000000000000000000b1' as const;
 const TEST_ORCHESTRATOR_WALLET = '0x00000000000000000000000000000000000000b2' as const;
 const TEST_DELEGATION_MANAGER = '0x00000000000000000000000000000000000000b3' as const;
 
-async function resolveSharedEmberTarget(): Promise<StartedSharedEmberTarget> {
-  const explicitBaseUrl = process.env['SHARED_EMBER_BASE_URL']?.trim();
-  if (explicitBaseUrl) {
-    return {
-      baseUrl: explicitBaseUrl,
-      close: async () => undefined,
-    };
-  }
-
-  const privateRepoRoot = process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT']?.trim();
-  if (!privateRepoRoot) {
-    throw new Error(
-      'Set SHARED_EMBER_BASE_URL or EMBER_ORCHESTRATION_V1_SPEC_ROOT when RUN_SHARED_EMBER_INT=1.',
-    );
-  }
-
-  if (!existsSync(path.join(privateRepoRoot, 'node_modules'))) {
-    throw new Error(
-      'The private ember-orchestration-v1-spec repo must have dependencies installed before running shared Ember integration tests.',
-    );
-  }
-
-  const harnessModule = (await import(
-    pathToFileURL(path.join(privateRepoRoot, 'scripts/shared-domain-service-repo-harness.ts')).href
-  )) as {
-    startRepoLocalSharedEmberDomainProtocolHttpServer: () => Promise<StartedSharedEmberTarget>;
-  };
-
-  return harnessModule.startRepoLocalSharedEmberDomainProtocolHttpServer();
-}
-
 function createRootDelegationHandoff(suffix: string) {
   return {
     handoff_id: `handoff-root-portfolio-int-${suffix}`,
@@ -57,7 +21,7 @@ function createRootDelegationHandoff(suffix: string) {
     user_id: 'user_idle',
     user_wallet: TEST_USER_WALLET,
     orchestrator_wallet: TEST_ORCHESTRATOR_WALLET,
-    network: 'base',
+    network: 'arbitrum',
     artifact_ref: `artifact-root-portfolio-int-${suffix}`,
     issued_at: '2026-03-29T00:00:00Z',
     activated_at: '2026-03-29T00:00:05Z',
@@ -112,7 +76,7 @@ function createOnboardingBootstrap() {
       rooted_wallet_context_id: 'rwc-user-protocol-001',
       user_id: 'user_idle',
       wallet_address: TEST_USER_WALLET,
-      network: 'base',
+      network: 'arbitrum',
       registered_at: '2026-03-29T00:00:00Z',
       metadata: {
         source: 'onboarding_scan',
@@ -149,11 +113,11 @@ function createOnboardingBootstrap() {
 describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integration', () => {
   let target: StartedSharedEmberTarget;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     target = await resolveSharedEmberTarget();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await target?.close();
   });
 
@@ -386,7 +350,7 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
         id: `rpc-shared-ember-int-read-onboarding-${suffix}`,
         method: 'orchestrator.readOnboardingState.v1',
         params: {
-          agent_id: 'portfolio-manager',
+          agent_id: 'ember-lending',
           wallet_address: onboarding.rootedWalletContext.wallet_address,
           network: onboarding.rootedWalletContext.network,
         },
@@ -400,17 +364,17 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
           phase: 'active',
           owned_units: [
             expect.objectContaining({
-              control_path: 'unassigned',
+              control_path: 'lending.supply',
             }),
           ],
           reservations: [
             expect.objectContaining({
-              control_path: 'unassigned',
+              control_path: 'lending.supply',
             }),
           ],
           policy_snapshots: [
             expect.objectContaining({
-              control_paths: ['unassigned'],
+              control_paths: ['lending.supply'],
             }),
           ],
         },
@@ -519,7 +483,7 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
         id: `rpc-shared-ember-int-read-onboarding-signing-${suffix}`,
         method: 'orchestrator.readOnboardingState.v1',
         params: {
-          agent_id: 'portfolio-manager',
+          agent_id: 'ember-lending',
           wallet_address: walletAddress,
           network: 'arbitrum',
         },
@@ -536,12 +500,12 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
           },
           reservations: expect.arrayContaining([
             expect.objectContaining({
-              control_path: 'unassigned',
+              control_path: 'lending.supply',
             }),
           ]),
           policy_snapshots: expect.arrayContaining([
             expect.objectContaining({
-              control_paths: ['unassigned'],
+              control_paths: ['lending.supply'],
             }),
           ]),
         },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -159,10 +159,12 @@ const PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP = '2026-03-30T00:00:00.000Z';
 const PORTFOLIO_MANAGER_PROTOCOL_SOURCE = 'onboarding_scan';
 const PORTFOLIO_MANAGER_DEFAULT_RISK_LEVEL = 'medium';
 const PORTFOLIO_MANAGER_ACTIVATION_PURPOSE = 'deploy';
-const PORTFOLIO_MANAGER_CONTROL_PATH = 'unassigned';
 const FIRST_MANAGED_AGENT_TYPE = 'ember-lending';
 const FIRST_MANAGED_AGENT_PROTOCOL = 'aave';
 const FIRST_MANAGED_AGENT_ROOT_ASSET = 'USDC';
+const FIRST_MANAGED_AGENT_BENCHMARK_ASSET = 'USD';
+const FIRST_MANAGED_AGENT_ALLOCATION_MODE = 'allocable_idle';
+const FIRST_MANAGED_AGENT_ONBOARDING_CONTROL_PATH = 'lending.supply';
 
 type PortfolioManagerPortfolioMandate = {
   approved: true;
@@ -184,6 +186,14 @@ type PortfolioManagerManagedAgentMandate = {
   agentType: typeof FIRST_MANAGED_AGENT_TYPE;
   approved: true;
   settings: EmberLendingManagedAgentSettings;
+};
+
+type ManagedOnboardingMandate = {
+  root_asset: string;
+  benchmark_asset: string;
+  allocation_mode: typeof FIRST_MANAGED_AGENT_ALLOCATION_MODE;
+  intent: typeof PORTFOLIO_MANAGER_ACTIVATION_PURPOSE;
+  control_path: typeof FIRST_MANAGED_AGENT_ONBOARDING_CONTROL_PATH;
 };
 
 type PortfolioManagerApprovedMandateEnvelope = {
@@ -511,6 +521,18 @@ function buildManagedAgentMandateSummary(input: PortfolioManagerManagedAgentMand
   return `lend ${primaryAsset} on Aave within medium-risk allocation, LTV, and health-factor guardrails`;
 }
 
+function buildManagedOnboardingMandate(
+  input: PortfolioManagerManagedAgentMandate,
+): ManagedOnboardingMandate {
+  return {
+    root_asset: input.settings.allowedCollateralAssets[0] ?? FIRST_MANAGED_AGENT_ROOT_ASSET,
+    benchmark_asset: FIRST_MANAGED_AGENT_BENCHMARK_ASSET,
+    allocation_mode: FIRST_MANAGED_AGENT_ALLOCATION_MODE,
+    intent: PORTFOLIO_MANAGER_ACTIVATION_PURPOSE,
+    control_path: FIRST_MANAGED_AGENT_ONBOARDING_CONTROL_PATH,
+  };
+}
+
 function buildPortfolioManagerOnboardingBootstrap(params: {
   agentId: string;
   threadId: string;
@@ -548,18 +570,18 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
         mandate_summary: buildPortfolioManagerMandateSummary(
           params.approvedMandateEnvelope.portfolioMandate,
         ),
+        managed_onboarding: null,
       },
       {
         mandate_ref: managedAgentMandateRef,
         agent_id: FIRST_MANAGED_AGENT_TYPE,
         mandate_summary: buildManagedAgentMandateSummary(firstManagedAgentMandate),
+        managed_onboarding: buildManagedOnboardingMandate(firstManagedAgentMandate),
       },
     ],
     userReservePolicies: [],
     activation: {
-      agentId: firstManagedAgentMandate.agentType,
-      purpose: PORTFOLIO_MANAGER_ACTIVATION_PURPOSE,
-      controlPath: PORTFOLIO_MANAGER_CONTROL_PATH,
+      mandateRef: managedAgentMandateRef,
     },
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -2,6 +2,7 @@ import type { AgentRuntimeDomainConfig } from 'agent-runtime';
 import {
   buildPortfolioManagerWalletAccountingDetails,
   buildSharedEmberAccountingContextXml,
+  resolvePortfolioManagerAccountingAgentId,
   readPortfolioManagerOnboardingState,
 } from './sharedEmberOnboardingState.js';
 
@@ -791,9 +792,12 @@ export function createPortfolioManagerDomain(
       const walletAddress = readPortfolioManagerContextWalletAddress(currentState);
       if (walletAddress && options.protocolHost) {
         try {
+          const accountingAgentId = resolvePortfolioManagerAccountingAgentId(
+            currentState.lastOnboardingBootstrap,
+          );
           const { revision, onboardingState } = await readPortfolioManagerOnboardingState({
             protocolHost: options.protocolHost,
-            agentId,
+            agentId: accountingAgentId,
             walletAddress,
           });
           context.push(

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -68,18 +68,24 @@ function createOnboardingBootstrap() {
         mandate_ref: 'mandate-portfolio-protocol-001',
         agent_id: 'portfolio-manager',
         mandate_summary: 'preserve direct-user liquidity',
+        managed_onboarding: null,
       },
       {
         mandate_ref: 'mandate-ember-lending-protocol-001',
         agent_id: 'ember-lending',
         mandate_summary: 'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+        managed_onboarding: {
+          root_asset: 'USDC',
+          benchmark_asset: 'USD',
+          allocation_mode: 'allocable_idle',
+          intent: 'deploy',
+          control_path: 'lending.supply',
+        },
       },
     ],
     userReservePolicies: [],
     activation: {
-      agentId: 'ember-lending',
-      purpose: 'deploy',
-      controlPath: 'unassigned',
+      mandateRef: 'mandate-ember-lending-protocol-001',
     },
   };
 }
@@ -325,18 +331,24 @@ describe('createPortfolioManagerDomain', () => {
                 mandate_ref: expect.stringContaining('mandate-'),
                 agent_id: 'portfolio-manager',
                 mandate_summary: 'preserve direct-user liquidity at medium risk while coordinating managed subagents',
+                managed_onboarding: null,
               },
               {
                 mandate_ref: expect.stringContaining('mandate-'),
                 agent_id: 'ember-lending',
                 mandate_summary:
                   'lend USDC on Aave within medium-risk allocation, LTV, and health-factor guardrails',
+                managed_onboarding: {
+                  root_asset: 'USDC',
+                  benchmark_asset: 'USD',
+                  allocation_mode: 'allocable_idle',
+                  intent: 'deploy',
+                  control_path: 'lending.supply',
+                },
               },
             ],
             activation: {
-              agentId: 'ember-lending',
-              purpose: 'deploy',
-              controlPath: 'unassigned',
+              mandateRef: expect.stringContaining('mandate-'),
             },
           }),
           handoff: expect.objectContaining({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -370,9 +370,23 @@ describe('createPortfolioManagerDomain', () => {
 
     const rootedBootstrapRequest = rootedBootstrapCall[0] as {
       params?: {
-        onboarding?: Record<string, unknown>;
+        onboarding?: {
+          mandates?: Array<{
+            mandate_ref?: string;
+            agent_id?: string;
+          }>;
+          activation?: {
+            mandateRef?: string;
+          };
+        } & Record<string, unknown>;
       };
     };
+
+    const managedMandateRef = rootedBootstrapRequest.params?.onboarding?.mandates?.find(
+      (mandate) => mandate.agent_id === 'ember-lending',
+    )?.mandate_ref;
+    expect(managedMandateRef).toEqual(expect.any(String));
+    expect(rootedBootstrapRequest.params?.onboarding?.activation?.mandateRef).toBe(managedMandateRef);
 
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('capitalObservation');
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('ownedUnits');
@@ -1158,7 +1172,7 @@ describe('createPortfolioManagerDomain', () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => ({
         jsonrpc: '2.0',
-        id: 'shared-ember-wallet-accounting-portfolio-manager-0x00000000000000000000000000000000000000a1',
+        id: 'shared-ember-wallet-accounting-ember-lending-0x00000000000000000000000000000000000000a1',
         result: {
           revision: 4,
           onboarding_state: {
@@ -1189,17 +1203,17 @@ describe('createPortfolioManagerDomain', () => {
                 root_asset: 'USDC',
                 quantity: '10',
                 status: 'reserved',
-                control_path: 'unassigned',
+                control_path: 'lending.supply',
                 reservation_id: 'reservation-a1',
               },
             ],
             reservations: [
               {
                 reservation_id: 'reservation-a1',
-                agent_id: 'portfolio-manager',
+                agent_id: 'ember-lending',
                 purpose: 'deploy',
                 status: 'active',
-                control_path: 'unassigned',
+                control_path: 'lending.supply',
                 unit_allocations: [
                   {
                     unit_id: 'unit-a1',
@@ -1245,7 +1259,7 @@ describe('createPortfolioManagerDomain', () => {
         '  <revision>4</revision>',
         '  <phase>active</phase>',
         '    <asset unit_id="unit-a1" reservation_id="reservation-a1">',
-        '    <reservation reservation_id="reservation-a1" agent_id="portfolio-manager">',
+        '    <reservation reservation_id="reservation-a1" agent_id="ember-lending">',
       ]),
     );
   });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberIntegrationHarness.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberIntegrationHarness.ts
@@ -1,0 +1,169 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export type StartedSharedEmberTarget = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+const DEFAULT_MANAGED_AGENT_ID = 'ember-lending';
+const DEFAULT_MANAGED_AGENT_WALLET =
+  '0x00000000000000000000000000000000000000c1' as const;
+const DEFAULT_BENCHMARK_ASSET = 'USD';
+const DEFAULT_OBSERVED_ASSET = 'USDC';
+const DEFAULT_OBSERVED_QUANTITY = '10';
+const DEFAULT_DELEGATION_ISSUED_AT = '2026-03-29T00:01:00Z';
+const DEFAULT_DELEGATION_ACTIVATED_AT = '2026-03-29T00:01:05Z';
+const DEFAULT_IDENTITY_REGISTERED_AT = '2026-03-29T00:00:30Z';
+
+type ResolveSharedEmberTargetOptions = {
+  managedAgentId?: string;
+  managedAgentWalletAddress?: `0x${string}`;
+  observedAsset?: string;
+  observedQuantity?: string;
+  benchmarkAsset?: string;
+};
+
+function resolveChainId(network: string): string {
+  switch (network) {
+    case 'arbitrum':
+      return '42161';
+    case 'base':
+      return '8453';
+    default:
+      return '1';
+  }
+}
+
+function createWalletObservationSource(input: {
+  observedAsset: string;
+  observedQuantity: string;
+  benchmarkAsset: string;
+}) {
+  return {
+    async observeWallet(params: {
+      walletAddress: string;
+      network: string;
+      observedAt: string;
+    }) {
+      return {
+        observation_id: `wallet-obs-${params.network}-${params.walletAddress.toLowerCase()}`,
+        wallet_address: params.walletAddress,
+        network: params.network,
+        observed_at: params.observedAt,
+        benchmark_asset: input.benchmarkAsset,
+        balances: [
+          {
+            observation_family: 'wallet_balance' as const,
+            adapter_route: 'spot_wallet_balance' as const,
+            token: {
+              chain_id: resolveChainId(params.network),
+              address: `0x${input.observedAsset}${params.network.toUpperCase()}`,
+              symbol: input.observedAsset,
+              decimals: 6,
+            },
+            quantity: input.observedQuantity,
+            benchmark_value: input.observedQuantity,
+            metadata: {},
+          },
+        ],
+        positions: [],
+      };
+    },
+  };
+}
+
+function createManagedOnboardingIssuerFixture(input: { managedAgentId: string }) {
+  return {
+    [input.managedAgentId]: {
+      async issueDelegation(params: { requestId: string }) {
+        const issuanceId = `${input.managedAgentId}-${params.requestId}`;
+        return {
+          delegationId: `del-${issuanceId}`,
+          artifactRef: `artifact-${issuanceId}`,
+          issuedAt: DEFAULT_DELEGATION_ISSUED_AT,
+          activatedAt: DEFAULT_DELEGATION_ACTIVATED_AT,
+          policyHash: `hash-${issuanceId}`,
+        };
+      },
+    },
+  };
+}
+
+function createManagedSubagentIdentity(input: {
+  managedAgentId: string;
+  managedAgentWalletAddress: `0x${string}`;
+}) {
+  return {
+    identity_ref: `agent-identity-${input.managedAgentId}-protocol-001`,
+    agent_id: input.managedAgentId,
+    role: 'subagent' as const,
+    wallet_address: input.managedAgentWalletAddress,
+    wallet_source: 'ember_local_write',
+    capability_metadata: {
+      execution: true,
+      onboarding: true,
+    },
+    registration_version: 1,
+    registered_at: DEFAULT_IDENTITY_REGISTERED_AT,
+  };
+}
+
+export async function resolveSharedEmberTarget(
+  options: ResolveSharedEmberTargetOptions = {},
+): Promise<StartedSharedEmberTarget> {
+  const explicitBaseUrl = process.env['SHARED_EMBER_BASE_URL']?.trim();
+  if (explicitBaseUrl) {
+    return {
+      baseUrl: explicitBaseUrl,
+      close: async () => undefined,
+    };
+  }
+
+  const privateRepoRoot = process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT']?.trim();
+  if (!privateRepoRoot) {
+    throw new Error(
+      'Set SHARED_EMBER_BASE_URL or EMBER_ORCHESTRATION_V1_SPEC_ROOT when RUN_SHARED_EMBER_INT=1.',
+    );
+  }
+
+  if (!existsSync(path.join(privateRepoRoot, 'node_modules'))) {
+    throw new Error(
+      'The private ember-orchestration-v1-spec repo must have dependencies installed before running shared Ember integration tests.',
+    );
+  }
+
+  const harnessModule = (await import(
+    pathToFileURL(path.join(privateRepoRoot, 'scripts/shared-domain-service-repo-harness.ts')).href
+  )) as {
+    startRepoLocalSharedEmberDomainProtocolHttpServer: (input?: {
+      bootstrap?: unknown;
+    }) => Promise<StartedSharedEmberTarget>;
+  };
+
+  const managedAgentId = options.managedAgentId ?? DEFAULT_MANAGED_AGENT_ID;
+  const managedAgentWalletAddress =
+    options.managedAgentWalletAddress ?? DEFAULT_MANAGED_AGENT_WALLET;
+
+  return harnessModule.startRepoLocalSharedEmberDomainProtocolHttpServer({
+    bootstrap: {
+      initialState: {
+        agent_service_identities: [
+          createManagedSubagentIdentity({
+            managedAgentId,
+            managedAgentWalletAddress,
+          }),
+        ],
+      },
+      walletObservationSource: createWalletObservationSource({
+        observedAsset: options.observedAsset ?? DEFAULT_OBSERVED_ASSET,
+        observedQuantity: options.observedQuantity ?? DEFAULT_OBSERVED_QUANTITY,
+        benchmarkAsset: options.benchmarkAsset ?? DEFAULT_BENCHMARK_ASSET,
+      }),
+      managedOnboardingIssuers: createManagedOnboardingIssuerFixture({
+        managedAgentId,
+      }),
+    },
+  });
+}

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.ts
@@ -1,6 +1,7 @@
 import type { PortfolioManagerSharedEmberProtocolHost } from './sharedEmberAdapter.js';
 
 export const PORTFOLIO_MANAGER_SHARED_EMBER_NETWORK = 'arbitrum';
+export const PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID = 'ember-lending';
 
 export type OnboardingProofs = {
   rooted_wallet_context_registered: boolean;
@@ -58,6 +59,12 @@ type OnboardingStateResponse = {
   };
 };
 
+type OnboardingBootstrapMandate = {
+  mandate_ref?: string;
+  agent_id?: string;
+  managed_onboarding?: unknown;
+};
+
 export type PortfolioManagerWalletAccountingDetails = {
   wallet: {
     address: string;
@@ -100,6 +107,39 @@ function escapeXml(value: string): string {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&apos;');
+}
+
+export function resolvePortfolioManagerAccountingAgentId(onboardingBootstrap: unknown): string {
+  if (typeof onboardingBootstrap !== 'object' || onboardingBootstrap === null) {
+    return PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID;
+  }
+
+  const onboardingBootstrapRecord = onboardingBootstrap as Record<string, unknown>;
+  const mandates = Array.isArray(onboardingBootstrapRecord['mandates'])
+    ? (onboardingBootstrapRecord['mandates'] as OnboardingBootstrapMandate[])
+    : [];
+  const activation =
+    typeof onboardingBootstrapRecord['activation'] === 'object' &&
+    onboardingBootstrapRecord['activation'] !== null
+      ? onboardingBootstrapRecord['activation']
+      : null;
+  const activatedMandateRef =
+    activation && 'mandateRef' in activation && typeof activation.mandateRef === 'string'
+      ? activation.mandateRef
+      : null;
+
+  const managedMandates = mandates.filter(
+    (mandate) => typeof mandate.agent_id === 'string' && mandate.managed_onboarding !== null,
+  );
+  const activatedManagedMandate = managedMandates.find(
+    (mandate) => mandate.mandate_ref === activatedMandateRef,
+  );
+
+  return (
+    activatedManagedMandate?.agent_id ??
+    managedMandates[0]?.agent_id ??
+    PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID
+  );
 }
 
 export async function readPortfolioManagerOnboardingState(input: {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.ts
@@ -127,16 +127,32 @@ export function resolvePortfolioManagerAccountingAgentId(onboardingBootstrap: un
     activation && 'mandateRef' in activation && typeof activation.mandateRef === 'string'
       ? activation.mandateRef
       : null;
+  const activatedAgentId =
+    activation && 'agentId' in activation && typeof activation.agentId === 'string'
+      ? activation.agentId
+      : null;
 
   const managedMandates = mandates.filter(
-    (mandate) => typeof mandate.agent_id === 'string' && mandate.managed_onboarding !== null,
+    (mandate) =>
+      typeof mandate.agent_id === 'string' &&
+      'managed_onboarding' in mandate &&
+      mandate.managed_onboarding !== null,
   );
   const activatedManagedMandate = managedMandates.find(
     (mandate) => mandate.mandate_ref === activatedMandateRef,
   );
+  const legacyActivatedManagedMandate =
+    activatedAgentId === null
+      ? null
+      : mandates.find(
+          (mandate) =>
+            mandate.agent_id === activatedAgentId &&
+            mandate.agent_id !== 'portfolio-manager',
+        );
 
   return (
     activatedManagedMandate?.agent_id ??
+    legacyActivatedManagedMandate?.agent_id ??
     managedMandates[0]?.agent_id ??
     PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID
   );

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePortfolioManagerAccountingAgentId } from './sharedEmberOnboardingState.js';
+
+describe('resolvePortfolioManagerAccountingAgentId', () => {
+  it('keeps legacy bootstrap payloads on the activated managed agent when managed_onboarding is absent', () => {
+    expect(
+      resolvePortfolioManagerAccountingAgentId({
+        mandates: [
+          {
+            mandate_ref: 'mandate-portfolio-001',
+            agent_id: 'portfolio-manager',
+          },
+          {
+            mandate_ref: 'mandate-ember-lending-001',
+            agent_id: 'ember-lending',
+          },
+        ],
+        activation: {
+          agentId: 'ember-lending',
+        },
+      }),
+    ).toBe('ember-lending');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.int.test.ts
@@ -1,51 +1,15 @@
-import { existsSync } from 'node:fs';
-import path from 'node:path';
-import { pathToFileURL } from 'node:url';
-
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createPortfolioManagerDomain } from './sharedEmberAdapter.js';
 import { createPortfolioManagerSharedEmberHttpHost } from './sharedEmberHttpHost.js';
+import {
+  resolveSharedEmberTarget,
+  type StartedSharedEmberTarget,
+} from './sharedEmberIntegrationHarness.js';
 import { createPortfolioManagerWalletAccountingTool } from './walletAccountingTool.js';
-
-type StartedSharedEmberTarget = {
-  baseUrl: string;
-  close: () => Promise<void>;
-};
 
 const runSharedEmberIntegration = process.env['RUN_SHARED_EMBER_INT']?.trim() === '1';
 const describeSharedEmberIntegration = runSharedEmberIntegration ? describe : describe.skip;
-
-async function resolveSharedEmberTarget(): Promise<StartedSharedEmberTarget> {
-  const explicitBaseUrl = process.env['SHARED_EMBER_BASE_URL']?.trim();
-  if (explicitBaseUrl) {
-    return {
-      baseUrl: explicitBaseUrl,
-      close: async () => undefined,
-    };
-  }
-
-  const privateRepoRoot = process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT']?.trim();
-  if (!privateRepoRoot) {
-    throw new Error(
-      'Set SHARED_EMBER_BASE_URL or EMBER_ORCHESTRATION_V1_SPEC_ROOT when RUN_SHARED_EMBER_INT=1.',
-    );
-  }
-
-  if (!existsSync(path.join(privateRepoRoot, 'node_modules'))) {
-    throw new Error(
-      'The private ember-orchestration-v1-spec repo must have dependencies installed before running shared Ember integration tests.',
-    );
-  }
-
-  const harnessModule = (await import(
-    pathToFileURL(path.join(privateRepoRoot, 'scripts/shared-domain-service-repo-harness.ts')).href
-  )) as {
-    startRepoLocalSharedEmberDomainProtocolHttpServer: () => Promise<StartedSharedEmberTarget>;
-  };
-
-  return harnessModule.startRepoLocalSharedEmberDomainProtocolHttpServer();
-}
 
 function createUniqueWalletAddress(seed: number): `0x${string}` {
   return `0x${seed.toString(16).padStart(40, '0')}` as `0x${string}`;
@@ -85,87 +49,28 @@ function createOnboardingBootstrap(suffix: string, walletAddress: `0x${string}`)
     },
     mandates: [
       {
-        mandate_ref: `mandate-wallet-accounting-${suffix}`,
+        mandate_ref: `mandate-portfolio-manager-${suffix}`,
         agent_id: 'portfolio-manager',
         mandate_summary: 'activate portfolio manager reserves',
+        managed_onboarding: null,
       },
-    ],
-    capitalObservation: {
-      observation_id: `observation-wallet-accounting-${suffix}`,
-      kind: 'onboarding_scan',
-      wallet_address: walletAddress,
-      network: 'arbitrum',
-      observed_at: '2026-03-30T00:00:00.000Z',
-      benchmark_asset: 'USD',
-      valuation_ref: `valuation-wallet-accounting-${suffix}`,
-      asset_deltas: [{ root_asset: 'USDC', quantity_delta: '10' }],
-      affected_unit_ids: [`unit-wallet-accounting-${suffix}`],
-    },
-    userReservePolicies: [
       {
-        reserve_policy_ref: `reserve-policy-wallet-accounting-${suffix}`,
-        summary: 'reserve 10 USDC for portfolio manager',
-        user_reserve_rules: [
-          {
-            root_asset: 'USDC',
-            network: 'arbitrum',
-            benchmark_asset: 'USD',
-            reserved_quantity: '10',
-            reason: 'portfolio manager bootstrap reserve',
-          },
-        ],
-      },
-    ],
-    ownedUnits: [
-      {
-        unit_id: `unit-wallet-accounting-${suffix}`,
-        root_asset: 'USDC',
-        network: 'arbitrum',
-        wallet_address: walletAddress,
-        quantity: '10',
-        owner_type: 'user_idle',
-        owner_id: `user-wallet-accounting-${suffix}`,
-        status: 'reserved',
-        reservation_id: `reservation-wallet-accounting-${suffix}`,
-        delegation_id: null,
-        control_path: 'unassigned',
-        position_kind: 'unassigned',
-        benchmark_asset: 'USD',
-        benchmark_value: '10',
-        valuation_ref: `valuation-wallet-accounting-${suffix}`,
-        cost_basis: '10',
-        opened_at: '2026-03-30T00:00:00.000Z',
-        closed_at: null,
-        parent_unit_ids: [],
-        metadata: {
-          source: 'onboarding_scan',
+        mandate_ref: `mandate-ember-lending-${suffix}`,
+        agent_id: 'ember-lending',
+        mandate_summary: 'lend USDC through the managed lending lane',
+        managed_onboarding: {
+          root_asset: 'USDC',
+          benchmark_asset: 'USD',
+          allocation_mode: 'allocable_idle',
+          intent: 'deploy',
+          control_path: 'lending.supply',
         },
       },
     ],
-    reservations: [
-      {
-        reservation_id: `reservation-wallet-accounting-${suffix}`,
-        agent_id: 'portfolio-manager',
-        owner_id: `user-wallet-accounting-${suffix}`,
-        purpose: 'deploy',
-        control_path: 'unassigned',
-        unit_allocations: [{ unit_id: `unit-wallet-accounting-${suffix}`, quantity: '10' }],
-        status: 'active',
-        created_at: '2026-03-30T00:00:00.000Z',
-        released_at: null,
-        superseded_by: null,
-      },
-    ],
-    policySnapshots: [
-      {
-        policy_snapshot_ref: `policy-wallet-accounting-${suffix}`,
-        agent_id: 'portfolio-manager',
-        network: 'arbitrum',
-        control_paths: ['unassigned'],
-        unit_bounds: [{ unit_id: `unit-wallet-accounting-${suffix}`, quantity: '10' }],
-        created_at: '2026-03-30T00:00:00.000Z',
-      },
-    ],
+    userReservePolicies: [],
+    activation: {
+      mandateRef: `mandate-ember-lending-${suffix}`,
+    },
   };
 }
 
@@ -192,7 +97,7 @@ describeSharedEmberIntegration('wallet accounting tool Shared Ember integration'
     });
     const tool = createPortfolioManagerWalletAccountingTool({
       protocolHost,
-      agentId: 'portfolio-manager',
+      agentId: 'ember-lending',
     });
 
     await expect(
@@ -248,13 +153,13 @@ describeSharedEmberIntegration('wallet accounting tool Shared Ember integration'
           expect.objectContaining({
             asset: 'USDC',
             quantity: '10',
-            controlPath: 'unassigned',
+            controlPath: 'lending.supply',
           }),
         ],
         reservations: [
           expect.objectContaining({
-            agentId: 'portfolio-manager',
-            controlPath: 'unassigned',
+            agentId: 'ember-lending',
+            controlPath: 'lending.supply',
           }),
         ],
       },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.ts
@@ -3,6 +3,7 @@ import type { CreateAgentRuntimeOptions } from 'agent-runtime';
 import type { PortfolioManagerSharedEmberProtocolHost } from './sharedEmberAdapter.js';
 import {
   buildPortfolioManagerWalletAccountingDetails,
+  PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID,
   PORTFOLIO_MANAGER_SHARED_EMBER_NETWORK,
   readPortfolioManagerOnboardingState,
   type PortfolioManagerWalletAccountingDetails,
@@ -81,7 +82,7 @@ export function createPortfolioManagerWalletAccountingTool(input: {
       const toolArgs = parseWalletAccountingToolArgs(args);
       const { revision, onboardingState } = await readPortfolioManagerOnboardingState({
         protocolHost: input.protocolHost,
-        agentId: input.agentId,
+        agentId: input.agentId || PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID,
         walletAddress: toolArgs.walletAddress,
         network: PORTFOLIO_MANAGER_SHARED_EMBER_NETWORK,
       });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.unit.test.ts
@@ -12,7 +12,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
           protocol_version: 'v1',
           revision: 4,
           onboarding_state: {
-            agent_id: 'portfolio-manager',
+            agent_id: 'ember-lending',
             wallet_address: '0x00000000000000000000000000000000000000a1',
             network: 'arbitrum',
             phase: 'active',
@@ -41,17 +41,17 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
                 root_asset: 'USDC',
                 quantity: '10',
                 status: 'reserved',
-                control_path: 'unassigned',
+                control_path: 'lending.supply',
                 reservation_id: 'reservation-usdc-a1',
               },
             ],
             reservations: [
               {
                 reservation_id: 'reservation-usdc-a1',
-                agent_id: 'portfolio-manager',
+                agent_id: 'ember-lending',
                 purpose: 'deploy',
                 status: 'active',
-                control_path: 'unassigned',
+                control_path: 'lending.supply',
                 unit_allocations: [
                   {
                     unit_id: 'unit-usdc-a1',
@@ -63,7 +63,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
             policy_snapshots: [
               {
                 policy_snapshot_ref: 'policy-usdc-a1',
-                control_paths: ['unassigned'],
+                control_paths: ['lending.supply'],
               },
             ],
           },
@@ -75,7 +75,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
 
     const tool = createPortfolioManagerWalletAccountingTool({
       protocolHost,
-      agentId: 'portfolio-manager',
+      agentId: 'ember-lending',
     });
 
     const result = await tool.execute?.('tool-wallet-accounting-1', {
@@ -84,10 +84,10 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
-      id: 'shared-ember-wallet-accounting-portfolio-manager-0x00000000000000000000000000000000000000a1',
+      id: 'shared-ember-wallet-accounting-ember-lending-0x00000000000000000000000000000000000000a1',
       method: 'orchestrator.readOnboardingState.v1',
       params: {
-        agent_id: 'portfolio-manager',
+        agent_id: 'ember-lending',
         wallet_address: '0x00000000000000000000000000000000000000a1',
         network: 'arbitrum',
       },
@@ -114,14 +114,14 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
             asset: 'USDC',
             quantity: '10',
             status: 'reserved',
-            controlPath: 'unassigned',
+            controlPath: 'lending.supply',
           },
         ],
         reservations: [
           {
             reservationId: 'reservation-usdc-a1',
-            agentId: 'portfolio-manager',
-            controlPath: 'unassigned',
+            agentId: 'ember-lending',
+            controlPath: 'lending.supply',
             allocations: [
               {
                 unitId: 'unit-usdc-a1',
@@ -177,7 +177,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
 
     const tool = createPortfolioManagerWalletAccountingTool({
       protocolHost,
-      agentId: 'portfolio-manager',
+      agentId: 'ember-lending',
     });
 
     const result = await tool.execute?.('tool-wallet-accounting-2', {

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -158,6 +158,7 @@ Container responsibilities:
 - Current managed-runtime example:
   - `agent-portfolio-manager` owns onboarding approval, rooted-signing collection, and managed-agent control-plane projection, but Shared Ember owns the durable reservation and owned-unit truth created during onboarding completion.
   - `agent-portfolio-manager` wallet-accounting reads must target the activated managed mandate lane, not the portfolio-manager lane, so reservation and policy-snapshot context comes from the same agent scope that Shared Ember activated during bootstrap.
+  - The current portfolio-manager implementation writes `activation.mandateRef` on new bootstrap completions but still tolerates legacy stored bootstrap payloads that only captured `activation.agentId` until older thread state is replaced.
   - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember and consumes agent-scoped lane data plus rooted-wallet-wide wallet contents from Shared Ember execution context.
 
 Important web constraint:

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -157,6 +157,7 @@ Container responsibilities:
 - Operator control plane: scheduler health, maintenance, replay/recreate, inspection, and archival workflows that are not model-facing tools
 - Current managed-runtime example:
   - `agent-portfolio-manager` owns onboarding approval, rooted-signing collection, and managed-agent control-plane projection, but Shared Ember owns the durable reservation and owned-unit truth created during onboarding completion.
+  - `agent-portfolio-manager` wallet-accounting reads must target the activated managed mandate lane, not the portfolio-manager lane, so reservation and policy-snapshot context comes from the same agent scope that Shared Ember activated during bootstrap.
   - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember and consumes agent-scoped lane data plus rooted-wallet-wide wallet contents from Shared Ember execution context.
 
 Important web constraint:

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -100,6 +100,7 @@ Container responsibilities:
 - Managed downstream note: `agent-portfolio-manager` owns managed onboarding/control-plane flows, while `agent-ember-lending` stays on the bounded subagent read/plan/execute/escalate surface against Shared Ember.
   - Shared Ember, not the portfolio-manager runtime, owns the durable wallet observation, managed-lane owned units, reservations, and policy snapshots produced during onboarding completion.
   - Portfolio-manager wallet/accounting context must read `orchestrator.readOnboardingState.v1` through the activated managed mandate lane so the operator sees the same `lending.supply` reservation and policy state that Ember Lending consumes.
+  - During migration, portfolio-manager keeps a read-side fallback for older stored bootstrap payloads that only recorded `activation.agentId`; current writes still use `activation.mandateRef`.
 
 Explicit non-goal container:
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -99,6 +99,7 @@ Container responsibilities:
 - Agent runtimes: workflow execution and state emission.
 - Managed downstream note: `agent-portfolio-manager` owns managed onboarding/control-plane flows, while `agent-ember-lending` stays on the bounded subagent read/plan/execute/escalate surface against Shared Ember.
   - Shared Ember, not the portfolio-manager runtime, owns the durable wallet observation, managed-lane owned units, reservations, and policy snapshots produced during onboarding completion.
+  - Portfolio-manager wallet/accounting context must read `orchestrator.readOnboardingState.v1` through the activated managed mandate lane so the operator sees the same `lending.supply` reservation and policy state that Ember Lending consumes.
 
 Explicit non-goal container:
 

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -29,7 +29,7 @@ sequenceDiagram
   participant EL as agent-ember-lending
   participant SE as Shared Ember
 
-  PM->>SE: orchestrator.completeRootedBootstrapFromUserSigning.v1(portfolio + lending mandates, activation.agentId=ember-lending)
+  PM->>SE: orchestrator.completeRootedBootstrapFromUserSigning.v1(portfolio mandate + managed lending mandate, activation.mandateRef=<approved lending mandate>)
   Note over SE: Observe rooted wallet and materialize the initial ember-lending lane internally
   User->>Web: Open Ember Lending detail
   Web->>Runtime: connect(agent-ember-lending, threadId)
@@ -78,4 +78,5 @@ sequenceDiagram
 - Blocked execution responses preserve the already-hydrated mandate and wallet context even when the blocked portfolio payload is sparse.
 - Nested raw `handoff` payloads, planner-owned `payload_builder_output`, and reasoning-trace fields are not forwarded on planning calls.
 - Escalation calls still forward only the bounded escalation handoff fields plus the blocked result.
-- In the current implementation, onboarding bootstrap creates the initial lending `owned_units`, `reservations`, and policy snapshot for `activation.agentId`, but `subagent_wallet_address` can still remain `null` until later delegation issuance.
+- The selected managed lending mandate now carries `managed_onboarding` so Shared Ember can derive the initial lane from structured mandate data instead of a summary-only agent selector.
+- Ember Lending still treats Shared Ember as the wallet source of truth: if the first `subagent.readExecutionContext.v1` response includes a non-null `subagent_wallet_address`, the runtime/UI projects it immediately; if upstream returns `null`, downstream leaves it unset.

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -82,4 +82,5 @@ sequenceDiagram
 - Escalation calls still forward only the bounded escalation handoff fields plus the blocked result.
 - The selected managed lending mandate now carries `managed_onboarding` so Shared Ember can derive the initial lane from structured mandate data instead of a summary-only agent selector.
 - Portfolio-manager wallet-accounting reads must resolve the agent scope from the activated managed mandate so `owned_units`, `reservations`, and `policy_snapshots` come back from the `lending.supply` lane rather than the portfolio-manager lane shell.
+- Current bootstrap writes `activation.mandateRef`, but the accounting-agent resolver still accepts legacy stored bootstrap payloads that only expose `activation.agentId` while pre-upgrade thread state drains.
 - Ember Lending still treats Shared Ember as the wallet source of truth: if the first `subagent.readExecutionContext.v1` response includes a non-null `subagent_wallet_address`, the runtime/UI projects it immediately; if upstream returns `null`, downstream leaves it unset.

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -31,6 +31,8 @@ sequenceDiagram
 
   PM->>SE: orchestrator.completeRootedBootstrapFromUserSigning.v1(portfolio mandate + managed lending mandate, activation.mandateRef=<approved lending mandate>)
   Note over SE: Observe rooted wallet and materialize the initial ember-lending lane internally
+  PM->>SE: orchestrator.readOnboardingState.v1(agent_id=<activated managed mandate agent>)
+  Note over PM,SE: Portfolio-manager wallet accounting and system context read back the activated managed lane, not the portfolio-manager lane
   User->>Web: Open Ember Lending detail
   Web->>Runtime: connect(agent-ember-lending, threadId)
   Runtime->>EL: hydrate_runtime_projection (internal)
@@ -79,4 +81,5 @@ sequenceDiagram
 - Nested raw `handoff` payloads, planner-owned `payload_builder_output`, and reasoning-trace fields are not forwarded on planning calls.
 - Escalation calls still forward only the bounded escalation handoff fields plus the blocked result.
 - The selected managed lending mandate now carries `managed_onboarding` so Shared Ember can derive the initial lane from structured mandate data instead of a summary-only agent selector.
+- Portfolio-manager wallet-accounting reads must resolve the agent scope from the activated managed mandate so `owned_units`, `reservations`, and `policy_snapshots` come back from the `lending.supply` lane rather than the portfolio-manager lane shell.
 - Ember Lending still treats Shared Ember as the wallet source of truth: if the first `subagent.readExecutionContext.v1` response includes a non-null `subagent_wallet_address`, the runtime/UI projects it immediately; if upstream returns `null`, downstream leaves it unset.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -33,6 +33,8 @@ sequenceDiagram
 
   PM->>SE: complete rooted bootstrap with activation.mandateRef targeting the approved lending mandate
   Note over SE: Wallet observation, accounting-unit ingestion, reservation creation, and policy snapshot materialization happen inside Shared Ember
+  PM->>SE: read onboarding/accounting state through the activated managed mandate lane
+  Note over PM,SE: Portfolio-manager accounting context follows the same managed `lending.supply` lane that bootstrap activated
   User->>Web: Open Ember Lending detail
   Web->>Runtime: connect(agent-ember-lending, threadId)
   Runtime->>EL: runtime-owned hydrate + system-context assembly
@@ -76,4 +78,5 @@ sequenceDiagram
 - There is no model-visible onboarding-context read or manual sync/bootstrap step.
 - `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.
 - The managed lending mandate supplied at bootstrap should carry `managed_onboarding` so Shared Ember can derive the initial lane and delegation inputs from structured mandate data.
+- Portfolio-manager wallet accounting should resolve its onboarding-state `agent_id` from the activated managed mandate so operator-visible reservations and policy snapshots match the managed lane Ember Lending sees.
 - When Shared Ember has a durable subagent identity ready during onboarding, the first post-bootstrap execution-context read should already expose a non-null `subagent_wallet_address`, and Ember Lending should project it without any manual reseed step.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -31,7 +31,7 @@ sequenceDiagram
   participant SE as Shared Ember
   participant Planner as ember-cli planner path
 
-  PM->>SE: complete rooted bootstrap with activation targeted to ember-lending
+  PM->>SE: complete rooted bootstrap with activation.mandateRef targeting the approved lending mandate
   Note over SE: Wallet observation, accounting-unit ingestion, reservation creation, and policy snapshot materialization happen inside Shared Ember
   User->>Web: Open Ember Lending detail
   Web->>Runtime: connect(agent-ember-lending, threadId)
@@ -75,4 +75,5 @@ sequenceDiagram
 - There is no model-visible `read_portfolio_state` tool.
 - There is no model-visible onboarding-context read or manual sync/bootstrap step.
 - `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.
-- In the current reference implementation, bootstrap-created lending lanes can still have `subagent_wallet_address = null` until a later delegation issuance step assigns a dedicated subagent wallet.
+- The managed lending mandate supplied at bootstrap should carry `managed_onboarding` so Shared Ember can derive the initial lane and delegation inputs from structured mandate data.
+- When Shared Ember has a durable subagent identity ready during onboarding, the first post-bootstrap execution-context read should already expose a non-null `subagent_wallet_address`, and Ember Lending should project it without any manual reseed step.


### PR DESCRIPTION
## Summary
- align the portfolio-manager rooted-bootstrap payload with the live Shared Ember onboarding contract and activate the approved managed mandate by `mandateRef`
- harden portfolio-manager accounting and system-context reads so they resolve through the activated managed lane and pass against the repo-local Shared Ember harness
- preserve pre-upgrade bootstrap compatibility by falling back to legacy `activation.agentId` when stored payloads omit `managed_onboarding`
- refresh the source-traced and C4 architecture docs so the managed-lane read path and migration fallback are documented

## Testing
- `pnpm test:unit -- sharedEmberAdapter.unit.test.ts walletAccountingTool.unit.test.ts portfolioManagerFoundation.unit.test.ts` (`apps/agent-portfolio-manager`)
- `pnpm test:int -- agUiServer.int.test.ts` (`apps/agent-portfolio-manager`)
- `pnpm build` (`apps/agent-portfolio-manager`)
- `RUN_SHARED_EMBER_INT=1 EMBER_ORCHESTRATION_V1_SPEC_ROOT=/Users/tomdaniel/Documents/Ember_Cognition_Inc/Software/forge/repos/ember-orchestration-v1-spec pnpm test:int -- sharedEmberAdapter.int.test.ts walletAccountingTool.int.test.ts` (`apps/agent-portfolio-manager`)
- `pnpm test:unit -- sharedEmberAdapter.unit.test.ts` (`apps/agent-ember-lending`)
- `pnpm test:unit -- sharedEmberOnboardingState.unit.test.ts sharedEmberAdapter.unit.test.ts walletAccountingTool.unit.test.ts` (`apps/agent-portfolio-manager`)
- `pnpm test:int -- agUiServer.int.test.ts` (`apps/agent-portfolio-manager`)
- `pnpm build` (`apps/agent-portfolio-manager`)

## Related
- Relates #558
- Parent issue: #538
