### PR TITLE
feat(web-ag-ui): add local ows signing and multi-call execution

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
@@ -18,3 +18,7 @@ OPENROUTER_API_KEY=
 
 # Optional: point the lending runtime at the Shared Ember Domain Service HTTP boundary.
 # SHARED_EMBER_BASE_URL=http://127.0.0.1:4010
+
+# Optional: point the lending runtime at the local OWS signing boundary used for
+# redelegation and execution signing.
+# EMBER_LENDING_OWS_BASE_URL=http://127.0.0.1:4020

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -15,7 +15,7 @@ subagent surface for:
 
 - portfolio-state reads
 - planner-backed candidate-plan creation
-- transaction-plan execution
+- transaction execution preparation and local signing behind one execution tool
 - escalation requests
 
 Direct lending-agent onboarding is intentionally out of scope here. The
@@ -33,6 +33,19 @@ Current execution-context semantics:
   sparse
 - `subagent_wallet_address` can still be `null` until a later delegation
   issuance path assigns a dedicated subagent wallet
+- local OWS signing stays inside the downstream service layer and must fail
+  closed if the prepared signing package does not match the resolved dedicated
+  subagent wallet identity
+
+Runtime wiring:
+
+- `SHARED_EMBER_BASE_URL` points the app at the bounded Shared Ember HTTP
+  surface
+- `EMBER_LENDING_OWS_BASE_URL` points the app at the local OWS signing surface
+  used for redelegation and execution signing
+- when `EMBER_LENDING_OWS_BASE_URL` is not configured, execution still uses the
+  new prepare path but fails locally when Shared Ember reaches a signing-ready
+  stage instead of falling back to the retired single-call execution path
 
 Like the portfolio manager app, this package should stay a thin downstream app.
 Shared Ember business logic and durable truth remain outside the app behind the

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -33,6 +33,9 @@ Current execution-context semantics:
   sparse
 - `subagent_wallet_address` can still be `null` until a later delegation
   issuance path assigns a dedicated subagent wallet
+- `authority_preparation_needed` stays runtime-internal; the adapter re-polls
+  Shared Ember with a stage-scoped retry idempotency key until readiness
+  advances or the local execution attempt fails closed
 - local OWS signing stays inside the downstream service layer and must fail
   closed if the prepared signing package does not match the resolved dedicated
   subagent wallet identity

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -232,6 +232,110 @@ function createBlockedExecutionResult(input: {
   };
 }
 
+function createBlockedPreparationResult(input: {
+  result: 'needs_release_or_transfer' | 'denied';
+  requestId: string;
+  message: string;
+  blockingReasonCode: string;
+  nextAction: 'escalate_to_control_plane' | 'stop';
+}) {
+  return {
+    phase: 'blocked',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: input.requestId,
+    request_result: {
+      result: input.result,
+      request_id: input.requestId,
+      message: input.message,
+      reservation_id: 'reservation-ember-lending-001',
+      blocking_reason_code: input.blockingReasonCode,
+      next_action: input.nextAction,
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      owned_units: [],
+      reservations: [],
+    },
+  };
+}
+
+function createReadyForExecutionSigningPreparationResult() {
+  return {
+    phase: 'ready_for_execution_signing',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution_preparation: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      network: 'arbitrum',
+      reservation_id: 'reservation-ember-lending-001',
+      required_control_path: 'lending.supply',
+      canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      active_delegation_id: 'del-ember-lending-001',
+      root_delegation_id: 'root-user-ember-lending-001',
+      prepared_at: '2026-04-01T06:15:00.000Z',
+      metadata: {},
+    },
+    execution_signing_package: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      active_delegation_id: 'del-ember-lending-001',
+      canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+    },
+  };
+}
+
+function createTerminalExecutionResult(input: {
+  status:
+    | 'submitted'
+    | 'confirmed'
+    | 'failed_before_submission'
+    | 'failed_after_submission'
+    | 'partial_settlement';
+  transactionHash?: `0x${string}`;
+}) {
+  return {
+    phase: 'completed',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution: {
+      execution_id: 'exec-ember-lending-001',
+      status: input.status,
+      transaction_hash: input.transactionHash ?? null,
+      successor_unit_ids:
+        input.status === 'failed_before_submission' ? [] : ['unit-ember-lending-successor-001'],
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      mandate_ref: 'mandate-ember-lending-001',
+      mandate_summary:
+        'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+      reservations: [
+        {
+          reservation_id: 'reservation-ember-lending-001',
+          purpose: 'deploy',
+          control_path: 'lending.supply',
+        },
+      ],
+      owned_units: [
+        {
+          unit_id: 'unit-ember-lending-successor-001',
+          root_asset: 'USDC',
+          quantity: '10',
+          reservation_id: 'reservation-ember-lending-001',
+        },
+      ],
+    },
+  };
+}
+
 async function runAgUiCommand(input: {
   baseUrl: string;
   runId: string;
@@ -297,6 +401,9 @@ async function runAgUiConnect(input: {
 describe('agent-ember-lending AG-UI integration', () => {
   let server: Server;
   let baseUrl: string;
+  let executionSigner: {
+    signExecutionPackage: ReturnType<typeof vi.fn>;
+  };
   const defaultHandleJsonRpc = async (input: unknown) => {
     const request =
       typeof input === 'object' && input !== null
@@ -402,45 +509,27 @@ describe('agent-ember-lending AG-UI integration', () => {
       case 'subagent.requestTransactionExecution.v1':
         return {
           jsonrpc: '2.0',
-          id: 'shared-ember-thread-1-execute-transaction-plan',
+          id: 'shared-ember-thread-1-request-transaction-execution',
           result: {
             protocol_version: 'v1',
             revision: 9,
-            committed_event_ids: ['evt-execution-1'],
-            execution_result: {
-              transaction_plan_id: 'txplan-ember-lending-001',
-              request_id: 'req-ember-lending-execution-001',
-              execution: {
-                execution_id: 'exec-ember-lending-001',
-                status: 'confirmed',
-                transaction_hash:
-                  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-                successor_unit_ids: ['unit-ember-lending-successor-001'],
-              },
-              portfolio_state: {
-                agent_id: 'ember-lending',
-                agent_wallet: '0x00000000000000000000000000000000000000b1',
-                root_user_wallet: '0x00000000000000000000000000000000000000a1',
-                mandate_ref: 'mandate-ember-lending-001',
-                mandate_summary:
-                  'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
-                reservations: [
-                  {
-                    reservation_id: 'reservation-ember-lending-001',
-                    purpose: 'deploy',
-                    control_path: 'lending.supply',
-                  },
-                ],
-                owned_units: [
-                  {
-                    unit_id: 'unit-ember-lending-successor-001',
-                    root_asset: 'USDC',
-                    quantity: '10',
-                    reservation_id: 'reservation-ember-lending-001',
-                  },
-                ],
-              },
-            },
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        };
+      case 'subagent.submitSignedTransaction.v1':
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-submit-execution-1'],
+            execution_result: createTerminalExecutionResult({
+              status: 'confirmed',
+              transactionHash:
+                '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            }),
           },
         };
       case 'subagent.createEscalationRequest.v1':
@@ -478,6 +567,14 @@ describe('agent-ember-lending AG-UI integration', () => {
   };
 
   beforeEach(async () => {
+    executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
     const service = await createEmberLendingGatewayService({
       runtimeConfig: {
         model: {
@@ -492,6 +589,7 @@ describe('agent-ember-lending AG-UI integration', () => {
         tools: [],
         domain: createEmberLendingDomain({
           protocolHost,
+          executionSigner,
           agentId: 'ember-lending',
         }),
         agentOptions: {
@@ -877,7 +975,6 @@ describe('agent-ember-lending AG-UI integration', () => {
         params: expect.objectContaining({
           handoff: expect.objectContaining({
             agent_id: 'ember-lending',
-            agent_wallet: '0x00000000000000000000000000000000000000b1',
             mandate_ref: 'mandate-ember-lending-001',
           }),
         }),
@@ -936,10 +1033,10 @@ describe('agent-ember-lending AG-UI integration', () => {
             current: {
               data: {
                 type: 'shared-ember-execution-result',
-                revision: 9,
-                executionResult: {
-                  transaction_plan_id: 'txplan-ember-lending-001',
-                },
+                revision: 10,
+                outcome: 'confirmed',
+                transactionHash:
+                  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
               },
             },
           },
@@ -947,6 +1044,18 @@ describe('agent-ember-lending AG-UI integration', () => {
       },
     });
 
+    expect(executionSigner.signExecutionPackage).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
+      executionSigningPackage: {
+        execution_preparation_id: 'execprep-ember-lending-001',
+        transaction_plan_id: 'txplan-ember-lending-001',
+        request_id: 'req-ember-lending-execution-001',
+        active_delegation_id: 'del-ember-lending-001',
+        canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      },
+    });
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'subagent.requestTransactionExecution.v1',
@@ -968,12 +1077,12 @@ describe('agent-ember-lending AG-UI integration', () => {
       if (request.method === 'subagent.requestTransactionExecution.v1') {
         return {
           jsonrpc: '2.0',
-          id: 'shared-ember-thread-1-execute-transaction-plan',
+          id: 'shared-ember-thread-1-request-transaction-execution',
           result: {
             protocol_version: 'v1',
             revision: 9,
             committed_event_ids: ['evt-execution-blocked-1'],
-            execution_result: createBlockedExecutionResult({
+            execution_result: createBlockedPreparationResult({
               result: 'needs_release_or_transfer',
               requestId: 'req-ember-lending-blocked-001',
               message: 'reserved capital is still claimed by another agent',
@@ -1026,11 +1135,9 @@ describe('agent-ember-lending AG-UI integration', () => {
               data: {
                 type: 'shared-ember-execution-result',
                 revision: 9,
-                executionResult: {
-                  phase: 'blocked',
-                  transaction_plan_id: 'txplan-ember-lending-001',
-                  request_id: 'req-ember-lending-blocked-001',
-                },
+                outcome: 'blocked',
+                message:
+                  'Lending transaction execution request was blocked by Shared Ember: reserved capital is still claimed by another agent.',
               },
             },
           },
@@ -1049,12 +1156,12 @@ describe('agent-ember-lending AG-UI integration', () => {
       if (request.method === 'subagent.requestTransactionExecution.v1') {
         return {
           jsonrpc: '2.0',
-          id: 'shared-ember-thread-1-execute-transaction-plan',
+          id: 'shared-ember-thread-1-request-transaction-execution',
           result: {
             protocol_version: 'v1',
             revision: 9,
             committed_event_ids: ['evt-execution-denied-1'],
-            execution_result: createBlockedExecutionResult({
+            execution_result: createBlockedPreparationResult({
               result: 'denied',
               requestId: 'req-ember-lending-denied-001',
               message: 'risk policy denied the requested lending path',
@@ -1107,11 +1214,9 @@ describe('agent-ember-lending AG-UI integration', () => {
               data: {
                 type: 'shared-ember-execution-result',
                 revision: 9,
-                executionResult: {
-                  phase: 'blocked',
-                  transaction_plan_id: 'txplan-ember-lending-001',
-                  request_id: 'req-ember-lending-denied-001',
-                },
+                outcome: 'denied',
+                message:
+                  'Lending transaction execution request was denied by Shared Ember: risk policy denied the requested lending path.',
               },
             },
           },
@@ -1167,7 +1272,6 @@ describe('agent-ember-lending AG-UI integration', () => {
         params: expect.objectContaining({
           handoff: expect.objectContaining({
             agent_id: 'ember-lending',
-            agent_wallet: '0x00000000000000000000000000000000000000b1',
             mandate_ref: 'mandate-ember-lending-001',
           }),
           result: expect.objectContaining({

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
@@ -4,6 +4,10 @@ import type {
 
 import { createEmberLendingDomain, type EmberLendingLifecycleState } from './sharedEmberAdapter.js';
 import {
+  createEmberLendingLocalOwsExecutionSigner,
+  resolveEmberLendingLocalOwsBaseUrl,
+} from './localOwsExecutionSigner.js';
+import {
   createEmberLendingSharedEmberHttpHost,
   resolveEmberLendingSharedEmberBaseUrl,
 } from './sharedEmberHttpHost.js';
@@ -18,6 +22,7 @@ export type EmberLendingGatewayEnv = NodeJS.ProcessEnv & {
   EMBER_LENDING_MODEL?: string;
   DATABASE_URL?: string;
   SHARED_EMBER_BASE_URL?: string;
+  EMBER_LENDING_OWS_BASE_URL?: string;
 };
 
 type EmberLendingAgentRuntimeOptions = CreateAgentRuntimeOptions<EmberLendingLifecycleState>;
@@ -67,9 +72,15 @@ export function createEmberLendingAgentConfig(
   const apiKey = requireEnvValue(env.OPENROUTER_API_KEY, 'OPENROUTER_API_KEY');
   const modelId = env.EMBER_LENDING_MODEL?.trim() || DEFAULT_EMBER_LENDING_MODEL;
   const sharedEmberBaseUrl = resolveEmberLendingSharedEmberBaseUrl(env);
+  const localOwsBaseUrl = resolveEmberLendingLocalOwsBaseUrl(env);
   const protocolHost = sharedEmberBaseUrl
     ? createEmberLendingSharedEmberHttpHost({
         baseUrl: sharedEmberBaseUrl,
+      })
+    : undefined;
+  const executionSigner = localOwsBaseUrl
+    ? createEmberLendingLocalOwsExecutionSigner({
+        baseUrl: localOwsBaseUrl,
       })
     : undefined;
 
@@ -80,6 +91,7 @@ export function createEmberLendingAgentConfig(
     tools: [],
     domain: createEmberLendingDomain({
       protocolHost,
+      executionSigner,
     }),
     agentOptions: {
       initialState: {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.ts
@@ -1,0 +1,82 @@
+import type { EmberLendingExecutionSigner } from './sharedEmberAdapter.js';
+
+const jsonContentType = 'application/json; charset=utf-8';
+
+type EmberLendingLocalOwsSignerEnv = NodeJS.ProcessEnv & {
+  EMBER_LENDING_OWS_BASE_URL?: string;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readErrorMessage(body: unknown): string | null {
+  if (!isRecord(body)) {
+    return null;
+  }
+
+  const message = body['message'];
+  return typeof message === 'string' && message.trim().length > 0 ? message : null;
+}
+
+async function postJson(input: {
+  url: string;
+  body: unknown;
+}): Promise<unknown> {
+  const response = await fetch(input.url, {
+    method: 'POST',
+    headers: {
+      'content-type': jsonContentType,
+    },
+    body: JSON.stringify(input.body),
+  });
+
+  const rawBody = await response.text();
+  const parsedBody = rawBody.length === 0 ? null : (JSON.parse(rawBody) as unknown);
+
+  if (!response.ok) {
+    throw new Error(`Local OWS signer HTTP request failed with status ${response.status}.`);
+  }
+
+  const errorMessage = readErrorMessage(parsedBody);
+  if (errorMessage) {
+    throw new Error(`Local OWS signer error: ${errorMessage}`);
+  }
+
+  return parsedBody;
+}
+
+export function resolveEmberLendingLocalOwsBaseUrl(
+  env: EmberLendingLocalOwsSignerEnv = process.env,
+): string | null {
+  const normalized = env['EMBER_LENDING_OWS_BASE_URL']?.trim();
+  return normalized ? trimTrailingSlash(normalized) : null;
+}
+
+export function createEmberLendingLocalOwsExecutionSigner(input: {
+  baseUrl: string;
+}): EmberLendingExecutionSigner {
+  const baseUrl = trimTrailingSlash(input.baseUrl);
+
+  return {
+    async signExecutionPackage(request) {
+      return (await postJson({
+        url: `${baseUrl}/sign/execution`,
+        body: request,
+      })) as Awaited<ReturnType<EmberLendingExecutionSigner['signExecutionPackage']>>;
+    },
+
+    async signRedelegationPackage(request) {
+      return (await postJson({
+        url: `${baseUrl}/sign/redelegation`,
+        body: request,
+      })) as Awaited<
+        ReturnType<NonNullable<EmberLendingExecutionSigner['signRedelegationPackage']>>
+      >;
+    },
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.unit.test.ts
@@ -1,0 +1,209 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createEmberLendingLocalOwsExecutionSigner,
+  resolveEmberLendingLocalOwsBaseUrl,
+} from './localOwsExecutionSigner.js';
+
+async function readRequestBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString());
+}
+
+describe('createEmberLendingLocalOwsExecutionSigner', () => {
+  let server: Server;
+  let baseUrl: string;
+  let responseStatus: number;
+  let responseBody: unknown;
+
+  beforeEach(async () => {
+    responseStatus = 200;
+    responseBody = null;
+    server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      void (async () => {
+        if (request.url !== '/sign/execution' && request.url !== '/sign/redelegation') {
+          response.writeHead(404);
+          response.end();
+          return;
+        }
+
+        response.writeHead(responseStatus, {
+          'content-type': 'application/json; charset=utf-8',
+        });
+        response.end(
+          JSON.stringify(
+            responseBody ?? {
+              ok: true,
+              path: request.url,
+              received: await readRequestBody(request),
+            },
+          ),
+        );
+      })().catch((error: unknown) => {
+        response.writeHead(500);
+        response.end(error instanceof Error ? error.message : 'unknown error');
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}/`;
+  });
+
+  afterEach(async () => {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  });
+
+  it('posts execution and redelegation signing payloads to the local OWS endpoints and trims trailing slashes', async () => {
+    const signer = createEmberLendingLocalOwsExecutionSigner({
+      baseUrl,
+    });
+
+    await expect(
+      signer.signExecutionPackage({
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        executionSigningPackage: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+        },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      path: '/sign/execution',
+      received: {
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        executionSigningPackage: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+        },
+      },
+    });
+
+    await expect(
+      signer.signRedelegationPackage({
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        redelegationSigningPackage: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          redelegation_intent_id: 'reintent-ember-lending-001',
+          active_delegation_id: 'del-ember-lending-001',
+          delegation_id: 'del-ember-lending-002',
+          delegation_plan_id: 'plan-ember-lending-002',
+          root_delegation_id: 'root-user-ember-lending-001',
+          root_delegation_artifact_ref: 'artifact-root-ember-lending-001',
+          delegator_address: '0x00000000000000000000000000000000000000a1',
+          agent_id: 'ember-lending',
+          agent_wallet: '0x00000000000000000000000000000000000000b1',
+          network: 'arbitrum',
+          reservation_ids: ['reservation-ember-lending-001'],
+          unit_ids: ['unit-ember-lending-001'],
+          control_paths: ['lending.supply'],
+          zero_capacity: false,
+          policy_snapshot_ref: 'pol-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+        },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      path: '/sign/redelegation',
+      received: {
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        redelegationSigningPackage: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          redelegation_intent_id: 'reintent-ember-lending-001',
+          active_delegation_id: 'del-ember-lending-001',
+          delegation_id: 'del-ember-lending-002',
+          delegation_plan_id: 'plan-ember-lending-002',
+          root_delegation_id: 'root-user-ember-lending-001',
+          root_delegation_artifact_ref: 'artifact-root-ember-lending-001',
+          delegator_address: '0x00000000000000000000000000000000000000a1',
+          agent_id: 'ember-lending',
+          agent_wallet: '0x00000000000000000000000000000000000000b1',
+          network: 'arbitrum',
+          reservation_ids: ['reservation-ember-lending-001'],
+          unit_ids: ['unit-ember-lending-001'],
+          control_paths: ['lending.supply'],
+          zero_capacity: false,
+          policy_snapshot_ref: 'pol-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+        },
+      },
+    });
+  });
+
+  it('throws when the local OWS signer returns an application error payload with HTTP 200', async () => {
+    responseBody = {
+      message: 'execution signer unavailable',
+    };
+
+    const signer = createEmberLendingLocalOwsExecutionSigner({
+      baseUrl,
+    });
+
+    await expect(
+      signer.signExecutionPackage({
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        executionSigningPackage: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+        },
+      }),
+    ).rejects.toThrow('execution signer unavailable');
+  });
+
+  it('normalizes the optional local OWS base URL from env', () => {
+    expect(
+      resolveEmberLendingLocalOwsBaseUrl({
+        EMBER_LENDING_OWS_BASE_URL: 'http://127.0.0.1:4020/',
+      }),
+    ).toBe('http://127.0.0.1:4020');
+    expect(resolveEmberLendingLocalOwsBaseUrl({})).toBeNull();
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
@@ -466,7 +466,8 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
               status: 'confirmed',
             },
           },
-          lastExecutionTxHash: null,
+          lastExecutionTxHash:
+            '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
         },
         outputs: {
           status: {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
@@ -22,6 +22,19 @@ type SignerRequestRecord = {
   body: Record<string, unknown>;
 };
 
+type ForwardedJsonResponse = {
+  status: number;
+  rawBody: string;
+  parsedBody: unknown;
+};
+
+type InterruptedSubmitProxy = {
+  baseUrl: string;
+  close: () => Promise<void>;
+  submitAttempts: Record<string, unknown>[];
+  interruptedSubmitResponse: unknown | null;
+};
+
 function createManagedLifecycleState() {
   return {
     phase: 'active' as const,
@@ -102,6 +115,98 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function forwardJsonRequest(input: {
+  targetBaseUrl: string;
+  requestPath: string;
+  body: Record<string, unknown>;
+}): Promise<ForwardedJsonResponse> {
+  const response = await fetch(`${input.targetBaseUrl}${input.requestPath}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(input.body),
+  });
+
+  const rawBody = await response.text();
+
+  return {
+    status: response.status,
+    rawBody,
+    parsedBody: rawBody.length === 0 ? null : (JSON.parse(rawBody) as unknown),
+  };
+}
+
+async function startInterruptedSubmitProxy(input: {
+  targetBaseUrl: string;
+}): Promise<InterruptedSubmitProxy> {
+  const submitAttempts: Record<string, unknown>[] = [];
+  let interruptedSubmitResponse: unknown | null = null;
+
+  const proxyServer = createServer((request: IncomingMessage, response: ServerResponse) => {
+    void (async () => {
+      const requestPath = request.url ?? '/jsonrpc';
+      const body = await readRequestBody(request);
+      const forwarded = await forwardJsonRequest({
+        targetBaseUrl: input.targetBaseUrl,
+        requestPath,
+        body,
+      });
+
+      if (requestPath === '/jsonrpc' && body['method'] === 'subagent.submitSignedTransaction.v1') {
+        submitAttempts.push(body);
+
+        if (submitAttempts.length === 1) {
+          interruptedSubmitResponse = forwarded.parsedBody;
+          response.destroy();
+          return;
+        }
+      }
+
+      response.writeHead(forwarded.status, {
+        'content-type': 'application/json; charset=utf-8',
+      });
+      response.end(forwarded.rawBody);
+    })().catch((error: unknown) => {
+      response.writeHead(500);
+      response.end(error instanceof Error ? error.message : 'unknown error');
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    proxyServer.once('error', reject);
+    proxyServer.listen(0, '127.0.0.1', () => {
+      proxyServer.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = proxyServer.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => closeServer(proxyServer),
+    submitAttempts,
+    get interruptedSubmitResponse() {
+      return interruptedSubmitResponse;
+    },
+  };
+}
+
 describeSharedEmberIntegration('ember-lending Shared Ember execution integration', () => {
   let target: StartedSharedEmberTarget;
   let signerServer: Server;
@@ -179,18 +284,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
   });
 
   afterEach(async () => {
-    signerServer.closeAllConnections?.();
-    await new Promise<void>((resolve, reject) => {
-      signerServer.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve();
-      });
-    });
-
+    await closeServer(signerServer);
     await target?.close();
   });
 
@@ -301,5 +395,103 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
         canonical_unsigned_payload_ref: expect.any(String),
       },
     });
+  });
+
+  it('resumes after a dropped submit response without duplicate local signing or duplicate upstream submission', async () => {
+    const proxy = await startInterruptedSubmitProxy({
+      targetBaseUrl: target.baseUrl,
+    });
+
+    try {
+      const protocolHost = createEmberLendingSharedEmberHttpHost({
+        baseUrl: proxy.baseUrl,
+      });
+      const executionSigner = createEmberLendingLocalOwsExecutionSigner({
+        baseUrl: signerBaseUrl,
+      });
+      const domain = createEmberLendingDomain({
+        protocolHost,
+        executionSigner,
+        agentId: TEST_EMBER_LENDING_AGENT_ID,
+      });
+      const threadId = 'thread-ember-lending-int-transport-retry';
+      const executionInput = {
+        idempotencyKey: 'idem-execute-transaction-plan-ember-int-transport-retry',
+      };
+
+      const planResult = await domain.handleOperation?.({
+        threadId,
+        state: createManagedLifecycleState(),
+        operation: {
+          source: 'tool',
+          name: 'create_transaction_plan',
+          input: createCandidatePlanInput(),
+        },
+      });
+
+      const interruptedResult = await domain.handleOperation?.({
+        threadId,
+        state: planResult?.state,
+        operation: {
+          source: 'tool',
+          name: 'request_transaction_execution',
+          input: executionInput,
+        },
+      });
+
+      expect(interruptedResult).toMatchObject({
+        outputs: {
+          status: {
+            executionStatus: 'failed',
+          },
+        },
+      });
+
+      const resumedResult = await domain.handleOperation?.({
+        threadId,
+        state: interruptedResult?.state,
+        operation: {
+          source: 'tool',
+          name: 'request_transaction_execution',
+          input: executionInput,
+        },
+      });
+
+      expect(resumedResult).toMatchObject({
+        state: {
+          phase: 'active',
+          lastExecutionResult: {
+            phase: 'completed',
+            execution: {
+              status: 'confirmed',
+            },
+          },
+          lastExecutionTxHash: null,
+        },
+        outputs: {
+          status: {
+            executionStatus: 'completed',
+            statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+          },
+        },
+      });
+
+      expect(proxy.submitAttempts).toHaveLength(1);
+      expect(proxy.interruptedSubmitResponse).toMatchObject({
+        result: {
+          execution_result: {
+            execution: {
+              status: 'confirmed',
+            },
+          },
+        },
+      });
+      expect(signerRequests.map((entry) => entry.path)).toEqual([
+        '/sign/redelegation',
+        '/sign/execution',
+      ]);
+    } finally {
+      await proxy.close();
+    }
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
@@ -1,0 +1,305 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createEmberLendingLocalOwsExecutionSigner } from './localOwsExecutionSigner.js';
+import { createEmberLendingDomain } from './sharedEmberAdapter.js';
+import {
+  resolveSharedEmberTarget,
+  TEST_EMBER_LENDING_AGENT_ID,
+  TEST_EMBER_LENDING_AGENT_WALLET,
+  TEST_EMBER_LENDING_USER_WALLET,
+  type StartedSharedEmberTarget,
+} from './sharedEmberIntegrationHarness.js';
+import { createEmberLendingSharedEmberHttpHost } from './sharedEmberHttpHost.js';
+
+const runSharedEmberIntegration = process.env['RUN_SHARED_EMBER_INT']?.trim() === '1';
+const describeSharedEmberIntegration = runSharedEmberIntegration ? describe : describe.skip;
+
+type SignerRequestRecord = {
+  path: string;
+  body: Record<string, unknown>;
+};
+
+function createManagedLifecycleState() {
+  return {
+    phase: 'active' as const,
+    mandateRef: 'mandate-ember-lending-001',
+    mandateSummary: 'unwind the managed lending position and return capital',
+    mandateContext: {
+      network: 'arbitrum',
+      protocol: 'aave',
+    },
+    walletAddress: TEST_EMBER_LENDING_AGENT_WALLET,
+    rootUserWalletAddress: TEST_EMBER_LENDING_USER_WALLET,
+    rootedWalletContextId: 'rwc-ember-lending-001',
+    lastPortfolioState: {
+      agent_id: TEST_EMBER_LENDING_AGENT_ID,
+      owned_units: [
+        {
+          unit_id: 'unit-ember-lending-001',
+          root_asset: 'USDC',
+          quantity: '10',
+          reservation_id: 'reservation-ember-lending-001',
+        },
+      ],
+      reservations: [
+        {
+          reservation_id: 'reservation-ember-lending-001',
+          purpose: 'unwind',
+          control_path: 'vault.withdraw',
+        },
+      ],
+    },
+    lastSharedEmberRevision: 0,
+    lastReservationSummary:
+      'Reservation reservation-ember-lending-001 unwinds 10 USDC via vault.withdraw.',
+    lastCandidatePlan: null,
+    lastCandidatePlanSummary: null,
+    lastExecutionResult: null,
+    lastExecutionTxHash: null,
+    lastEscalationRequest: null,
+    lastEscalationSummary: null,
+  };
+}
+
+function createCandidatePlanInput() {
+  return {
+    idempotencyKey: 'idem-candidate-plan-ember-int-001',
+    intent: 'unwind',
+    action_summary: 'withdraw the active lending position and return capital',
+    candidate_unit_ids: ['unit-ember-lending-001'],
+    requested_quantities: [
+      {
+        unit_id: 'unit-ember-lending-001',
+        quantity: '10',
+      },
+    ],
+    decision_context: {
+      objective_summary: 'free the reserved capital for the user',
+      accounting_state_summary:
+        'the reserved unit remains associated with the current delegation',
+      why_this_path_is_best:
+        'vault.withdraw is the direct path to unwind the managed position',
+      consequence_if_delayed: 'the capital remains trapped in the active position',
+      alternatives_considered: ['wait for a later retry'],
+    },
+  };
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+describeSharedEmberIntegration('ember-lending Shared Ember execution integration', () => {
+  let target: StartedSharedEmberTarget;
+  let signerServer: Server;
+  let signerBaseUrl: string;
+  let signerRequests: SignerRequestRecord[];
+
+  beforeEach(async () => {
+    target = await resolveSharedEmberTarget();
+    signerRequests = [];
+
+    signerServer = createServer((request: IncomingMessage, response: ServerResponse) => {
+      void (async () => {
+        if (request.url !== '/sign/redelegation' && request.url !== '/sign/execution') {
+          response.writeHead(404);
+          response.end();
+          return;
+        }
+
+        const body = await readRequestBody(request);
+        signerRequests.push({
+          path: request.url,
+          body,
+        });
+
+        if (request.url === '/sign/redelegation') {
+          const signingPackage = isRecord(body['redelegationSigningPackage'])
+            ? body['redelegationSigningPackage']
+            : {};
+
+          response.writeHead(200, {
+            'content-type': 'application/json; charset=utf-8',
+          });
+          response.end(
+            JSON.stringify({
+              signer_wallet_address: body['walletAddress'],
+              signed_redelegation: {
+                ...signingPackage,
+                artifact_ref: 'artifact-ember-lending-int-002',
+                issued_at: '2026-04-01T06:16:00Z',
+                activated_at: '2026-04-01T06:16:05Z',
+                policy_hash: 'hash-ember-lending-int-002',
+              },
+            }),
+          );
+          return;
+        }
+
+        response.writeHead(200, {
+          'content-type': 'application/json; charset=utf-8',
+        });
+        response.end(
+          JSON.stringify({
+            signer_wallet_address: body['walletAddress'],
+            signer_address: body['walletAddress'],
+            raw_transaction:
+              '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          }),
+        );
+      })().catch((error: unknown) => {
+        response.writeHead(500);
+        response.end(error instanceof Error ? error.message : 'unknown error');
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      signerServer.once('error', reject);
+      signerServer.listen(0, '127.0.0.1', () => {
+        signerServer.off('error', reject);
+        resolve();
+      });
+    });
+
+    const address = signerServer.address() as AddressInfo;
+    signerBaseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    signerServer.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) => {
+      signerServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+
+    await target?.close();
+  });
+
+  it('executes the real Shared Ember request, redelegation registration, and signed-transaction flow through the lending agent service', async () => {
+    const protocolHost = createEmberLendingSharedEmberHttpHost({
+      baseUrl: target.baseUrl,
+    });
+    const executionSigner = createEmberLendingLocalOwsExecutionSigner({
+      baseUrl: signerBaseUrl,
+    });
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: TEST_EMBER_LENDING_AGENT_ID,
+    });
+
+    const planResult = await domain.handleOperation?.({
+      threadId: 'thread-ember-lending-int-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    expect(planResult).toMatchObject({
+      state: {
+        phase: 'active',
+        lastCandidatePlan: {
+          transaction_plan_id: expect.any(String),
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Candidate lending plan created through the Shared Ember planner.',
+        },
+      },
+    });
+
+    const executeResult = await domain.handleOperation?.({
+      threadId: 'thread-ember-lending-int-1',
+      state: planResult?.state,
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executeResult).toMatchObject({
+      state: {
+        phase: 'active',
+        lastExecutionResult: {
+          phase: 'completed',
+          execution: {
+            status: 'confirmed',
+          },
+        },
+        lastExecutionTxHash:
+          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-execution-result',
+              outcome: 'confirmed',
+              transactionHash:
+                '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(signerRequests.map((entry) => entry.path)).toEqual([
+      '/sign/redelegation',
+      '/sign/execution',
+    ]);
+
+    const transactionPlanId =
+      (isRecord(planResult?.state?.lastCandidatePlan)
+        ? planResult?.state?.lastCandidatePlan['transaction_plan_id']
+        : null) ?? null;
+
+    expect(signerRequests[0]?.body).toMatchObject({
+      walletAddress: TEST_EMBER_LENDING_AGENT_WALLET,
+      transactionPlanId,
+      requestId: expect.any(String),
+      redelegationSigningPackage: {
+        agent_wallet: TEST_EMBER_LENDING_AGENT_WALLET,
+        transaction_plan_id: transactionPlanId,
+      },
+    });
+
+    expect(signerRequests[1]?.body).toMatchObject({
+      walletAddress: TEST_EMBER_LENDING_AGENT_WALLET,
+      transactionPlanId,
+      requestId: expect.any(String),
+      executionSigningPackage: {
+        transaction_plan_id: transactionPlanId,
+        active_delegation_id: expect.any(String),
+        canonical_unsigned_payload_ref: expect.any(String),
+      },
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createEmberLendingLocalOwsExecutionSigner } from './localOwsExecutionSigner.js';
 import { createEmberLendingDomain } from './sharedEmberAdapter.js';
 import {
+  createSharedEmberExecutionSeed,
   resolveSharedEmberTarget,
   TEST_EMBER_LENDING_AGENT_ID,
   TEST_EMBER_LENDING_AGENT_WALLET,
@@ -33,6 +34,12 @@ type InterruptedSubmitProxy = {
   close: () => Promise<void>;
   submitAttempts: Record<string, unknown>[];
   interruptedSubmitResponse: unknown | null;
+};
+
+type AuthorityPreparationRecoveryProxy = {
+  baseUrl: string;
+  close: () => Promise<void>;
+  preparationPhases: string[];
 };
 
 function createManagedLifecycleState() {
@@ -207,6 +214,95 @@ async function startInterruptedSubmitProxy(input: {
   };
 }
 
+async function startAuthorityPreparationRecoveryProxy(input: {
+  targetBaseUrl: string;
+}): Promise<AuthorityPreparationRecoveryProxy> {
+  const preparationPhases: string[] = [];
+  let repairedAuthority = false;
+
+  const proxyServer = createServer((request: IncomingMessage, response: ServerResponse) => {
+    void (async () => {
+      const requestPath = request.url ?? '/jsonrpc';
+      const body = await readRequestBody(request);
+      const forwarded = await forwardJsonRequest({
+        targetBaseUrl: input.targetBaseUrl,
+        requestPath,
+        body,
+      });
+
+      if (requestPath === '/jsonrpc' && body['method'] === 'subagent.requestTransactionExecution.v1') {
+        const parsedBody = isRecord(forwarded.parsedBody) ? forwarded.parsedBody : null;
+        const result = parsedBody && isRecord(parsedBody['result']) ? parsedBody['result'] : null;
+        const executionResult = result && isRecord(result['execution_result']) ? result['execution_result'] : null;
+        const phase = executionResult ? executionResult['phase'] : null;
+
+        if (typeof phase === 'string') {
+          preparationPhases.push(phase);
+        }
+
+        if (
+          phase === 'authority_preparation_needed' &&
+          !repairedAuthority &&
+          typeof result?.['revision'] === 'number'
+        ) {
+          repairedAuthority = true;
+
+          await forwardJsonRequest({
+            targetBaseUrl: input.targetBaseUrl,
+            requestPath: '/jsonrpc',
+            body: {
+              jsonrpc: '2.0',
+              id: 'authority-preparation-repair-identity',
+              method: 'orchestrator.writeAgentServiceIdentity.v1',
+              params: {
+                idempotency_key: 'idem-authority-preparation-repair-identity',
+                expected_revision: result['revision'],
+                agent_service_identity: {
+                  identity_ref: 'agent-identity-ember-lending-repaired-001',
+                  agent_id: TEST_EMBER_LENDING_AGENT_ID,
+                  role: 'subagent',
+                  wallet_address: TEST_EMBER_LENDING_AGENT_WALLET,
+                  wallet_source: 'ember_local_write',
+                  capability_metadata: {
+                    execution: true,
+                    onboarding: true,
+                  },
+                  registration_version: 2,
+                  registered_at: '2026-04-01T06:15:00Z',
+                },
+              },
+            },
+          });
+        }
+      }
+
+      response.writeHead(forwarded.status, {
+        'content-type': 'application/json; charset=utf-8',
+      });
+      response.end(forwarded.rawBody);
+    })().catch((error: unknown) => {
+      response.writeHead(500);
+      response.end(error instanceof Error ? error.message : 'unknown error');
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    proxyServer.once('error', reject);
+    proxyServer.listen(0, '127.0.0.1', () => {
+      proxyServer.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = proxyServer.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => closeServer(proxyServer),
+    preparationPhases,
+  };
+}
+
 describeSharedEmberIntegration('ember-lending Shared Ember execution integration', () => {
   let target: StartedSharedEmberTarget;
   let signerServer: Server;
@@ -285,7 +381,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
 
   afterEach(async () => {
     await closeServer(signerServer);
-    await target?.close();
+    await target?.close().catch(() => undefined);
   });
 
   it('executes the real Shared Ember request, redelegation registration, and signed-transaction flow through the lending agent service', async () => {
@@ -395,6 +491,158 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
         canonical_unsigned_payload_ref: expect.any(String),
       },
     });
+  });
+
+  it('surfaces a repo-backed blocked execution result without signing or submitting', async () => {
+    await target.close();
+    target = await resolveSharedEmberTarget({
+      bootstrap: {
+        initialState: createSharedEmberExecutionSeed({
+          competingReservation: true,
+        }),
+      },
+    });
+
+    const protocolHost = createEmberLendingSharedEmberHttpHost({
+      baseUrl: target.baseUrl,
+    });
+    const executionSigner = createEmberLendingLocalOwsExecutionSigner({
+      baseUrl: signerBaseUrl,
+    });
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: TEST_EMBER_LENDING_AGENT_ID,
+    });
+
+    const planResult = await domain.handleOperation?.({
+      threadId: 'thread-ember-lending-int-blocked-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    const executeResult = await domain.handleOperation?.({
+      threadId: 'thread-ember-lending-int-blocked-1',
+      state: planResult?.state,
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executeResult).toMatchObject({
+      state: {
+        phase: 'active',
+        lastExecutionResult: {
+          phase: 'blocked',
+          request_result: {
+            result: 'needs_release_or_transfer',
+            blocking_reason_code: 'reserved_for_other_agent',
+          },
+        },
+        lastExecutionTxHash: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending transaction execution request was blocked by Shared Ember: another agent currently holds the controlling reservation.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-execution-result',
+              outcome: 'blocked',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(signerRequests).toEqual([]);
+  });
+
+  it('polls through a repo-backed authority-preparation response before reaching local execution signing', async () => {
+    await target.close();
+    target = await resolveSharedEmberTarget({
+      bootstrap: {
+        initialState: createSharedEmberExecutionSeed({
+          omitAgentServiceIdentity: true,
+        }),
+      },
+    });
+
+    const proxy = await startAuthorityPreparationRecoveryProxy({
+      targetBaseUrl: target.baseUrl,
+    });
+
+    try {
+      const protocolHost = createEmberLendingSharedEmberHttpHost({
+        baseUrl: proxy.baseUrl,
+      });
+      const executionSigner = createEmberLendingLocalOwsExecutionSigner({
+        baseUrl: signerBaseUrl,
+      });
+      const domain = createEmberLendingDomain({
+        protocolHost,
+        executionSigner,
+        agentId: TEST_EMBER_LENDING_AGENT_ID,
+      });
+
+      const planResult = await domain.handleOperation?.({
+        threadId: 'thread-ember-lending-int-authority-prep-1',
+        state: createManagedLifecycleState(),
+        operation: {
+          source: 'tool',
+          name: 'create_transaction_plan',
+          input: createCandidatePlanInput(),
+        },
+      });
+
+      const executeResult = await domain.handleOperation?.({
+        threadId: 'thread-ember-lending-int-authority-prep-1',
+        state: planResult?.state,
+        operation: {
+          source: 'tool',
+          name: 'request_transaction_execution',
+        },
+      });
+
+      expect(executeResult).toMatchObject({
+        state: {
+          phase: 'active',
+          lastExecutionResult: {
+            phase: 'completed',
+            execution: {
+              status: 'confirmed',
+            },
+          },
+          lastExecutionTxHash:
+            '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        },
+        outputs: {
+          status: {
+            executionStatus: 'completed',
+            statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+          },
+        },
+      });
+
+      expect(proxy.preparationPhases).toEqual([
+        'authority_preparation_needed',
+        'ready_for_redelegation',
+      ]);
+      expect(signerRequests.map((entry) => entry.path)).toEqual([
+        '/sign/redelegation',
+        '/sign/execution',
+      ]);
+    } finally {
+      await proxy.close();
+    }
   });
 
   it('resumes after a dropped submit response without duplicate local signing or duplicate upstream submission', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -1302,6 +1302,18 @@ function readTransactionPlanId(
   return null;
 }
 
+function buildExecutionPreparationRequestIdempotencyKey(input: {
+  baseIdempotencyKey: string;
+  attempt: number;
+  priorRevision: number | null;
+}): string {
+  if (input.attempt <= 1) {
+    return input.baseIdempotencyKey;
+  }
+
+  return `${input.baseIdempotencyKey}:await-authority-preparation:${input.priorRevision ?? input.attempt - 1}`;
+}
+
 async function runPreparedExecutionFlow(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
   executionSigner?: EmberLendingExecutionSigner;
@@ -1325,7 +1337,11 @@ async function runPreparedExecutionFlow(input: {
       id: `shared-ember-${input.threadId}-request-transaction-execution`,
       method: 'subagent.requestTransactionExecution.v1',
       params: {
-        idempotency_key: input.idempotencyKey,
+        idempotency_key: buildExecutionPreparationRequestIdempotencyKey({
+          baseIdempotencyKey: input.idempotencyKey,
+          attempt: 1,
+          priorRevision: input.currentState.lastSharedEmberRevision,
+        }),
         expected_revision: expectedRevision,
         transaction_plan_id: input.transactionPlanId,
       },
@@ -1357,7 +1373,11 @@ async function runPreparedExecutionFlow(input: {
         id: `shared-ember-${input.threadId}-request-transaction-execution`,
         method: 'subagent.requestTransactionExecution.v1',
         params: {
-          idempotency_key: input.idempotencyKey,
+          idempotency_key: buildExecutionPreparationRequestIdempotencyKey({
+            baseIdempotencyKey: input.idempotencyKey,
+            attempt: requestAttempts,
+            priorRevision: requestResponse.result?.revision ?? null,
+          }),
           expected_revision: expectedRevision,
           transaction_plan_id: input.transactionPlanId,
         },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -45,6 +45,7 @@ export type EmberLendingLifecycleState = {
   lastCandidatePlanSummary: string | null;
   lastExecutionResult: unknown;
   lastExecutionTxHash: `0x${string}` | null;
+  pendingExecutionSubmission?: PendingExecutionSubmission | null;
   lastEscalationRequest: unknown;
   lastEscalationSummary: string | null;
 };
@@ -102,6 +103,22 @@ type SharedEmberExecutionContextEnvelope = {
   executionContext: NonNullable<SharedEmberExecutionContext>;
 };
 
+type PendingExecutionSubmission = {
+  transactionPlanId: string;
+  requestId: string;
+  idempotencyKey: string;
+  signedTransaction: Record<string, unknown>;
+  revision: number | null;
+};
+
+type SharedEmberCommittedEvent = {
+  sequence?: number;
+  aggregate?: string;
+  aggregate_id?: string;
+  event_type?: string;
+  payload?: Record<string, unknown>;
+};
+
 type PortfolioProjection = Pick<
   EmberLendingLifecycleState,
   | 'mandateRef'
@@ -130,6 +147,18 @@ class LocalExecutionFailureError extends Error {
   }
 }
 
+class PendingExecutionSubmissionError extends Error {
+  revision: number | null;
+  pendingSubmission: PendingExecutionSubmission;
+
+  constructor(message: string, revision: number | null, pendingSubmission: PendingExecutionSubmission) {
+    super(message);
+    this.name = 'PendingExecutionSubmissionError';
+    this.revision = revision;
+    this.pendingSubmission = pendingSubmission;
+  }
+}
+
 function buildDefaultLifecycleState(): EmberLendingLifecycleState {
   return {
     phase: 'prehire',
@@ -146,6 +175,7 @@ function buildDefaultLifecycleState(): EmberLendingLifecycleState {
     lastCandidatePlanSummary: null,
     lastExecutionResult: null,
     lastExecutionTxHash: null,
+    pendingExecutionSubmission: null,
     lastEscalationRequest: null,
     lastEscalationSummary: null,
   };
@@ -740,6 +770,20 @@ function readExecutionRequestResult(executionResult: unknown): Record<string, un
   return executionResult['request_result'];
 }
 
+function readCommittedEvent(value: unknown): SharedEmberCommittedEvent | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    sequence: typeof value['sequence'] === 'number' ? value['sequence'] : undefined,
+    aggregate: readString(value['aggregate']) ?? undefined,
+    aggregate_id: readString(value['aggregate_id']) ?? undefined,
+    event_type: readString(value['event_type']) ?? undefined,
+    payload: isRecord(value['payload']) ? value['payload'] : undefined,
+  };
+}
+
 function ensureSentence(value: string): string {
   return /[.!?]$/.test(value) ? value : `${value}.`;
 }
@@ -1033,6 +1077,64 @@ async function submitSignedTransaction(input: {
     revision: response.result?.revision ?? null,
     committedEventIds: response.result?.committed_event_ids ?? [],
     executionResult: response.result?.execution_result ?? null,
+  };
+}
+
+async function readRecoveredExecutionResultFromOutbox(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  agentId: string;
+  requestId: string;
+}): Promise<{
+  revision: number | null;
+  executionResult: unknown;
+} | null> {
+  const outboxPage = (await input.protocolHost.readCommittedEventOutbox({
+    protocol_version: 'v1',
+    consumer_id: `${input.agentId}-${input.requestId}`,
+    after_sequence: 0,
+    limit: 100,
+  })) as {
+    revision?: number;
+    events?: unknown[];
+  };
+
+  const matchingEvent = (outboxPage.events ?? [])
+    .map((event) => readCommittedEvent(event))
+    .filter((event): event is SharedEmberCommittedEvent => event !== null)
+    .filter(
+      (event) =>
+        event.aggregate === 'request' &&
+        event.aggregate_id === input.requestId &&
+        (event.event_type === 'requestExecution.submitted.v1' ||
+          event.event_type === 'requestExecution.completed.v1'),
+    )
+    .sort((left, right) => (left.sequence ?? 0) - (right.sequence ?? 0))
+    .at(-1);
+
+  if (!matchingEvent) {
+    return null;
+  }
+
+  const status = readString(matchingEvent.payload?.['status']);
+  const executionId = readString(matchingEvent.payload?.['execution_id']);
+  const transactionPlanId = readString(matchingEvent.payload?.['transaction_plan_id']);
+  const requestId = readString(matchingEvent.payload?.['request_id']);
+
+  if (!status || !transactionPlanId || !requestId) {
+    return null;
+  }
+
+  return {
+    revision: outboxPage.revision ?? null,
+    executionResult: {
+      phase: 'completed',
+      request_id: requestId,
+      transaction_plan_id: transactionPlanId,
+      execution: {
+        status,
+        ...(executionId ? { execution_id: executionId } : {}),
+      },
+    },
   };
 }
 
@@ -1381,6 +1483,12 @@ async function runPreparedExecutionFlow(input: {
     );
   }
 
+  const signedTransaction = {
+    ...readExecutionSigningPackage(executionResult)!,
+    signer_address: signerAddress,
+    raw_transaction: rawTransaction,
+  };
+
   const submitResponse = await submitSignedTransaction({
     protocolHost: input.protocolHost,
     threadId: input.threadId,
@@ -1389,11 +1497,19 @@ async function runPreparedExecutionFlow(input: {
     transactionPlanId: input.transactionPlanId,
     requestId: requestId!,
     idempotencyKey: input.idempotencyKey,
-    signedTransaction: {
-      ...readExecutionSigningPackage(executionResult)!,
-      signer_address: signerAddress,
-      raw_transaction: rawTransaction,
-    },
+    signedTransaction,
+  }).catch((error: unknown) => {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    throw new PendingExecutionSubmissionError(error.message, requestResponse.result?.revision ?? null, {
+      transactionPlanId: input.transactionPlanId,
+      requestId: requestId!,
+      idempotencyKey: input.idempotencyKey,
+      signedTransaction,
+      revision: requestResponse.result?.revision ?? null,
+    });
   });
 
   return {
@@ -1404,6 +1520,60 @@ async function runPreparedExecutionFlow(input: {
     ],
     executionResult: submitResponse.executionResult,
   };
+}
+
+async function resumePendingExecutionSubmission(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  threadId: string;
+  agentId: string;
+  pendingSubmission: PendingExecutionSubmission;
+}): Promise<{
+  revision: number | null;
+  committedEventIds: string[];
+  executionResult: unknown;
+}> {
+  const recoveredResult = await readRecoveredExecutionResultFromOutbox({
+    protocolHost: input.protocolHost,
+    agentId: input.agentId,
+    requestId: input.pendingSubmission.requestId,
+  });
+
+  if (recoveredResult) {
+    return {
+      revision: recoveredResult.revision,
+      committedEventIds: [],
+      executionResult: recoveredResult.executionResult,
+    };
+  }
+
+  try {
+    const submitResponse = await submitSignedTransaction({
+      protocolHost: input.protocolHost,
+      threadId: input.threadId,
+      agentId: input.agentId,
+      currentRevision: input.pendingSubmission.revision,
+      transactionPlanId: input.pendingSubmission.transactionPlanId,
+      requestId: input.pendingSubmission.requestId,
+      idempotencyKey: input.pendingSubmission.idempotencyKey,
+      signedTransaction: input.pendingSubmission.signedTransaction,
+    });
+
+    return {
+      revision: submitResponse.revision,
+      committedEventIds: submitResponse.committedEventIds,
+      executionResult: submitResponse.executionResult,
+    };
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    throw new PendingExecutionSubmissionError(
+      error.message,
+      input.pendingSubmission.revision,
+      input.pendingSubmission,
+    );
+  }
 }
 
 function readEscalationResult(operationInput: unknown): unknown {
@@ -1694,15 +1864,24 @@ export function createEmberLendingDomain(
             `idem-execute-transaction-plan-${threadId}`;
           let preparedExecutionResult: Awaited<ReturnType<typeof runPreparedExecutionFlow>>;
           try {
-            preparedExecutionResult = await runPreparedExecutionFlow({
-              protocolHost: options.protocolHost,
-              executionSigner: options.executionSigner,
-              threadId,
-              agentId,
-              currentState,
-              transactionPlanId,
-              idempotencyKey,
-            });
+            preparedExecutionResult =
+              currentState.pendingExecutionSubmission?.transactionPlanId === transactionPlanId &&
+              currentState.pendingExecutionSubmission?.idempotencyKey === idempotencyKey
+                ? await resumePendingExecutionSubmission({
+                    protocolHost: options.protocolHost,
+                    threadId,
+                    agentId,
+                    pendingSubmission: currentState.pendingExecutionSubmission,
+                  })
+                : await runPreparedExecutionFlow({
+                    protocolHost: options.protocolHost,
+                    executionSigner: options.executionSigner,
+                    threadId,
+                    agentId,
+                    currentState,
+                    transactionPlanId,
+                    idempotencyKey,
+                  });
           } catch (error) {
             if (!(error instanceof Error)) {
               throw error;
@@ -1713,11 +1892,16 @@ export function createEmberLendingDomain(
                 ...currentState,
                 phase: 'active',
                 lastSharedEmberRevision:
-                  error instanceof LocalExecutionFailureError
+                  error instanceof LocalExecutionFailureError ||
+                  error instanceof PendingExecutionSubmissionError
                     ? error.revision ?? currentState.lastSharedEmberRevision
                     : currentState.lastSharedEmberRevision,
                 lastExecutionResult: currentState.lastExecutionResult,
                 lastExecutionTxHash: null,
+                pendingExecutionSubmission:
+                  error instanceof PendingExecutionSubmissionError
+                    ? error.pendingSubmission
+                    : null,
               },
               outputs: {
                 status: {
@@ -1743,6 +1927,7 @@ export function createEmberLendingDomain(
             lastSharedEmberRevision: preparedExecutionResult.revision,
             lastExecutionResult: executionResult,
             lastExecutionTxHash: readExecutionTxHash(executionResult),
+            pendingExecutionSubmission: null,
           };
 
           return {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -6,6 +6,28 @@ export type EmberLendingSharedEmberProtocolHost = {
   acknowledgeCommittedEventOutbox: (input: unknown) => Promise<unknown>;
 };
 
+export type EmberLendingExecutionSigner = {
+  signRedelegationPackage?: (input: {
+    walletAddress: `0x${string}`;
+    transactionPlanId: string;
+    requestId: string;
+    redelegationSigningPackage: Record<string, unknown>;
+  }) => Promise<{
+    signer_wallet_address?: string;
+    signed_redelegation?: Record<string, unknown>;
+  }>;
+  signExecutionPackage: (input: {
+    walletAddress: `0x${string}`;
+    transactionPlanId: string;
+    requestId: string;
+    executionSigningPackage: Record<string, unknown>;
+  }) => Promise<{
+    signer_wallet_address?: string;
+    signer_address?: string;
+    raw_transaction?: string;
+  }>;
+};
+
 export const EMBER_LENDING_INTERNAL_HYDRATE_COMMAND = 'hydrate_runtime_projection';
 
 export type EmberLendingLifecycleState = {
@@ -29,7 +51,16 @@ export type EmberLendingLifecycleState = {
 
 type CreateEmberLendingDomainOptions = {
   protocolHost?: EmberLendingSharedEmberProtocolHost;
+  executionSigner?: EmberLendingExecutionSigner;
   agentId?: string;
+};
+
+type RequestTransactionExecutionResponse = {
+  result?: {
+    revision?: number;
+    committed_event_ids?: string[];
+    execution_result?: unknown;
+  };
 };
 
 type SharedEmberRevisionResponse = {
@@ -87,6 +118,17 @@ const DIRECT_HIRE_MESSAGE =
 const DIRECT_FIRE_MESSAGE =
   'Use the portfolio manager to deactivate the managed lending agent.';
 const SHARED_EMBER_NETWORK = 'arbitrum';
+const MAX_PREPARE_TRANSACTION_ATTEMPTS = 3;
+
+class LocalExecutionFailureError extends Error {
+  revision: number | null;
+
+  constructor(message: string, revision: number | null) {
+    super(message);
+    this.name = 'LocalExecutionFailureError';
+    this.revision = revision;
+  }
+}
 
 function buildDefaultLifecycleState(): EmberLendingLifecycleState {
   return {
@@ -670,7 +712,16 @@ function readCandidatePlanSummary(candidatePlan: unknown): string | null {
 }
 
 function readExecutionTxHash(executionResult: unknown): `0x${string}` | null {
-  if (!isRecord(executionResult) || !isRecord(executionResult['execution'])) {
+  if (!isRecord(executionResult)) {
+    return null;
+  }
+
+  const topLevel = readHexAddress(executionResult['transaction_hash']);
+  if (topLevel) {
+    return topLevel;
+  }
+
+  if (!isRecord(executionResult['execution'])) {
     return null;
   }
 
@@ -698,6 +749,44 @@ function readExecutionStatusMessage(executionResult: unknown): {
   statusMessage: string;
 } {
   const phase = isRecord(executionResult) ? readString(executionResult['phase']) : null;
+  const execution = readRecordKey(executionResult, 'execution');
+  const status = readString(execution?.['status']);
+
+  if (phase === 'completed' && status === 'confirmed') {
+    return {
+      executionStatus: 'completed',
+      statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+    };
+  }
+
+  if (phase === 'completed' && status === 'submitted') {
+    return {
+      executionStatus: 'completed',
+      statusMessage: 'Lending transaction submitted through Shared Ember.',
+    };
+  }
+
+  if (phase === 'completed' && status === 'failed_before_submission') {
+    return {
+      executionStatus: 'failed',
+      statusMessage: 'Lending transaction failed before submission through Shared Ember.',
+    };
+  }
+
+  if (phase === 'completed' && status === 'failed_after_submission') {
+    return {
+      executionStatus: 'failed',
+      statusMessage: 'Lending transaction failed after submission through Shared Ember.',
+    };
+  }
+
+  if (phase === 'completed' && status === 'partial_settlement') {
+    return {
+      executionStatus: 'failed',
+      statusMessage: 'Lending transaction reached partial settlement through Shared Ember.',
+    };
+  }
+
   if (phase !== 'blocked') {
     return {
       executionStatus: 'completed',
@@ -733,6 +822,50 @@ function readEscalationSummary(escalationRequest: unknown): string | null {
   return `${requestKind} escalation ${requestId} created from blocked lending execution.`;
 }
 
+function readExecutionOutcome(executionResult: unknown): string | null {
+  const phase = readStringKey(executionResult, 'phase');
+  const execution = readRecordKey(executionResult, 'execution');
+  const status = readString(execution?.['status']);
+
+  if (phase === 'completed' && status) {
+    return status;
+  }
+
+  if (phase && phase !== 'blocked') {
+    return phase;
+  }
+
+  const requestOutcome = readString(readExecutionRequestResult(executionResult)?.['result']);
+  return requestOutcome === 'denied' ? 'denied' : 'blocked';
+}
+
+function buildExecutionArtifactData(input: {
+  revision: number | null;
+  executionResult: unknown;
+  executionStatus: 'completed' | 'failed';
+  statusMessage: string;
+}) {
+  return {
+    type: 'shared-ember-execution-result',
+    revision: input.revision,
+    ...(readExecutionOutcome(input.executionResult)
+      ? {
+          outcome: readExecutionOutcome(input.executionResult),
+        }
+      : {}),
+    ...(readExecutionTxHash(input.executionResult)
+      ? {
+          transactionHash: readExecutionTxHash(input.executionResult),
+        }
+      : {}),
+    ...(input.executionStatus === 'failed'
+      ? {
+          message: input.statusMessage,
+        }
+      : {}),
+  };
+}
+
 function readStringKey(
   input: unknown,
   key: string,
@@ -740,9 +873,171 @@ function readStringKey(
   return isRecord(input) ? readString(input[key]) : null;
 }
 
+function readRecordKey(input: unknown, key: string): Record<string, unknown> | null {
+  return isRecord(input) && isRecord(input[key]) ? input[key] : null;
+}
+
+function readExecutionSigningPackage(
+  preparationResult: unknown,
+): Record<string, unknown> | null {
+  return readRecordKey(preparationResult, 'execution_signing_package');
+}
+
+function readExecutionPreparation(
+  executionResult: unknown,
+): Record<string, unknown> | null {
+  return readRecordKey(executionResult, 'execution_preparation');
+}
+
+function readRedelegationSigningPackage(
+  preparationResult: unknown,
+): Record<string, unknown> | null {
+  return readRecordKey(preparationResult, 'redelegation_signing_package');
+}
+
+function readPreparedExecutionWalletAddress(
+  executionResult: unknown,
+): `0x${string}` | null {
+  const executionPreparation = readExecutionPreparation(executionResult);
+  return readHexAddress(executionPreparation?.['agent_wallet']);
+}
+
+function readPreparedRedelegationWalletAddress(
+  executionResult: unknown,
+): `0x${string}` | null {
+  const redelegationSigningPackage = readRedelegationSigningPackage(executionResult);
+  return (
+    readHexAddress(redelegationSigningPackage?.['agent_wallet']) ??
+    readPreparedExecutionWalletAddress(executionResult)
+  );
+}
+
+function hasExecutionSigningPreparation(
+  executionResult: unknown,
+): executionResult is Record<string, unknown> {
+  return (
+    isRecord(executionResult) &&
+    readString(executionResult['phase']) === 'ready_for_execution_signing' &&
+    readString(executionResult['request_id']) !== null &&
+    readString(executionResult['transaction_plan_id']) !== null &&
+    readExecutionPreparation(executionResult) !== null &&
+    readExecutionSigningPackage(executionResult) !== null
+  );
+}
+
+function hasRedelegationSigningPreparation(
+  executionResult: unknown,
+): executionResult is Record<string, unknown> {
+  return (
+    isRecord(executionResult) &&
+    readString(executionResult['phase']) === 'ready_for_redelegation' &&
+    readString(executionResult['request_id']) !== null &&
+    readString(executionResult['transaction_plan_id']) !== null &&
+    readExecutionPreparation(executionResult) !== null &&
+    readRedelegationSigningPackage(executionResult) !== null
+  );
+}
+
+function readSignerWalletAddress(result: unknown): `0x${string}` | null {
+  if (!isRecord(result)) {
+    return null;
+  }
+
+  return readHexAddress(result['signer_wallet_address']) ?? readHexAddress(result['signer_address']);
+}
+
+async function registerSignedRedelegation(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  threadId: string;
+  agentId: string;
+  currentRevision: number | null;
+  transactionPlanId: string;
+  requestId: string;
+  idempotencyKey: string;
+  signedRedelegation: Record<string, unknown>;
+}): Promise<{
+  revision: number | null;
+  committedEventIds: string[];
+  executionResult: unknown;
+}> {
+  const response = await runSharedEmberCommandWithResolvedRevision<{
+    result?: {
+      revision?: number;
+      committed_event_ids?: string[];
+      execution_result?: unknown;
+    };
+  }>({
+    protocolHost: input.protocolHost,
+    threadId: input.threadId,
+    agentId: input.agentId,
+    currentRevision: input.currentRevision,
+    buildRequest: (expectedRevision) => ({
+      jsonrpc: '2.0',
+      id: `shared-ember-${input.threadId}-register-signed-redelegation`,
+      method: 'orchestrator.registerSignedRedelegation.v1',
+      params: {
+        idempotency_key: `${input.idempotencyKey}:register-redelegation:${input.requestId}`,
+        expected_revision: expectedRevision,
+        transaction_plan_id: input.transactionPlanId,
+        signed_redelegation: input.signedRedelegation,
+      },
+    }),
+  });
+
+  return {
+    revision: response.result?.revision ?? null,
+    committedEventIds: response.result?.committed_event_ids ?? [],
+    executionResult: response.result?.execution_result ?? null,
+  };
+}
+
+async function submitSignedTransaction(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  threadId: string;
+  agentId: string;
+  currentRevision: number | null;
+  transactionPlanId: string;
+  requestId: string;
+  idempotencyKey: string;
+  signedTransaction: Record<string, unknown>;
+}): Promise<{
+  revision: number | null;
+  committedEventIds: string[];
+  executionResult: unknown;
+}> {
+  const response = await runSharedEmberCommandWithResolvedRevision<{
+    result?: {
+      revision?: number;
+      committed_event_ids?: string[];
+      execution_result?: unknown;
+    };
+  }>({
+    protocolHost: input.protocolHost,
+    threadId: input.threadId,
+    agentId: input.agentId,
+    currentRevision: input.currentRevision,
+    buildRequest: (expectedRevision) => ({
+      jsonrpc: '2.0',
+      id: `shared-ember-${input.threadId}-submit-signed-transaction`,
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: `${input.idempotencyKey}:submit-transaction:${input.requestId}`,
+        expected_revision: expectedRevision,
+        transaction_plan_id: input.transactionPlanId,
+        signed_transaction: input.signedTransaction,
+      },
+    }),
+  });
+
+  return {
+    revision: response.result?.revision ?? null,
+    committedEventIds: response.result?.committed_event_ids ?? [],
+    executionResult: response.result?.execution_result ?? null,
+  };
+}
+
 function buildManagedSubagentHandoffBase(input: {
   state: EmberLendingLifecycleState;
-  threadId: string;
   agentId: string;
 }): Record<string, unknown> | null {
   if (!input.state.walletAddress || !input.state.rootUserWalletAddress || !input.state.mandateRef) {
@@ -755,7 +1050,6 @@ function buildManagedSubagentHandoffBase(input: {
 
   return {
     agent_id: input.agentId,
-    agent_wallet: input.state.walletAddress,
     root_user_wallet: input.state.rootUserWalletAddress,
     mandate_ref: input.state.mandateRef,
   };
@@ -902,6 +1196,214 @@ function readTransactionPlanId(
   }
 
   return null;
+}
+
+async function runPreparedExecutionFlow(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  executionSigner?: EmberLendingExecutionSigner;
+  threadId: string;
+  agentId: string;
+  currentState: EmberLendingLifecycleState;
+  transactionPlanId: string;
+  idempotencyKey: string;
+}): Promise<{
+  revision: number | null;
+  committedEventIds: string[];
+  executionResult: unknown;
+}> {
+  let requestResponse = await runSharedEmberCommandWithResolvedRevision<RequestTransactionExecutionResponse>({
+    protocolHost: input.protocolHost,
+    threadId: input.threadId,
+    agentId: input.agentId,
+    currentRevision: input.currentState.lastSharedEmberRevision,
+    buildRequest: (expectedRevision) => ({
+      jsonrpc: '2.0',
+      id: `shared-ember-${input.threadId}-request-transaction-execution`,
+      method: 'subagent.requestTransactionExecution.v1',
+      params: {
+        idempotency_key: input.idempotencyKey,
+        expected_revision: expectedRevision,
+        transaction_plan_id: input.transactionPlanId,
+      },
+    }),
+  });
+  let committedEventIds = [...(requestResponse.result?.committed_event_ids ?? [])];
+  let executionResult: unknown = requestResponse.result?.execution_result ?? null;
+  let requestAttempts = 1;
+
+  while (
+    isRecord(executionResult) &&
+    readString(executionResult['phase']) === 'authority_preparation_needed'
+  ) {
+    if (requestAttempts >= MAX_PREPARE_TRANSACTION_ATTEMPTS) {
+      throw new LocalExecutionFailureError(
+        'Lending transaction execution could not continue because Shared Ember did not complete authority preparation.',
+        requestResponse.result?.revision ?? null,
+      );
+    }
+
+    requestAttempts += 1;
+    requestResponse = await runSharedEmberCommandWithResolvedRevision<RequestTransactionExecutionResponse>({
+      protocolHost: input.protocolHost,
+      threadId: input.threadId,
+      agentId: input.agentId,
+      currentRevision: requestResponse.result?.revision ?? null,
+      buildRequest: (expectedRevision) => ({
+        jsonrpc: '2.0',
+        id: `shared-ember-${input.threadId}-request-transaction-execution`,
+        method: 'subagent.requestTransactionExecution.v1',
+        params: {
+          idempotency_key: input.idempotencyKey,
+          expected_revision: expectedRevision,
+          transaction_plan_id: input.transactionPlanId,
+        },
+      }),
+    });
+    committedEventIds.push(...(requestResponse.result?.committed_event_ids ?? []));
+    executionResult = requestResponse.result?.execution_result ?? null;
+  }
+
+  if (hasRedelegationSigningPreparation(executionResult)) {
+    const preparedWalletAddress = readPreparedRedelegationWalletAddress(executionResult);
+    if (!input.currentState.walletAddress || !preparedWalletAddress) {
+      throw new LocalExecutionFailureError(
+        'Lending redelegation signing could not continue because the dedicated subagent wallet identity is incomplete.',
+        requestResponse.result?.revision ?? null,
+      );
+    }
+    if (preparedWalletAddress !== input.currentState.walletAddress) {
+      throw new LocalExecutionFailureError(
+        'Lending redelegation signing could not continue because the prepared signing package does not match the dedicated subagent wallet.',
+        requestResponse.result?.revision ?? null,
+      );
+    }
+    if (!input.executionSigner?.signRedelegationPackage) {
+      throw new LocalExecutionFailureError(
+        'Local OWS signer is not configured for lending transaction execution.',
+        requestResponse.result?.revision ?? null,
+      );
+    }
+
+    const requestId = readString(executionResult['request_id']);
+    const signedRedelegation = await input.executionSigner.signRedelegationPackage({
+      walletAddress: input.currentState.walletAddress,
+      transactionPlanId: input.transactionPlanId,
+      requestId: requestId!,
+      redelegationSigningPackage: readRedelegationSigningPackage(executionResult)!,
+    });
+
+    const signerWalletAddress = readSignerWalletAddress(signedRedelegation);
+    if (!signerWalletAddress || signerWalletAddress !== input.currentState.walletAddress) {
+      throw new LocalExecutionFailureError(
+        'Lending redelegation signing could not continue because the local signer did not confirm the dedicated subagent wallet identity.',
+        requestResponse.result?.revision ?? null,
+      );
+    }
+
+    const signedRedelegationRecord = readRecordKey(signedRedelegation, 'signed_redelegation');
+    if (!signedRedelegationRecord) {
+      throw new LocalExecutionFailureError(
+        'Lending redelegation signing could not continue because the local signer did not return a signed redelegation payload.',
+        requestResponse.result?.revision ?? null,
+      );
+    }
+
+    const redelegationResponse = await registerSignedRedelegation({
+      protocolHost: input.protocolHost,
+      threadId: input.threadId,
+      agentId: input.agentId,
+      currentRevision: requestResponse.result?.revision ?? null,
+      transactionPlanId: input.transactionPlanId,
+      requestId: requestId!,
+      idempotencyKey: input.idempotencyKey,
+      signedRedelegation: signedRedelegationRecord,
+    });
+
+    committedEventIds.push(...redelegationResponse.committedEventIds);
+    executionResult = redelegationResponse.executionResult;
+    requestResponse = {
+      result: {
+        revision: redelegationResponse.revision ?? undefined,
+      },
+    };
+  }
+
+  if (!hasExecutionSigningPreparation(executionResult)) {
+    return {
+      revision: requestResponse.result?.revision ?? null,
+      committedEventIds,
+      executionResult,
+    };
+  }
+
+  const preparedWalletAddress = readPreparedExecutionWalletAddress(executionResult);
+  if (!input.currentState.walletAddress || !preparedWalletAddress) {
+    throw new LocalExecutionFailureError(
+      'Lending execution signing could not continue because the dedicated subagent wallet identity is incomplete.',
+      requestResponse.result?.revision ?? null,
+    );
+  }
+  if (preparedWalletAddress !== input.currentState.walletAddress) {
+    throw new LocalExecutionFailureError(
+      'Lending execution signing could not continue because the prepared signing package does not match the dedicated subagent wallet.',
+      requestResponse.result?.revision ?? null,
+    );
+  }
+
+  const requestId = readString(executionResult['request_id']);
+  if (!input.executionSigner) {
+    throw new LocalExecutionFailureError(
+      'Local OWS signer is not configured for lending transaction execution.',
+      requestResponse.result?.revision ?? null,
+    );
+  }
+  const signedExecution = await input.executionSigner.signExecutionPackage({
+    walletAddress: input.currentState.walletAddress,
+    transactionPlanId: input.transactionPlanId,
+    requestId: requestId!,
+    executionSigningPackage: readExecutionSigningPackage(executionResult)!,
+  });
+
+  const signerWalletAddress = readSignerWalletAddress(signedExecution);
+  if (!signerWalletAddress || signerWalletAddress !== input.currentState.walletAddress) {
+    throw new LocalExecutionFailureError(
+      'Lending execution signing could not continue because the local signer did not confirm the dedicated subagent wallet identity.',
+      requestResponse.result?.revision ?? null,
+    );
+  }
+
+  const signerAddress = readHexAddress(signedExecution.signer_address) ?? signerWalletAddress;
+  const rawTransaction = readString(signedExecution.raw_transaction);
+  if (!signerAddress || !rawTransaction) {
+    throw new LocalExecutionFailureError(
+      'Lending execution signing could not continue because the local signer did not return a signed transaction payload.',
+      requestResponse.result?.revision ?? null,
+    );
+  }
+
+  const submitResponse = await submitSignedTransaction({
+    protocolHost: input.protocolHost,
+    threadId: input.threadId,
+    agentId: input.agentId,
+    currentRevision: requestResponse.result?.revision ?? null,
+    transactionPlanId: input.transactionPlanId,
+    requestId: requestId!,
+    idempotencyKey: input.idempotencyKey,
+    signedTransaction: {
+      ...readExecutionSigningPackage(executionResult)!,
+      signer_address: signerAddress,
+      raw_transaction: rawTransaction,
+    },
+  });
+
+  return {
+    revision: submitResponse.revision,
+    committedEventIds: [
+      ...committedEventIds,
+      ...submitResponse.committedEventIds,
+    ],
+    executionResult: submitResponse.executionResult,
+  };
 }
 
 function readEscalationResult(operationInput: unknown): unknown {
@@ -1190,30 +1692,43 @@ export function createEmberLendingDomain(
           const idempotencyKey =
             readStringKey(operation.input, 'idempotencyKey') ??
             `idem-execute-transaction-plan-${threadId}`;
-          const response = await runSharedEmberCommandWithResolvedRevision<{
-            result?: {
-              revision?: number;
-              committed_event_ids?: string[];
-              execution_result?: unknown;
-            };
-          }>({
-            protocolHost: options.protocolHost,
-            threadId,
-            agentId,
-            currentRevision: currentState.lastSharedEmberRevision,
-            buildRequest: (expectedRevision) => ({
-              jsonrpc: '2.0',
-              id: `shared-ember-${threadId}-execute-transaction-plan`,
-              method: 'subagent.requestTransactionExecution.v1',
-              params: {
-                idempotency_key: idempotencyKey,
-                expected_revision: expectedRevision,
-                transaction_plan_id: transactionPlanId,
-              },
-            }),
-          });
+          let preparedExecutionResult: Awaited<ReturnType<typeof runPreparedExecutionFlow>>;
+          try {
+            preparedExecutionResult = await runPreparedExecutionFlow({
+              protocolHost: options.protocolHost,
+              executionSigner: options.executionSigner,
+              threadId,
+              agentId,
+              currentState,
+              transactionPlanId,
+              idempotencyKey,
+            });
+          } catch (error) {
+            if (!(error instanceof Error)) {
+              throw error;
+            }
 
-          const executionResult = response.result?.execution_result ?? null;
+            return {
+              state: {
+                ...currentState,
+                phase: 'active',
+                lastSharedEmberRevision:
+                  error instanceof LocalExecutionFailureError
+                    ? error.revision ?? currentState.lastSharedEmberRevision
+                    : currentState.lastSharedEmberRevision,
+                lastExecutionResult: currentState.lastExecutionResult,
+                lastExecutionTxHash: null,
+              },
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage: error.message,
+                },
+              },
+            };
+          }
+
+          const executionResult = preparedExecutionResult.executionResult ?? null;
           const executionPortfolioState = readExecutionPortfolioState(executionResult);
           const projection = mergePortfolioProjectionPreservingKnownContext(
             currentState,
@@ -1225,7 +1740,7 @@ export function createEmberLendingDomain(
             ...projection,
             phase: 'active',
             lastPortfolioState: executionPortfolioState ?? currentState.lastPortfolioState,
-            lastSharedEmberRevision: response.result?.revision ?? null,
+            lastSharedEmberRevision: preparedExecutionResult.revision,
             lastExecutionResult: executionResult,
             lastExecutionTxHash: readExecutionTxHash(executionResult),
           };
@@ -1239,12 +1754,12 @@ export function createEmberLendingDomain(
               },
               artifacts: [
                 {
-                  data: {
-                    type: 'shared-ember-execution-result',
+                  data: buildExecutionArtifactData({
                     revision: nextState.lastSharedEmberRevision,
-                    committedEventIds: response.result?.committed_event_ids ?? [],
                     executionResult,
-                  },
+                    executionStatus: executionStatus.executionStatus,
+                    statusMessage: executionStatus.statusMessage,
+                  }),
                 },
               ],
             },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -1117,6 +1117,7 @@ async function readRecoveredExecutionResultFromOutbox(input: {
 
   const status = readString(matchingEvent.payload?.['status']);
   const executionId = readString(matchingEvent.payload?.['execution_id']);
+  const transactionHash = readHexAddress(matchingEvent.payload?.['transaction_hash']);
   const transactionPlanId = readString(matchingEvent.payload?.['transaction_plan_id']);
   const requestId = readString(matchingEvent.payload?.['request_id']);
 
@@ -1133,6 +1134,7 @@ async function readRecoveredExecutionResultFromOutbox(input: {
       execution: {
         status,
         ...(executionId ? { execution_id: executionId } : {}),
+        ...(transactionHash ? { transaction_hash: transactionHash } : {}),
       },
     },
   };

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -1646,7 +1646,7 @@ describe('createEmberLendingDomain', () => {
       id: 'shared-ember-thread-1-request-transaction-execution',
       method: 'subagent.requestTransactionExecution.v1',
       params: {
-        idempotency_key: 'idem-execute-transaction-plan-thread-1',
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:await-authority-preparation:8',
         expected_revision: 8,
         transaction_plan_id: 'txplan-ember-lending-001',
       },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -339,6 +339,156 @@ function createBlockedExecutionResult(input: {
   };
 }
 
+function createReadyForExecutionSigningPreparationResult(input?: {
+  signerWalletAddress?: string;
+}) {
+  return {
+    phase: 'ready_for_execution_signing',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution_preparation: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      agent_id: 'ember-lending',
+      agent_wallet:
+        input?.signerWalletAddress ?? '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      network: 'arbitrum',
+      reservation_id: 'reservation-ember-lending-001',
+      required_control_path: 'lending.supply',
+      canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      active_delegation_id: 'del-ember-lending-001',
+      root_delegation_id: 'root-user-ember-lending-001',
+      prepared_at: '2026-04-01T06:15:00.000Z',
+      metadata: {},
+    },
+    execution_signing_package: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      active_delegation_id: 'del-ember-lending-001',
+      canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+    },
+  };
+}
+
+function createBlockedPreparationResult(input: {
+  result: 'needs_release_or_transfer' | 'denied';
+  requestId: string;
+  message: string;
+  blockingReasonCode: string;
+  nextAction: 'escalate_to_control_plane' | 'stop';
+}) {
+  return {
+    phase: 'blocked',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: input.requestId,
+    request_result: {
+      result: input.result,
+      request_id: input.requestId,
+      message: input.message,
+      reservation_id: 'reservation-ember-lending-001',
+      blocking_reason_code: input.blockingReasonCode,
+      next_action: input.nextAction,
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      owned_units: [],
+      reservations: [],
+    },
+  };
+}
+
+function createAuthorityPreparationRequiredResult() {
+  return {
+    phase: 'authority_preparation_needed',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    authority_gap: 'missing_root_delegation',
+  };
+}
+
+function createReadyForRedelegationSigningPreparationResult() {
+  return {
+    phase: 'ready_for_redelegation',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution_preparation: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      network: 'arbitrum',
+      reservation_id: 'reservation-ember-lending-001',
+      required_control_path: 'lending.supply',
+      canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      active_delegation_id: 'del-ember-lending-001',
+      root_delegation_id: 'root-user-ember-lending-001',
+      prepared_at: '2026-04-01T06:15:00.000Z',
+      metadata: {},
+    },
+    redelegation_signing_package: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      redelegation_intent_id: 'reintent-ember-lending-001',
+      active_delegation_id: 'del-ember-lending-001',
+      delegation_id: 'del-ember-lending-002',
+      delegation_plan_id: 'plan-ember-lending-002',
+      root_delegation_id: 'root-user-ember-lending-001',
+      root_delegation_artifact_ref: 'artifact-root-ember-lending-001',
+      delegator_address: '0x00000000000000000000000000000000000000a1',
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      network: 'arbitrum',
+      reservation_ids: ['reservation-ember-lending-001'],
+      unit_ids: ['unit-ember-lending-001'],
+      control_paths: ['lending.supply'],
+      zero_capacity: false,
+      policy_snapshot_ref: 'pol-ember-lending-001',
+      canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+    },
+  };
+}
+
+function createReadyForExecutionSigningResult() {
+  return createReadyForExecutionSigningPreparationResult();
+}
+
+function createTerminalExecutionResult(input: {
+  status:
+    | 'submitted'
+    | 'confirmed'
+    | 'failed_before_submission'
+    | 'failed_after_submission'
+    | 'partial_settlement';
+  transactionHash?: `0x${string}`;
+}) {
+  return {
+    phase: 'completed',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution: {
+      execution_id: 'exec-ember-lending-001',
+      status: input.status,
+      transaction_hash: input.transactionHash ?? null,
+      successor_unit_ids:
+        input.status === 'failed_before_submission' ? [] : ['unit-ember-lending-successor-001'],
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      mandate_ref: 'mandate-ember-lending-001',
+      reservations: [],
+      owned_units: [],
+    },
+  };
+}
+
 describe('createEmberLendingDomain', () => {
   it('exposes only the three model-visible lending tools plus managed lifecycle controls', () => {
     const domain = createEmberLendingDomain({
@@ -1000,7 +1150,6 @@ describe('createEmberLendingDomain', () => {
         handoff: {
           handoff_id: 'handoff-thread-1',
           agent_id: 'ember-lending',
-          agent_wallet: '0x00000000000000000000000000000000000000b1',
           root_user_wallet: '0x00000000000000000000000000000000000000a1',
           mandate_ref: 'mandate-ember-lending-001',
           intent: 'deploy',
@@ -1027,49 +1176,16 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
-  it('executes the latest candidate plan through the bounded subagent surface and records the tx hash', async () => {
+  it('fails execution when Shared Ember prepares signing but no local OWS signer is configured', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => ({
         jsonrpc: '2.0',
-        id: 'shared-ember-thread-1-execute-transaction-plan',
+        id: 'shared-ember-thread-1-request-transaction-execution',
         result: {
           protocol_version: 'v1',
           revision: 9,
-          committed_event_ids: ['evt-request-execution-2'],
-          execution_result: {
-            phase: 'completed',
-            transaction_plan_id: 'txplan-ember-lending-001',
-            request_id: 'req-ember-lending-execution-001',
-            execution: {
-              execution_id: 'exec-ember-lending-001',
-              status: 'confirmed',
-              transaction_hash: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-              successor_unit_ids: ['unit-ember-lending-successor-001'],
-            },
-            portfolio_state: {
-              agent_id: 'ember-lending',
-              agent_wallet: '0x00000000000000000000000000000000000000b1',
-              root_user_wallet: '0x00000000000000000000000000000000000000a1',
-              mandate_ref: 'mandate-ember-lending-001',
-              mandate_summary:
-                'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
-              reservations: [
-                {
-                  reservation_id: 'reservation-ember-lending-001',
-                  purpose: 'deploy',
-                  control_path: 'lending.supply',
-                },
-              ],
-              owned_units: [
-                {
-                  unit_id: 'unit-ember-lending-successor-001',
-                  root_asset: 'USDC',
-                  quantity: '10',
-                  reservation_id: 'reservation-ember-lending-001',
-                },
-              ],
-            },
-          },
+          committed_event_ids: ['evt-prepare-execution-1'],
+          execution_result: createReadyForExecutionSigningPreparationResult(),
         },
       })),
       readCommittedEventOutbox: vi.fn(async () => ({
@@ -1108,33 +1224,20 @@ describe('createEmberLendingDomain', () => {
       state: {
         phase: 'active',
         lastSharedEmberRevision: 9,
-        lastExecutionTxHash:
-          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-        lastReservationSummary:
-          'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
+        lastExecutionResult: null,
+        lastExecutionTxHash: null,
       },
       outputs: {
         status: {
-          executionStatus: 'completed',
-          statusMessage: 'Lending transaction plan admitted and executed through Shared Ember.',
+          executionStatus: 'failed',
+          statusMessage: 'Local OWS signer is not configured for lending transaction execution.',
         },
-        artifacts: [
-          {
-            data: {
-              type: 'shared-ember-execution-result',
-              revision: 9,
-              executionResult: {
-                transaction_plan_id: 'txplan-ember-lending-001',
-              },
-            },
-          },
-        ],
       },
     });
 
     expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
       jsonrpc: '2.0',
-      id: 'shared-ember-thread-1-execute-transaction-plan',
+      id: 'shared-ember-thread-1-request-transaction-execution',
       method: 'subagent.requestTransactionExecution.v1',
       params: {
         idempotency_key: 'idem-execute-transaction-plan-thread-1',
@@ -1144,16 +1247,1057 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
+  it('signs execution packages locally and submits them back to Shared Ember before returning the final outcome', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-submit-execution-1'],
+            execution_result: createTerminalExecutionResult({
+              status: 'confirmed',
+              transactionHash:
+                '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            }),
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executionSigner.signExecutionPackage).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
+      executionSigningPackage: {
+        execution_preparation_id: 'execprep-ember-lending-001',
+        transaction_plan_id: 'txplan-ember-lending-001',
+        request_id: 'req-ember-lending-execution-001',
+        active_delegation_id: 'del-ember-lending-001',
+        canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-transaction-execution',
+      method: 'subagent.requestTransactionExecution.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1',
+        expected_revision: 7,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:submit-transaction:req-ember-lending-execution-001',
+        expected_revision: 9,
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          signer_address: '0x00000000000000000000000000000000000000b1',
+          raw_transaction:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 10,
+        lastExecutionTxHash:
+          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        lastReservationSummary:
+          'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+      },
+    });
+  });
+
+  it('surfaces blocked preparation results from the multi-call execution path without signing or submitting', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-request-transaction-execution',
+        result: {
+          protocol_version: 'v1',
+          revision: 9,
+          committed_event_ids: ['evt-prepare-execution-blocked-1'],
+          execution_result: createBlockedPreparationResult({
+            result: 'needs_release_or_transfer',
+            requestId: 'req-ember-lending-blocked-001',
+            message: 'reserved capital is still claimed by another agent',
+            blockingReasonCode: 'reserved_for_other_agent',
+            nextAction: 'escalate_to_control_plane',
+          }),
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executionSigner.signExecutionPackage).not.toHaveBeenCalled();
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledTimes(1);
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 9,
+        lastExecutionTxHash: null,
+        lastExecutionResult: {
+          phase: 'blocked',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-blocked-001',
+          request_result: {
+            result: 'needs_release_or_transfer',
+          },
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending transaction execution request was blocked by Shared Ember: reserved capital is still claimed by another agent.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-execution-result',
+              revision: 9,
+              outcome: 'blocked',
+              message:
+                'Lending transaction execution request was blocked by Shared Ember: reserved capital is still claimed by another agent.',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('fails closed when the prepared execution signing package does not match the dedicated subagent wallet', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-request-transaction-execution',
+        result: {
+          protocol_version: 'v1',
+          revision: 9,
+          committed_event_ids: ['evt-prepare-execution-1'],
+          execution_result: createReadyForExecutionSigningPreparationResult({
+            signerWalletAddress: '0x00000000000000000000000000000000000000c1',
+          }),
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          ...createManagedLifecycleState(),
+          lastCandidatePlan: {
+            transaction_plan_id: 'txplan-ember-lending-001',
+          },
+          lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+        },
+        operation: {
+          source: 'tool',
+          name: 'request_transaction_execution',
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 9,
+        lastExecutionResult: null,
+        lastExecutionTxHash: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending execution signing could not continue because the prepared signing package does not match the dedicated subagent wallet.',
+        },
+      },
+    });
+
+    expect(executionSigner.signExecutionPackage).not.toHaveBeenCalled();
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries preparation internally when Shared Ember reports authority preparation is still pending', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 8,
+            committed_event_ids: ['evt-prepare-authority-1'],
+            execution_result: createAuthorityPreparationRequiredResult(),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-submit-execution-1'],
+            execution_result: {
+              ...createTerminalExecutionResult({
+                status: 'confirmed',
+                transactionHash:
+                  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+              }),
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-transaction-execution',
+      method: 'subagent.requestTransactionExecution.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1',
+        expected_revision: 7,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-transaction-execution',
+      method: 'subagent.requestTransactionExecution.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1',
+        expected_revision: 8,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:submit-transaction:req-ember-lending-execution-001',
+        expected_revision: 9,
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          signer_address: '0x00000000000000000000000000000000000000b1',
+          raw_transaction:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 10,
+        lastExecutionTxHash:
+          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+      },
+    });
+  });
+
+  it('signs redelegation artifacts locally before completing execution signing and submission', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-request-transaction-execution',
+        result: {
+          protocol_version: 'v1',
+          revision: 9,
+          committed_event_ids: ['evt-prepare-redelegation-1'],
+          execution_result: createReadyForRedelegationSigningPreparationResult(),
+        },
+      })
+      .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-register-signed-redelegation',
+        result: {
+          protocol_version: 'v1',
+          revision: 10,
+          committed_event_ids: ['evt-submit-redelegation-1'],
+            execution_result: createReadyForExecutionSigningResult(),
+          },
+      })
+      .mockResolvedValueOnce({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-submit-signed-transaction',
+        result: {
+          protocol_version: 'v1',
+          revision: 11,
+          committed_event_ids: ['evt-submit-execution-1'],
+          execution_result: createTerminalExecutionResult({
+            status: 'confirmed',
+            transactionHash:
+              '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          }),
+        },
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signRedelegationPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signed_redelegation: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          redelegation_intent_id: 'reintent-ember-lending-001',
+          active_delegation_id: 'del-ember-lending-001',
+          delegation_id: 'del-ember-lending-002',
+          delegation_plan_id: 'plan-ember-lending-002',
+          root_delegation_id: 'root-user-ember-lending-001',
+          root_delegation_artifact_ref: 'artifact-root-ember-lending-001',
+          delegator_address: '0x00000000000000000000000000000000000000a1',
+          agent_id: 'ember-lending',
+          agent_wallet: '0x00000000000000000000000000000000000000b1',
+          network: 'arbitrum',
+          reservation_ids: ['reservation-ember-lending-001'],
+          unit_ids: ['unit-ember-lending-001'],
+          control_paths: ['lending.supply'],
+          zero_capacity: false,
+          policy_snapshot_ref: 'pol-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          artifact_ref: 'artifact-ember-lending-002',
+          issued_at: '2026-04-01T06:16:00.000Z',
+          activated_at: '2026-04-01T06:16:05.000Z',
+          policy_hash: 'hash-ember-lending-002',
+        },
+      })),
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executionSigner.signRedelegationPackage).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
+      redelegationSigningPackage: {
+        execution_preparation_id: 'execprep-ember-lending-001',
+        transaction_plan_id: 'txplan-ember-lending-001',
+        request_id: 'req-ember-lending-execution-001',
+        redelegation_intent_id: 'reintent-ember-lending-001',
+        active_delegation_id: 'del-ember-lending-001',
+        delegation_id: 'del-ember-lending-002',
+        delegation_plan_id: 'plan-ember-lending-002',
+        root_delegation_id: 'root-user-ember-lending-001',
+        root_delegation_artifact_ref: 'artifact-root-ember-lending-001',
+        delegator_address: '0x00000000000000000000000000000000000000a1',
+        agent_id: 'ember-lending',
+        agent_wallet: '0x00000000000000000000000000000000000000b1',
+        network: 'arbitrum',
+        reservation_ids: ['reservation-ember-lending-001'],
+        unit_ids: ['unit-ember-lending-001'],
+        control_paths: ['lending.supply'],
+        zero_capacity: false,
+        policy_snapshot_ref: 'pol-ember-lending-001',
+        canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      },
+    });
+    expect(executionSigner.signExecutionPackage).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
+      executionSigningPackage: {
+        execution_preparation_id: 'execprep-ember-lending-001',
+        transaction_plan_id: 'txplan-ember-lending-001',
+        request_id: 'req-ember-lending-execution-001',
+        active_delegation_id: 'del-ember-lending-001',
+        canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-register-signed-redelegation',
+      method: 'orchestrator.registerSignedRedelegation.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:register-redelegation:req-ember-lending-execution-001',
+        expected_revision: 9,
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_redelegation: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          redelegation_intent_id: 'reintent-ember-lending-001',
+          active_delegation_id: 'del-ember-lending-001',
+          delegation_id: 'del-ember-lending-002',
+          delegation_plan_id: 'plan-ember-lending-002',
+          root_delegation_id: 'root-user-ember-lending-001',
+          root_delegation_artifact_ref: 'artifact-root-ember-lending-001',
+          delegator_address: '0x00000000000000000000000000000000000000a1',
+          agent_id: 'ember-lending',
+          agent_wallet: '0x00000000000000000000000000000000000000b1',
+          network: 'arbitrum',
+          reservation_ids: ['reservation-ember-lending-001'],
+          unit_ids: ['unit-ember-lending-001'],
+          control_paths: ['lending.supply'],
+          zero_capacity: false,
+          policy_snapshot_ref: 'pol-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          artifact_ref: 'artifact-ember-lending-002',
+          issued_at: '2026-04-01T06:16:00.000Z',
+          activated_at: '2026-04-01T06:16:05.000Z',
+          policy_hash: 'hash-ember-lending-002',
+        },
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:submit-transaction:req-ember-lending-execution-001',
+        expected_revision: 10,
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          signer_address: '0x00000000000000000000000000000000000000b1',
+          raw_transaction:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 11,
+        lastExecutionTxHash:
+          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+      },
+    });
+  });
+
+  it('maps submitted and terminal execution outcomes from the signed-artifact flow without treating failures as success', async () => {
+    const scenarios = [
+      {
+        status: 'submitted' as const,
+        transactionHash:
+          '0x1111111111111111111111111111111111111111111111111111111111111111' as const,
+        expectedStatus: 'completed' as const,
+        expectedMessage: 'Lending transaction submitted through Shared Ember.',
+      },
+      {
+        status: 'failed_before_submission' as const,
+        transactionHash: undefined,
+        expectedStatus: 'failed' as const,
+        expectedMessage: 'Lending transaction failed before submission through Shared Ember.',
+      },
+      {
+        status: 'failed_after_submission' as const,
+        transactionHash:
+          '0x2222222222222222222222222222222222222222222222222222222222222222' as const,
+        expectedStatus: 'failed' as const,
+        expectedMessage: 'Lending transaction failed after submission through Shared Ember.',
+      },
+      {
+        status: 'partial_settlement' as const,
+        transactionHash:
+          '0x3333333333333333333333333333333333333333333333333333333333333333' as const,
+        expectedStatus: 'failed' as const,
+        expectedMessage: 'Lending transaction reached partial settlement through Shared Ember.',
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const protocolHost = {
+        handleJsonRpc: vi
+          .fn()
+          .mockResolvedValueOnce({
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-transaction-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 9,
+              committed_event_ids: ['evt-prepare-execution-1'],
+              execution_result: createReadyForExecutionSigningPreparationResult(),
+            },
+          })
+          .mockResolvedValueOnce({
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-submit-signed-transaction',
+            result: {
+              protocol_version: 'v1',
+              revision: 10,
+              committed_event_ids: ['evt-submit-execution-1'],
+              execution_result: createTerminalExecutionResult({
+                status: scenario.status,
+                transactionHash: scenario.transactionHash,
+              }),
+            },
+          }),
+        readCommittedEventOutbox: vi.fn(async () => ({
+          protocol_version: 'v1',
+          revision: 10,
+          events: [],
+        })),
+        acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+          protocol_version: 'v1',
+          revision: 10,
+          consumer_id: 'ember-lending',
+          acknowledged_through_sequence: 0,
+        })),
+      };
+      const executionSigner = {
+        signExecutionPackage: vi.fn(async () => ({
+          signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+          signer_address: '0x00000000000000000000000000000000000000b1',
+          raw_transaction:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        })),
+      };
+      const domain = createEmberLendingDomain({
+        protocolHost,
+        executionSigner,
+        agentId: 'ember-lending',
+      });
+
+      const result = await domain.handleOperation?.({
+        threadId: `thread-${scenario.status}`,
+        state: {
+          ...createManagedLifecycleState(),
+          lastCandidatePlan: {
+            transaction_plan_id: 'txplan-ember-lending-001',
+          },
+          lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+        },
+        operation: {
+          source: 'tool',
+          name: 'request_transaction_execution',
+        },
+      });
+
+      expect(result).toMatchObject({
+        state: {
+          phase: 'active',
+          lastSharedEmberRevision: 10,
+          lastExecutionTxHash: scenario.transactionHash ?? null,
+          lastExecutionResult: {
+            phase: 'completed',
+            execution: {
+              status: scenario.status,
+            },
+          },
+        },
+        outputs: {
+          status: {
+            executionStatus: scenario.expectedStatus,
+            statusMessage: scenario.expectedMessage,
+          },
+        },
+      });
+    }
+  });
+
+  it('retries prepare and submit with refreshed revisions while keeping deterministic idempotency keys', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            'Shared Ember Domain Service JSON-RPC error: protocol_conflict expected_revision=7 actual_revision=8',
+          ),
+        )
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-read-current-revision',
+          result: {
+            protocol_version: 'v1',
+            revision: 8,
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockRejectedValueOnce(
+          new Error(
+            'Shared Ember Domain Service JSON-RPC error: protocol_conflict expected_revision=9 actual_revision=10',
+          ),
+        )
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-read-current-revision',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 11,
+            committed_event_ids: ['evt-submit-execution-1'],
+            execution_result: createTerminalExecutionResult({
+              status: 'confirmed',
+              transactionHash:
+                '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            }),
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executionSigner.signExecutionPackage).toHaveBeenCalledTimes(1);
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-transaction-execution',
+      method: 'subagent.requestTransactionExecution.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1',
+        expected_revision: 7,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-read-current-revision',
+      method: 'subagent.readPortfolioState.v1',
+      params: {
+        agent_id: 'ember-lending',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-transaction-execution',
+      method: 'subagent.requestTransactionExecution.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1',
+        expected_revision: 8,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(4, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:submit-transaction:req-ember-lending-execution-001',
+        expected_revision: 9,
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          signer_address: '0x00000000000000000000000000000000000000b1',
+          raw_transaction:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(5, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-read-current-revision',
+      method: 'subagent.readPortfolioState.v1',
+      params: {
+        agent_id: 'ember-lending',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(6, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: 'idem-execute-transaction-plan-thread-1:submit-transaction:req-ember-lending-execution-001',
+        expected_revision: 10,
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: {
+          execution_preparation_id: 'execprep-ember-lending-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          request_id: 'req-ember-lending-execution-001',
+          active_delegation_id: 'del-ember-lending-001',
+          canonical_unsigned_payload_ref: 'txpayload-ember-lending-001',
+          signer_address: '0x00000000000000000000000000000000000000b1',
+          raw_transaction:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 11,
+        lastExecutionTxHash:
+          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+      },
+    });
+  });
+
+  it('returns a failed execution result when signed-artifact submission hits a local transport error', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:4010')),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          ...createManagedLifecycleState(),
+          lastCandidatePlan: {
+            transaction_plan_id: 'txplan-ember-lending-001',
+          },
+          lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+        },
+        operation: {
+          source: 'tool',
+          name: 'request_transaction_execution',
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 7,
+        lastExecutionResult: null,
+        lastExecutionTxHash: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage: 'connect ECONNREFUSED 127.0.0.1:4010',
+        },
+      },
+    });
+  });
+
   it('surfaces blocked execution requests without claiming the transaction plan executed', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => ({
         jsonrpc: '2.0',
-        id: 'shared-ember-thread-1-execute-transaction-plan',
+        id: 'shared-ember-thread-1-request-transaction-execution',
         result: {
           protocol_version: 'v1',
           revision: 9,
           committed_event_ids: ['evt-request-execution-blocked-1'],
-          execution_result: createBlockedExecutionResult({
+          execution_result: createBlockedPreparationResult({
             result: 'needs_release_or_transfer',
             requestId: 'req-ember-lending-blocked-001',
             message: 'reserved capital is still claimed by another agent',
@@ -1224,11 +2368,9 @@ describe('createEmberLendingDomain', () => {
             data: {
               type: 'shared-ember-execution-result',
               revision: 9,
-              executionResult: {
-                phase: 'blocked',
-                transaction_plan_id: 'txplan-ember-lending-001',
-                request_id: 'req-ember-lending-blocked-001',
-              },
+              outcome: 'blocked',
+              message:
+                'Lending transaction execution request was blocked by Shared Ember: reserved capital is still claimed by another agent.',
             },
           },
         ],
@@ -1240,12 +2382,12 @@ describe('createEmberLendingDomain', () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => ({
         jsonrpc: '2.0',
-        id: 'shared-ember-thread-1-execute-transaction-plan',
+        id: 'shared-ember-thread-1-request-transaction-execution',
         result: {
           protocol_version: 'v1',
           revision: 9,
           committed_event_ids: ['evt-request-execution-denied-1'],
-          execution_result: createBlockedExecutionResult({
+          execution_result: createBlockedPreparationResult({
             result: 'denied',
             requestId: 'req-ember-lending-denied-001',
             message: 'risk policy denied the requested lending path',
@@ -1311,11 +2453,9 @@ describe('createEmberLendingDomain', () => {
             data: {
               type: 'shared-ember-execution-result',
               revision: 9,
-              executionResult: {
-                phase: 'blocked',
-                transaction_plan_id: 'txplan-ember-lending-001',
-                request_id: 'req-ember-lending-denied-001',
-              },
+              outcome: 'denied',
+              message:
+                'Lending transaction execution request was denied by Shared Ember: risk policy denied the requested lending path.',
             },
           },
         ],
@@ -1447,7 +2587,6 @@ describe('createEmberLendingDomain', () => {
         handoff: {
           handoff_id: 'handoff-ember-lending-escalation-001',
           agent_id: 'ember-lending',
-          agent_wallet: '0x00000000000000000000000000000000000000b1',
           root_user_wallet: '0x00000000000000000000000000000000000000a1',
           mandate_ref: 'mandate-ember-lending-001',
           intent: 'deploy',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -2275,14 +2275,135 @@ describe('createEmberLendingDomain', () => {
     ).resolves.toMatchObject({
       state: {
         phase: 'active',
-        lastSharedEmberRevision: 7,
+        lastSharedEmberRevision: 9,
         lastExecutionResult: null,
         lastExecutionTxHash: null,
+        pendingExecutionSubmission: {
+          transactionPlanId: 'txplan-ember-lending-001',
+          requestId: 'req-ember-lending-execution-001',
+          idempotencyKey: 'idem-execute-transaction-plan-thread-1',
+        },
       },
       outputs: {
         status: {
           executionStatus: 'failed',
           statusMessage: 'connect ECONNREFUSED 127.0.0.1:4010',
+        },
+      },
+    });
+  });
+
+  it('recovers a dropped submit response from the committed-event outbox without signing again', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:4010')),
+      readCommittedEventOutbox: vi
+        .fn()
+        .mockResolvedValueOnce({
+          protocol_version: 'v1',
+          revision: 10,
+          events: [
+            {
+              event_id: 'evt-request-execution-3',
+              sequence: 3,
+              aggregate: 'request',
+              aggregate_id: 'req-ember-lending-execution-001',
+              event_type: 'requestExecution.completed.v1',
+              committed_at: '2026-04-01T06:18:00Z',
+              payload: {
+                request_id: 'req-ember-lending-execution-001',
+                transaction_plan_id: 'txplan-ember-lending-001',
+                execution_id: 'exec-ember-lending-001',
+                status: 'confirmed',
+              },
+            },
+          ],
+        }),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const executionSigner = {
+      signExecutionPackage: vi.fn(async () => ({
+        signer_wallet_address: '0x00000000000000000000000000000000000000b1',
+        signer_address: '0x00000000000000000000000000000000000000b1',
+        raw_transaction:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      executionSigner,
+      agentId: 'ember-lending',
+    });
+    const initialState = {
+      ...createManagedLifecycleState(),
+      lastCandidatePlan: {
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+      lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+    };
+
+    const firstAttempt = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: initialState,
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    const resumedAttempt = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: firstAttempt?.state,
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(executionSigner.signExecutionPackage).toHaveBeenCalledTimes(1);
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledTimes(2);
+    expect(protocolHost.readCommittedEventOutbox).toHaveBeenNthCalledWith(1, {
+      protocol_version: 'v1',
+      consumer_id: 'ember-lending-req-ember-lending-execution-001',
+      after_sequence: 0,
+      limit: 100,
+    });
+    expect(resumedAttempt).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 10,
+        lastExecutionResult: {
+          phase: 'completed',
+          request_id: 'req-ember-lending-execution-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          execution: {
+            execution_id: 'exec-ember-lending-001',
+            status: 'confirmed',
+          },
+        },
+        lastExecutionTxHash: null,
+        pendingExecutionSubmission: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -2326,6 +2326,8 @@ describe('createEmberLendingDomain', () => {
                 transaction_plan_id: 'txplan-ember-lending-001',
                 execution_id: 'exec-ember-lending-001',
                 status: 'confirmed',
+                transaction_hash:
+                  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
               },
             },
           ],
@@ -2395,9 +2397,12 @@ describe('createEmberLendingDomain', () => {
           execution: {
             execution_id: 'exec-ember-lending-001',
             status: 'confirmed',
+            transaction_hash:
+              '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
           },
         },
-        lastExecutionTxHash: null,
+        lastExecutionTxHash:
+          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
         pendingExecutionSubmission: null,
       },
       outputs: {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberIntegrationHarness.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberIntegrationHarness.ts
@@ -1,0 +1,303 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export type StartedSharedEmberTarget = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+export const TEST_EMBER_LENDING_AGENT_ID = 'ember-lending';
+export const TEST_EMBER_LENDING_AGENT_WALLET =
+  '0x00000000000000000000000000000000000000b1' as const;
+export const TEST_EMBER_LENDING_USER_WALLET =
+  '0x00000000000000000000000000000000000000a1' as const;
+export const TEST_EMBER_LENDING_ORCHESTRATOR_WALLET =
+  '0x00000000000000000000000000000000000000a2' as const;
+
+function createRedelegationExecutionSeed() {
+  return {
+    owned_units: [
+      {
+        unit_id: 'unit-ember-lending-001',
+        root_asset: 'USDC',
+        network: 'arbitrum',
+        wallet_address: TEST_EMBER_LENDING_USER_WALLET,
+        quantity: '10',
+        owner_type: 'user_idle',
+        owner_id: 'user_idle',
+        status: 'reserved',
+        reservation_id: 'reservation-ember-lending-001',
+        delegation_id: 'del-ember-lending-001',
+        control_path: 'unassigned',
+        position_kind: 'unassigned',
+        benchmark_asset: 'USD',
+        benchmark_value: '10',
+        valuation_ref: 'val-ember-lending-001',
+        cost_basis: '10',
+        opened_at: '2026-04-01T06:00:00Z',
+        closed_at: null,
+        parent_unit_ids: [],
+        metadata: {},
+      },
+    ],
+    reservations: [
+      {
+        reservation_id: 'reservation-ember-lending-001',
+        agent_id: TEST_EMBER_LENDING_AGENT_ID,
+        owner_id: 'user_idle',
+        purpose: 'unwind',
+        control_path: 'vault.withdraw',
+        unit_allocations: [
+          {
+            unit_id: 'unit-ember-lending-001',
+            quantity: '10',
+          },
+        ],
+        status: 'active',
+        created_at: '2026-04-01T06:00:00Z',
+        released_at: null,
+        superseded_by: null,
+      },
+    ],
+    root_delegations: [
+      {
+        root_delegation_id: 'root-user-ember-lending-001',
+        user_id: 'user_idle',
+        user_wallet: TEST_EMBER_LENDING_USER_WALLET,
+        orchestrator_wallet: TEST_EMBER_LENDING_ORCHESTRATOR_WALLET,
+        network: 'arbitrum',
+        status: 'active',
+        issued_at: '2026-04-01T06:00:00Z',
+        activated_at: '2026-04-01T06:00:05Z',
+        revoked_at: null,
+        artifact_ref: 'artifact-root-ember-lending-001',
+        metadata: {},
+      },
+    ],
+    rooted_wallet_contexts: [
+      {
+        rooted_wallet_context_id: 'rwc-ember-lending-001',
+        user_id: 'user_idle',
+        wallet_address: TEST_EMBER_LENDING_USER_WALLET,
+        network: 'arbitrum',
+        registered_at: '2026-04-01T06:00:00Z',
+        metadata: {
+          source: 'integration_harness',
+        },
+      },
+    ],
+    capital_observations: [],
+    transaction_plans: [],
+    delegation_plans: [],
+    issued_delegations: [
+      {
+        delegation_id: 'del-ember-lending-001',
+        delegation_plan_id: 'plan-ember-lending-001',
+        root_delegation_id: 'root-user-ember-lending-001',
+        delegator_address: TEST_EMBER_LENDING_ORCHESTRATOR_WALLET,
+        agent_id: TEST_EMBER_LENDING_AGENT_ID,
+        agent_wallet: TEST_EMBER_LENDING_AGENT_WALLET,
+        status: 'active',
+        reservation_ids: ['reservation-ember-lending-001'],
+        unit_ids: ['unit-ember-lending-001'],
+        control_paths: ['vault.deposit'],
+        network: 'arbitrum',
+        issued_at: '2026-04-01T06:00:00Z',
+        activated_at: '2026-04-01T06:00:05Z',
+        revoked_at: null,
+        superseded_by: null,
+        zero_capacity: false,
+        artifact_ref: 'artifact-ember-lending-001',
+        policy_hash: 'hash-ember-lending-001',
+        policy_snapshot_ref: 'pol-ember-lending-001',
+      },
+    ],
+    delegation_executions: [],
+    policy_snapshots: [
+      {
+        policy_snapshot_ref: 'pol-ember-lending-001',
+        agent_id: TEST_EMBER_LENDING_AGENT_ID,
+        network: 'arbitrum',
+        control_paths: ['vault.withdraw'],
+        unit_bounds: [
+          {
+            unit_id: 'unit-ember-lending-001',
+            quantity: '10',
+          },
+        ],
+        created_at: '2026-04-01T06:00:00Z',
+      },
+    ],
+    mandates: [
+      {
+        mandate_ref: 'mandate-ember-lending-001',
+        agent_id: TEST_EMBER_LENDING_AGENT_ID,
+        mandate_summary: 'unwind the managed lending position and return capital',
+      },
+    ],
+    user_reserve_policies: [],
+    control_plane_decisions: [],
+    exception_escalations: [],
+    execution_ledger: [],
+    ownership_transfers: [],
+    valuation_refs: [],
+    agent_service_identities: [
+      {
+        identity_ref: 'agent-identity-ember-lending-001',
+        agent_id: TEST_EMBER_LENDING_AGENT_ID,
+        role: 'subagent',
+        wallet_address: TEST_EMBER_LENDING_AGENT_WALLET,
+        wallet_source: 'ember_local_write',
+        capability_metadata: {
+          execution: true,
+          onboarding: true,
+        },
+        registration_version: 1,
+        registered_at: '2026-04-01T05:59:30Z',
+      },
+    ],
+  };
+}
+
+function createSubagentRuntime() {
+  return {
+    agentWallet: TEST_EMBER_LENDING_AGENT_WALLET,
+    payloadStore: {
+      async getExecutionPayload() {
+        return {
+          action: 'raw' as const,
+          transaction_payload_ref: 'txpayload-handoff-ember-lending-int-001',
+          required_control_path: 'vault.withdraw' as const,
+          network: 'arbitrum',
+          target: '0x00000000000000000000000000000000000000c1',
+          callData: '0xdeadbeef',
+        };
+      },
+    },
+    issuer: {
+      async issueDelegation(input: { requestId: string }) {
+        return {
+          delegationId: `del-issued-${input.requestId}`,
+          artifactRef: `artifact-issued-${input.requestId}`,
+          issuedAt: '2026-04-01T06:16:00Z',
+          activatedAt: '2026-04-01T06:16:05Z',
+          policyHash: `hash-issued-${input.requestId}`,
+        };
+      },
+    },
+    delegationClient: {
+      async redeemActiveDelegation() {
+        return {
+          redeemedDelegationId: 'del-ember-lending-001',
+          delegationArtifactRef: 'artifact-ember-lending-001',
+          redeemerAddress: TEST_EMBER_LENDING_AGENT_WALLET,
+          transactionHash:
+            '0x4444444444444444444444444444444444444444444444444444444444444444',
+        };
+      },
+    },
+    executor: {
+      async signDelegatedPayload() {
+        return {
+          signedPayloadRef: 'signed-ember-lending-001',
+          signerAddress: TEST_EMBER_LENDING_AGENT_WALLET,
+        };
+      },
+    },
+    chainAdapter: {
+      async submitSignedPayload() {
+        return {
+          kind: 'confirmed' as const,
+          execution_id: 'exec-ember-lending-integration-001',
+          occurred_at: '2026-04-01T06:18:00Z',
+          transaction_hash:
+            '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          successor_plans: [
+            {
+              unit_id: 'unit-ember-lending-successor-001',
+              root_asset: 'USDC',
+              network: 'arbitrum',
+              wallet_address: TEST_EMBER_LENDING_AGENT_WALLET,
+              quantity: '10',
+              position_kind: 'loan' as const,
+              control_path: 'vault.withdraw' as const,
+              benchmark_value: '10',
+              valuation_ref: 'val-ember-lending-successor-001',
+              metadata: {
+                protocol_name: 'Integration Protocol',
+              },
+            },
+          ],
+        };
+      },
+    },
+    submissionBackend: {
+      async submitSignedTransaction() {
+        return {
+          kind: 'confirmed' as const,
+          execution_id: 'exec-ember-lending-integration-001',
+          occurred_at: '2026-04-01T06:18:00Z',
+          transaction_hash:
+            '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          successor_plans: [
+            {
+              unit_id: 'unit-ember-lending-successor-001',
+              root_asset: 'USDC',
+              network: 'arbitrum',
+              wallet_address: TEST_EMBER_LENDING_AGENT_WALLET,
+              quantity: '10',
+              position_kind: 'loan' as const,
+              control_path: 'vault.withdraw' as const,
+              benchmark_value: '10',
+              valuation_ref: 'val-ember-lending-successor-001',
+              metadata: {
+                protocol_name: 'Integration Protocol',
+              },
+            },
+          ],
+        };
+      },
+    },
+  };
+}
+
+export async function resolveSharedEmberTarget(): Promise<StartedSharedEmberTarget> {
+  const explicitBaseUrl = process.env['SHARED_EMBER_BASE_URL']?.trim();
+  if (explicitBaseUrl) {
+    return {
+      baseUrl: explicitBaseUrl,
+      close: async () => undefined,
+    };
+  }
+
+  const privateRepoRoot = process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT']?.trim();
+  if (!privateRepoRoot) {
+    throw new Error(
+      'Set SHARED_EMBER_BASE_URL or EMBER_ORCHESTRATION_V1_SPEC_ROOT when RUN_SHARED_EMBER_INT=1.',
+    );
+  }
+
+  if (!existsSync(path.join(privateRepoRoot, 'node_modules'))) {
+    throw new Error(
+      'The private ember-orchestration-v1-spec repo must have dependencies installed before running shared Ember integration tests.',
+    );
+  }
+
+  const harnessModule = (await import(
+    pathToFileURL(path.join(privateRepoRoot, 'scripts/shared-domain-service-repo-harness.ts')).href
+  )) as {
+    startRepoLocalSharedEmberDomainProtocolHttpServer: (input?: {
+      bootstrap?: unknown;
+    }) => Promise<StartedSharedEmberTarget>;
+  };
+
+  return harnessModule.startRepoLocalSharedEmberDomainProtocolHttpServer({
+    bootstrap: {
+      initialState: createRedelegationExecutionSeed(),
+      subagentRuntimes: {
+        [TEST_EMBER_LENDING_AGENT_ID]: createSubagentRuntime(),
+      },
+    },
+  });
+}

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberIntegrationHarness.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberIntegrationHarness.ts
@@ -15,7 +15,19 @@ export const TEST_EMBER_LENDING_USER_WALLET =
 export const TEST_EMBER_LENDING_ORCHESTRATOR_WALLET =
   '0x00000000000000000000000000000000000000a2' as const;
 
-function createRedelegationExecutionSeed() {
+type SharedEmberExecutionSeed = ReturnType<typeof createBaseSharedEmberExecutionSeed>;
+
+type SharedEmberExecutionSeedOptions = {
+  competingReservation?: boolean;
+  omitAgentServiceIdentity?: boolean;
+};
+
+type SharedEmberIntegrationBootstrap = {
+  initialState?: SharedEmberExecutionSeed;
+  subagentRuntimes?: Record<string, ReturnType<typeof createSubagentRuntime>>;
+};
+
+function createBaseSharedEmberExecutionSeed() {
   return {
     owned_units: [
       {
@@ -160,6 +172,29 @@ function createRedelegationExecutionSeed() {
   };
 }
 
+export function createSharedEmberExecutionSeed(
+  options: SharedEmberExecutionSeedOptions = {},
+): SharedEmberExecutionSeed {
+  const seed = createBaseSharedEmberExecutionSeed();
+
+  if (options.competingReservation) {
+    seed.reservations = seed.reservations.map((reservation) => ({
+      ...reservation,
+      agent_id: 'competing-agent',
+    }));
+    seed.issued_delegations = seed.issued_delegations.map((delegation) => ({
+      ...delegation,
+      agent_id: 'competing-agent',
+    }));
+  }
+
+  if (options.omitAgentServiceIdentity) {
+    seed.agent_service_identities = [];
+  }
+
+  return seed;
+}
+
 function createSubagentRuntime() {
   return {
     agentWallet: TEST_EMBER_LENDING_AGENT_WALLET,
@@ -262,7 +297,9 @@ function createSubagentRuntime() {
   };
 }
 
-export async function resolveSharedEmberTarget(): Promise<StartedSharedEmberTarget> {
+export async function resolveSharedEmberTarget(input?: {
+  bootstrap?: SharedEmberIntegrationBootstrap;
+}): Promise<StartedSharedEmberTarget> {
   const explicitBaseUrl = process.env['SHARED_EMBER_BASE_URL']?.trim();
   if (explicitBaseUrl) {
     return {
@@ -294,8 +331,8 @@ export async function resolveSharedEmberTarget(): Promise<StartedSharedEmberTarg
 
   return harnessModule.startRepoLocalSharedEmberDomainProtocolHttpServer({
     bootstrap: {
-      initialState: createRedelegationExecutionSeed(),
-      subagentRuntimes: {
+      initialState: input?.bootstrap?.initialState ?? createSharedEmberExecutionSeed(),
+      subagentRuntimes: input?.bootstrap?.subagentRuntimes ?? {
         [TEST_EMBER_LENDING_AGENT_ID]: createSubagentRuntime(),
       },
     },

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -195,6 +195,7 @@ Current concrete managed-path specialization:
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
   - keeps `request_transaction_execution` as one model-visible tool while internally composing Shared Ember execution preparation, local OWS redelegation/execution signing, and Ember-owned submission/finalization
+  - treats `authority_preparation_needed` as an internal wait state and re-polls the Shared Ember execution request with a stage-scoped retry idempotency key instead of exposing a second tool or reusing the original acknowledged request key
   - reconciles dropped signed-transaction submit responses through the Shared Ember committed-event outbox before replaying an idempotent submit
   - fails closed when the local OWS identity/signing path cannot prove it matches the prepared dedicated subagent signing package
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -195,6 +195,7 @@ Current concrete managed-path specialization:
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
   - keeps `request_transaction_execution` as one model-visible tool while internally composing Shared Ember execution preparation, local OWS redelegation/execution signing, and Ember-owned submission/finalization
+  - reconciles dropped signed-transaction submit responses through the Shared Ember committed-event outbox before replaying an idempotent submit
   - fails closed when the local OWS identity/signing path cannot prove it matches the prepared dedicated subagent signing package
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
   - treats `owned_units` and `reservations` as lending-lane truth while treating `wallet_contents` as rooted-wallet-wide context for prompt visibility

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -194,7 +194,8 @@ Current concrete managed-path specialization:
   - owns the first bounded managed-subagent runtime
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
-  - treats execution as admit-and-execute or blocked/denied admission rather than an execution-only success path
+  - keeps `request_transaction_execution` as one model-visible tool while internally composing Shared Ember execution preparation, local OWS redelegation/execution signing, and Ember-owned submission/finalization
+  - fails closed when the local OWS identity/signing path cannot prove it matches the prepared dedicated subagent signing package
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
   - treats `owned_units` and `reservations` as lending-lane truth while treating `wallet_contents` as rooted-wallet-wide context for prompt visibility
 

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -14,6 +14,7 @@ Scope: managed Portfolio Manager -> Ember Lending execution-preparation, local O
 - Runtime-only behavior remains hidden:
   - execution preparation
   - authority-preparation retry loops
+  - stage-scoped idempotency for authority-preparation re-polls
   - local redelegation signing
   - local execution signing
   - signed-artifact submission back to Shared Ember
@@ -77,7 +78,7 @@ sequenceDiagram
     EL-->>Runtime: failed status + blocking message
   else authority preparation required
     SE-->>EL: execution_result.phase=authority_preparation_needed
-    Note over EL,SE: keep authority-preparation recovery internal
+    Note over EL,SE: keep authority-preparation recovery internal and advance with a stage-scoped retry idempotency key
     EL->>SE: subagent.requestTransactionExecution.v1(transaction_plan_id)
   else ready for redelegation signing
     SE-->>EL: execution_result.phase=ready_for_redelegation + redelegation_signing_package + ids
@@ -112,5 +113,6 @@ sequenceDiagram
 - Only Shared Ember capital/control-plane blockers should flow into `create_escalation_request`.
 - Local OWS identity, signing, or transport failures should remain local execution failures rather than escalations.
 - Multi-call retries must be idempotent and must not create a second signing or submission side effect when the runtime retries after a conflict or transport interruption.
+- Authority-preparation re-polls must not reuse the original request idempotency key once Shared Ember has already acknowledged the waiting state; a stage-scoped retry key lets the real upstream contract advance after the missing authority is repaired.
 - After a local transport interruption during `subagent.submitSignedTransaction.v1`, Ember Lending should first reconcile through the committed-event outbox before deciding whether an idempotent resubmit is still needed.
 - When the committed-event outbox already contains the execution event, recovery should preserve `transaction_hash` from that event payload while converging on the terminal status.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -113,4 +113,4 @@ sequenceDiagram
 - Local OWS identity, signing, or transport failures should remain local execution failures rather than escalations.
 - Multi-call retries must be idempotent and must not create a second signing or submission side effect when the runtime retries after a conflict or transport interruption.
 - After a local transport interruption during `subagent.submitSignedTransaction.v1`, Ember Lending should first reconcile through the committed-event outbox before deciding whether an idempotent resubmit is still needed.
-- When recovery converges from the outbox instead of the original submit response, the minimal runtime-facing result may omit `transaction_hash` even though terminal status is known.
+- When the committed-event outbox already contains the execution event, recovery should preserve `transaction_hash` from that event payload while converging on the terminal status.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -17,6 +17,7 @@ Scope: managed Portfolio Manager -> Ember Lending execution-preparation, local O
   - local redelegation signing
   - local execution signing
   - signed-artifact submission back to Shared Ember
+  - committed-event outbox recovery after dropped submit responses
   - Ember-owned submission/final-outcome waiting
   - revision refresh / retry handling after Shared Ember conflicts
 - Shared Ember owns:
@@ -111,3 +112,5 @@ sequenceDiagram
 - Only Shared Ember capital/control-plane blockers should flow into `create_escalation_request`.
 - Local OWS identity, signing, or transport failures should remain local execution failures rather than escalations.
 - Multi-call retries must be idempotent and must not create a second signing or submission side effect when the runtime retries after a conflict or transport interruption.
+- After a local transport interruption during `subagent.submitSignedTransaction.v1`, Ember Lending should first reconcile through the committed-event outbox before deciding whether an idempotent resubmit is still needed.
+- When recovery converges from the outbox instead of the original submit response, the minimal runtime-facing result may omit `transaction_hash` even though terminal status is known.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -1,0 +1,113 @@
+# Target-State Portfolio Manager -> Ember Lending Execution Signing Sequence
+
+Status: Target-state contract for issue `#559`
+Scope: managed Portfolio Manager -> Ember Lending execution-preparation, local OWS signing, and Shared Ember submission behind `request_transaction_execution`
+
+## Contract summary
+
+- Portfolio Manager remains the owner of onboarding approval, rooted-signing collection, and control-plane interventions.
+- Ember Lending keeps exactly three model-visible tools:
+  - `create_transaction_plan`
+  - `request_transaction_execution`
+  - `create_escalation_request`
+- `request_transaction_execution` remains a model-visible tool on the lending agent. It is not a separate web command-lane concept.
+- Runtime-only behavior remains hidden:
+  - execution preparation
+  - authority-preparation retry loops
+  - local redelegation signing
+  - local execution signing
+  - signed-artifact submission back to Shared Ember
+  - Ember-owned submission/final-outcome waiting
+  - revision refresh / retry handling after Shared Ember conflicts
+- Shared Ember owns:
+  - capital admission
+  - redelegation semantics
+  - canonical unsigned signing packages
+  - transaction submission
+  - settlement tracking
+  - accounting reconciliation
+- Ember Lending owns:
+  - local OWS-backed wallet identity resolution
+  - local OWS redelegation signing
+  - local OWS execution signing
+  - translation of upstream execution outcomes into the minimal runtime-facing result
+- Fail-closed signing rule:
+  - if the runtime cannot prove that the prepared signing package matches the dedicated subagent wallet resolved through local OWS identity state, it must stop and fail
+  - there is no fallback to the portfolio-manager wallet, root user wallet, injected signer callbacks, web-side signing, or local chain submission
+- Internal Shared Ember RPCs for this slice:
+  - `subagent.requestTransactionExecution.v1`
+  - `orchestrator.registerSignedRedelegation.v1`
+  - `subagent.submitSignedTransaction.v1`
+
+## Internal result taxonomy
+
+- `subagent.requestTransactionExecution.v1` returns one of:
+  - `blocked`
+  - `authority_preparation_needed`
+  - `ready_for_redelegation`
+  - `ready_for_execution_signing`
+- `orchestrator.registerSignedRedelegation.v1` returns one of:
+  - `blocked`
+  - `ready_for_execution_signing`
+  - `completed`
+- `subagent.submitSignedTransaction.v1` returns:
+  - `submitted`
+  - `confirmed`
+  - `failed_before_submission`
+  - `failed_after_submission`
+  - `partial_settlement`
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Web
+  participant Runtime as AG-UI Runtime
+  participant EL as agent-ember-lending
+  participant SE as Shared Ember
+  participant OWS as local OWS signer
+
+  User->>Web: request_transaction_execution
+  Web->>Runtime: run(request_transaction_execution)
+  Runtime->>EL: handleOperation(request_transaction_execution)
+  EL->>SE: subagent.requestTransactionExecution.v1(transaction_plan_id)
+
+  alt blocked
+    SE-->>EL: execution_result.phase=blocked
+    EL-->>Runtime: failed status + blocking message
+  else authority preparation required
+    SE-->>EL: execution_result.phase=authority_preparation_needed
+    Note over EL,SE: keep authority-preparation recovery internal
+    EL->>SE: subagent.requestTransactionExecution.v1(transaction_plan_id)
+  else ready for redelegation signing
+    SE-->>EL: execution_result.phase=ready_for_redelegation + redelegation_signing_package + ids
+    EL->>OWS: sign redelegation package
+    OWS-->>EL: signed redelegation
+    EL->>SE: orchestrator.registerSignedRedelegation.v1(signed_redelegation + ids)
+    SE-->>EL: execution_result.phase=ready_for_execution_signing
+    EL->>OWS: sign execution package
+    OWS-->>EL: signer_address + raw_transaction
+    EL->>SE: subagent.submitSignedTransaction.v1(signed_transaction + ids)
+    SE-->>EL: execution_result.phase=completed + execution.status
+    EL-->>Runtime: minimal status + tx hash when available
+  else ready for execution signing
+    SE-->>EL: execution_result.phase=ready_for_execution_signing + execution_signing_package + ids
+    EL->>OWS: sign execution package
+    OWS-->>EL: signer_address + raw_transaction
+    EL->>SE: subagent.submitSignedTransaction.v1(signed_transaction + ids)
+    SE-->>EL: execution_result.phase=completed + execution.status
+    EL-->>Runtime: minimal status + tx hash when available
+  end
+```
+
+## Notes
+
+- There is still no model-visible `read_portfolio_state` tool.
+- There is still no model-visible onboarding-context read or manual sync/bootstrap step.
+- By default, the runtime-facing result should include only:
+  - final `status`
+  - `transaction_hash` when available
+  - blocking or failure `message` when applicable
+- Internal ids such as `request_id`, `execution_id`, and `transaction_plan_id` may be required inside the glue layer, but they should stay out of the model-visible tool result and shared web-gating contract by default.
+- Only Shared Ember capital/control-plane blockers should flow into `create_escalation_request`.
+- Local OWS identity, signing, or transport failures should remain local execution failures rather than escalations.
+- Multi-call retries must be idempotent and must not create a second signing or submission side effect when the runtime retries after a conflict or transport interruption.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -3,6 +3,11 @@
 Status: Target-state contract for issue `#555`
 Scope: managed Portfolio Manager -> Ember Lending coordination over Shared Ember
 
+Follow-on note:
+- Issue `#559` supersedes this file's single-call execution-path assumptions.
+- Keep this file as the durable target-state contract for the `#555` three-tool surface and minimal execution-context boundary.
+- For the multi-call execution-preparation and local OWS signing follow-up, see `target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd`.
+
 ## Contract summary
 
 - Portfolio Manager remains the owner of onboarding approval, rooted-signing collection, and control-plane interventions.

--- a/typescript/src/ci/affected-packages.ts
+++ b/typescript/src/ci/affected-packages.ts
@@ -69,9 +69,13 @@ export const DEFAULT_GLOBAL_INVALIDATORS = [
 
 export const DEFAULT_IGNORED_PATHS = [
   "README.md",
+  "**/README.md",
   "docs/",
+  "**/docs/",
   "img/",
+  "**/img/",
   ".agent/",
+  "**/.agent/",
 ];
 
 function normalizePath(path: string): string {
@@ -108,6 +112,20 @@ function isWithinPackage(changedFile: string, rootRelativeDir: string): boolean 
 }
 
 function matchesPathRule(changedFile: string, rule: string): boolean {
+  if (rule.startsWith("**/")) {
+    const nestedRule = rule.slice(3);
+
+    if (nestedRule.endsWith("/")) {
+      const normalizedPrefix = nestedRule;
+      return (
+        changedFile.startsWith(normalizedPrefix) ||
+        changedFile.includes(`/${normalizedPrefix}`)
+      );
+    }
+
+    return changedFile === nestedRule || changedFile.endsWith(`/${nestedRule}`);
+  }
+
   return rule.endsWith("/")
     ? changedFile.startsWith(rule)
     : changedFile === rule;

--- a/typescript/src/ci/affected-packages.unit.test.ts
+++ b/typescript/src/ci/affected-packages.unit.test.ts
@@ -95,6 +95,35 @@ describe("resolveAffectedPackages", () => {
     expect(result.selectedPackageNames).toEqual([]);
   });
 
+  it("ignores package-local docs so app changes do not pull in the web-ag-ui root package", () => {
+    const packages: WorkspacePackage[] = [
+      {
+        name: "langgraph-js-starter",
+        rootRelativeDir: "clients/web-ag-ui",
+        workspaceDependencies: [],
+      },
+      {
+        name: "agent-ember-lending",
+        rootRelativeDir: "clients/web-ag-ui/apps/agent-ember-lending",
+        workspaceDependencies: [],
+      },
+    ];
+
+    const result = resolveAffectedPackages({
+      changedFiles: [
+        "clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts",
+        "clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md",
+        "clients/web-ag-ui/apps/agent-ember-lending/README.md",
+      ],
+      globalInvalidators: ["pnpm-workspace.yaml"],
+      ignoredPaths: ["README.md", "**/README.md", "docs/", "**/docs/"],
+      packages,
+    });
+
+    expect(result.scope).toBe("partial");
+    expect(result.selectedPackageNames).toEqual(["agent-ember-lending"]);
+  });
+
   it("treats the top-level agent-runtime tree as the deepest owning package set and expands to facade dependents", () => {
     const packages: WorkspacePackage[] = [
       {
@@ -228,6 +257,56 @@ describe("resolveAffectedPackages", () => {
       expect(result.scope).toBe("none");
       expect(result.selectedPackageNames).toEqual([]);
       expect(result.selectedPackageDirs).toEqual([]);
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("uses default rules to ignore nested package docs and readmes", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "affected-packages-"));
+
+    try {
+      await writeFile(
+        path.join(workspaceRoot, "package.json"),
+        JSON.stringify({
+          name: "monorepo-root",
+          version: "1.0.0",
+        }),
+      );
+      await writeFile(
+        path.join(workspaceRoot, "pnpm-workspace.yaml"),
+        "packages:\n  - 'clients/web-ag-ui'\n  - 'clients/web-ag-ui/apps/*'\n",
+      );
+      await mkdir(path.join(workspaceRoot, "clients/web-ag-ui/apps/agent-ember-lending/src"), {
+        recursive: true,
+      });
+      await writeFile(
+        path.join(workspaceRoot, "clients/web-ag-ui/package.json"),
+        JSON.stringify({
+          name: "langgraph-js-starter",
+          version: "1.0.0",
+        }),
+      );
+      await writeFile(
+        path.join(workspaceRoot, "clients/web-ag-ui/apps/agent-ember-lending/package.json"),
+        JSON.stringify({
+          name: "agent-ember-lending",
+          version: "1.0.0",
+        }),
+      );
+
+      const result = await detectAffectedPackages({
+        changedFiles: [
+          "clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts",
+          "clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md",
+          "clients/web-ag-ui/apps/agent-ember-lending/README.md",
+        ],
+        workspaceRoot,
+      });
+
+      expect(result.scope).toBe("partial");
+      expect(result.selectedPackageNames).toEqual(["agent-ember-lending"]);
+      expect(result.selectedPackageDirs).toEqual(["clients/web-ag-ui/apps/agent-ember-lending"]);
     } finally {
       await rm(workspaceRoot, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary
- align `agent-ember-lending` execution with the real Ember protocol handshake and fail-closed local OWS signing
- add repo-backed integration coverage for blocked execution, authority-preparation polling, redelegation, signed-transaction flow, and dropped-submit recovery
- keep authority-preparation retries internal by advancing them with a stage-scoped retry idempotency key at the Shared Ember boundary
- preserve `transaction_hash` during outbox-based recovery after the upstream Ember Domain Service merge
- update the web AG-UI execution docs to match the implemented upstream contract and retry semantics

## Testing
- `pnpm test:unit`
- `RUN_SHARED_EMBER_INT=1 EMBER_ORCHESTRATION_V1_SPEC_ROOT=/Users/tomdaniel/Documents/Ember_Cognition_Inc/Software/forge/repos/ember-orchestration-v1-spec pnpm test:int`
- `pnpm build`

## Related
- Related: #559
- Upstream merged dependency: EmberAGI/ember-orchestration-v1-spec#216
- Stacked on #553
