### PR TITLE
fix(web-ag-ui): enforce onboarding identity proof

### DIFF
--- a/typescript/clients/web-ag-ui/README.md
+++ b/typescript/clients/web-ag-ui/README.md
@@ -29,6 +29,10 @@ It includes:
 - Use app-specific READMEs for local startup details.
 - Use the docs in `docs/` and `docs/adr/` for the authoritative architecture direction.
 - Treat older LangGraph starter language as historical context, not the current architecture contract.
+- Use `pnpm smoke:managed-identities` to prove the current downstream Shared Ember + OWS-facing identity boundary:
+  - `portfolio-manager` / `orchestrator` is non-null
+  - `ember-lending` / `subagent` is non-null
+  - post-bootstrap `subagent.readExecutionContext.v1` exposes a non-null `subagent_wallet_address`
 
 ## Key Docs
 
@@ -36,5 +40,6 @@ It includes:
 - [C4 Target Architecture: Pi Runtime + AG-UI + Automations](./docs/c4-pi-runtime-architecture-and-boundaries.md)
 - [AG-UI Client Runtime Invariants](./docs/ag-ui-client-runtime-invariants.md)
 - [AG-UI Frontend/Backend Contract for UI Stability](./docs/ag-ui-frontend-backend-contract-ui-stability.md)
+- [ADR 0014: fail-closed-service-identity-preflight-for-managed-shared-ember-agents](./docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md)
 - [ADR 0011: blessed-agent-runtime-factory-and-runtime-owned-projection-assembly](./docs/adr/0011-blessed-agent-runtime-factory-and-runtime-owned-projection-assembly.md)
 - [ADR 0010: pluggable-agent-domain-modules-above-pi-core-runtime](./docs/adr/0010-pluggable-agent-domain-modules-above-pi-core-runtime.md) (superseded lineage)

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
@@ -16,9 +16,14 @@ OPENROUTER_API_KEY=
 # Optional: override the runtime-managed Postgres URL.
 # DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/pi_runtime
 
-# Optional: point the lending runtime at the Shared Ember Domain Service HTTP boundary.
+# Optional: point the lending runtime at the Shared Ember Domain Service HTTP
+# boundary. When this is set for the live managed path,
+# `EMBER_LENDING_OWS_BASE_URL` is also required so startup can resolve the local
+# signer wallet and confirm or rewrite the durable subagent identity before the
+# service is ready.
 # SHARED_EMBER_BASE_URL=http://127.0.0.1:4010
 
 # Optional: point the lending runtime at the local OWS signing boundary used for
-# redelegation and execution signing.
+# startup identity preflight, redelegation, and execution signing. Required when
+# `SHARED_EMBER_BASE_URL` is set for the live managed path.
 # EMBER_LENDING_OWS_BASE_URL=http://127.0.0.1:4020

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -70,3 +70,11 @@ Runtime wiring:
 Like the portfolio manager app, this package should stay a thin downstream app.
 Shared Ember business logic and durable truth remain outside the app behind the
 Shared Ember Domain Service boundary.
+
+Validation note:
+
+- run `pnpm smoke:managed-identities` from `typescript/clients/web-ag-ui/` to
+  prove the current downstream pair can confirm both durable identities and
+  surface a non-null post-bootstrap `subagent_wallet_address`
+- that smoke stays on the current downstream OWS-facing HTTP seam; deeper OWS
+  integration is tracked separately

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -45,10 +45,20 @@ Runtime wiring:
 - `SHARED_EMBER_BASE_URL` points the app at the bounded Shared Ember HTTP
   surface
 - `EMBER_LENDING_OWS_BASE_URL` points the app at the local OWS signing surface
-  used for redelegation and execution signing
-- when `EMBER_LENDING_OWS_BASE_URL` is not configured, execution still uses the
-  new prepare path but fails locally when Shared Ember reaches a signing-ready
-  stage instead of falling back to the retired single-call execution path
+  used for startup identity proof, redelegation, and execution signing
+- when `SHARED_EMBER_BASE_URL` is set for the live managed path, startup now
+  resolves the local signer wallet from OWS and confirms the durable
+  `ember-lending` / `subagent` service identity in Shared Ember before the
+  runtime is considered ready
+- if the durable subagent identity is missing or points at a different wallet
+  than the current OWS-resolved signer wallet, startup rewrites the durable
+  identity record instead of continuing with stale state
+- if OWS is unavailable or does not resolve a signer wallet while Shared Ember
+  is configured, startup fails closed instead of waiting for a later
+  execution-time signing failure
+- portfolio-manager activation is expected to block until this durable
+  `ember-lending` / `subagent` identity exists and matches the current OWS
+  wallet
 
 Like the portfolio manager app, this package should stay a thin downstream app.
 Shared Ember business logic and durable truth remain outside the app behind the

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -57,7 +57,8 @@ Runtime wiring:
   identity record instead of continuing with stale state, using a fresh
   identity-scoped idempotency key for each distinct write
 - startup treats the Shared Ember write as successful only when the response
-  echoes back the confirmed `ember-lending` / `subagent` identity; if the
+  echoes back the confirmed `ember-lending` / `subagent` identity with the
+  expected `agent_id`, `role`, and wallet address; if any part of that
   confirmation is missing or mismatched, the runtime fails closed
 - if OWS is unavailable or does not resolve a signer wallet while Shared Ember
   is configured, startup fails closed instead of waiting for a later

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -31,8 +31,10 @@ Current execution-context semantics:
 - `wallet_contents` reflects the full rooted wallet so the lending prompt can
   see total wallet inventory even when agent-scoped delegation state is still
   sparse
-- `subagent_wallet_address` can still be `null` until a later delegation
-  issuance path assigns a dedicated subagent wallet
+- before healthy managed onboarding completes or when startup identity proof has
+  not succeeded, `subagent_wallet_address` can still be `null`; after
+  successful identity registration plus onboarding, the first healthy
+  execution-context read is expected to expose the dedicated subagent wallet
 - `authority_preparation_needed` stays runtime-internal; the adapter re-polls
   Shared Ember with a stage-scoped retry idempotency key until readiness
   advances or the local execution attempt fails closed
@@ -52,7 +54,11 @@ Runtime wiring:
   runtime is considered ready
 - if the durable subagent identity is missing or points at a different wallet
   than the current OWS-resolved signer wallet, startup rewrites the durable
-  identity record instead of continuing with stale state
+  identity record instead of continuing with stale state, using a fresh
+  identity-scoped idempotency key for each distinct write
+- startup treats the Shared Ember write as successful only when the response
+  echoes back the confirmed `ember-lending` / `subagent` identity; if the
+  confirmation is missing or mismatched, the runtime fails closed
 - if OWS is unavailable or does not resolve a signer wallet while Shared Ember
   is configured, startup fails closed instead of waiting for a later
   execution-time signing failure

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -828,7 +828,7 @@ describe('agent-ember-lending AG-UI integration', () => {
     );
   });
 
-  it('hydrates a managed lending thread from execution context when the portfolio state is still empty', async () => {
+  it('hydrates a managed lending thread from execution context with a non-null subagent wallet when the portfolio state is still empty', async () => {
     protocolHost.handleJsonRpc.mockImplementation(async (input: unknown) => {
       const request =
         typeof input === 'object' && input !== null
@@ -864,7 +864,7 @@ describe('agent-ember-lending AG-UI integration', () => {
                 mandate_summary:
                   'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
                 mandate_context: null,
-                subagent_wallet_address: null,
+                subagent_wallet_address: '0x00000000000000000000000000000000000000b1',
                 root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
                 owned_units: [],
                 wallet_contents: [],
@@ -894,7 +894,7 @@ describe('agent-ember-lending AG-UI integration', () => {
             mandateContext: {
               network: 'arbitrum',
             },
-            walletAddress: null,
+            walletAddress: '0x00000000000000000000000000000000000000b1',
             rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
             rootedWalletContextId: null,
             lastReservationSummary: null,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.ts
@@ -127,10 +127,17 @@ export async function createEmberLendingGatewayService(
         );
       }
 
-      await (options.__internalEnsureServiceIdentity ?? ensureEmberLendingServiceIdentity)({
+      const ensuredIdentity = await (
+        options.__internalEnsureServiceIdentity ?? ensureEmberLendingServiceIdentity
+      )({
         protocolHost: dependencies.protocolHost,
         readSignerWalletAddress,
       });
+      if (!ensuredIdentity.identity.wallet_address.startsWith('0x')) {
+        throw new Error(
+          'Lending startup identity preflight failed because Shared Ember did not return a confirmed subagent wallet address.',
+        );
+      }
     }
   }
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.ts
@@ -4,11 +4,13 @@ import {
   createEmberLendingAgentConfig,
   type EmberLendingAgentConfig,
   type EmberLendingGatewayEnv,
+  resolveEmberLendingGatewayDependencies,
 } from './emberLendingFoundation.js';
 import {
   EMBER_LENDING_INTERNAL_HYDRATE_COMMAND,
   hasEmberLendingRuntimeProjection,
 } from './sharedEmberAdapter.js';
+import { ensureEmberLendingServiceIdentity } from './serviceIdentityPreflight.js';
 
 export const EMBER_LENDING_AGENT_ID = 'agent-ember-lending';
 export const EMBER_LENDING_AG_UI_BASE_PATH = '/ag-ui';
@@ -27,6 +29,8 @@ type EmberLendingGatewayServiceOptions = {
 };
 
 type EmberLendingGatewayInternalOptions = EmberLendingGatewayServiceOptions & {
+  __internalCreateAgentRuntime?: typeof createAgentRuntime;
+  __internalEnsureServiceIdentity?: typeof ensureEmberLendingServiceIdentity;
   __internalPostgres?: {
     ensureReady?: (options?: { env?: { DATABASE_URL?: string } }) => Promise<{
       databaseUrl: string;
@@ -111,8 +115,27 @@ export async function createEmberLendingGatewayService(
 export async function createEmberLendingGatewayService(
   options: EmberLendingGatewayInternalOptions = {},
 ): Promise<AgentRuntimeService> {
+  const createAgentRuntimeImpl = options.__internalCreateAgentRuntime ?? createAgentRuntime;
+
+  if (options.runtimeConfig === undefined) {
+    const dependencies = resolveEmberLendingGatewayDependencies(options.env);
+    if (dependencies.protocolHost) {
+      const readSignerWalletAddress = dependencies.executionSigner?.readSignerWalletAddress;
+      if (!readSignerWalletAddress) {
+        throw new Error(
+          'Lending startup identity preflight requires EMBER_LENDING_OWS_BASE_URL to resolve the local signer wallet.',
+        );
+      }
+
+      await (options.__internalEnsureServiceIdentity ?? ensureEmberLendingServiceIdentity)({
+        protocolHost: dependencies.protocolHost,
+        readSignerWalletAddress,
+      });
+    }
+  }
+
   const runtimeConfig = options.runtimeConfig ?? createEmberLendingAgentConfig(options.env);
-  const runtime = await createAgentRuntime({
+  const runtime = await createAgentRuntimeImpl({
     ...runtimeConfig,
     ...(options.now ? { now: options.now } : {}),
     ...(options.__internalPostgres ? { __internalPostgres: options.__internalPostgres } : {}),

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
@@ -26,7 +26,13 @@ function createStubService(): AgentRuntimeService {
 describe('createEmberLendingGatewayService', () => {
   it('runs service-identity preflight before runtime creation when the live Shared Ember path is configured', async () => {
     const service = createStubService();
-    const ensureServiceIdentity = vi.fn(async () => undefined);
+    const ensureServiceIdentity = vi.fn(async () => ({
+      revision: 2,
+      wroteIdentity: false,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000b1',
+      },
+    }));
     const createAgentRuntime = vi.fn(async () => ({
       service,
     }));

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentRuntimeService } from 'agent-runtime';
+
+import { createEmberLendingGatewayService } from './agUiServer.js';
+
+function createStubService(): AgentRuntimeService {
+  return {
+    connect: async () => [],
+    run: async () => [],
+    stop: async () => [],
+    control: {
+      inspectHealth: async () => ({ status: 'ok' }),
+      listThreads: async () => [],
+      listExecutions: async () => [],
+      listAutomations: async () => [],
+      listAutomationRuns: async () => [],
+      inspectScheduler: async () => ({ dueAutomationIds: [], leases: [] }),
+      inspectOutbox: async () => ({ dueOutboxIds: [], intents: [] }),
+      inspectMaintenance: async () => ({ recovery: {}, archival: {} }),
+    },
+    createAgUiHandler: () => async () => new Response(null),
+  };
+}
+
+describe('createEmberLendingGatewayService', () => {
+  it('runs service-identity preflight before runtime creation when the live Shared Ember path is configured', async () => {
+    const service = createStubService();
+    const ensureServiceIdentity = vi.fn(async () => undefined);
+    const createAgentRuntime = vi.fn(async () => ({
+      service,
+    }));
+
+    await expect(
+      createEmberLendingGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: 'http://127.0.0.1:56436',
+          EMBER_LENDING_OWS_BASE_URL: 'http://127.0.0.1:4020',
+        },
+        __internalEnsureServiceIdentity: ensureServiceIdentity,
+        __internalCreateAgentRuntime: createAgentRuntime,
+      } as never),
+    ).resolves.toBe(service);
+
+    expect(ensureServiceIdentity).toHaveBeenCalledOnce();
+    expect(createAgentRuntime).toHaveBeenCalledOnce();
+    expect(ensureServiceIdentity.mock.invocationCallOrder[0]).toBeLessThan(
+      createAgentRuntime.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('fails closed before runtime creation when the lending service identity cannot be established', async () => {
+    const ensureServiceIdentity = vi.fn(async () => {
+      throw new Error(
+        'Lending startup identity preflight failed because the local OWS signer did not resolve a wallet address.',
+      );
+    });
+    const createAgentRuntime = vi.fn(async () => ({
+      service: createStubService(),
+    }));
+
+    await expect(
+      createEmberLendingGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: 'http://127.0.0.1:56436',
+          EMBER_LENDING_OWS_BASE_URL: 'http://127.0.0.1:4020',
+        },
+        __internalEnsureServiceIdentity: ensureServiceIdentity,
+        __internalCreateAgentRuntime: createAgentRuntime,
+      } as never),
+    ).rejects.toThrow(
+      'Lending startup identity preflight failed because the local OWS signer did not resolve a wallet address.',
+    );
+
+    expect(createAgentRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
@@ -34,6 +34,11 @@ export type EmberLendingAgentConfig = Pick<
 
 type EmberLendingGatewayModel = EmberLendingAgentConfig['model'];
 
+export type EmberLendingGatewayDependencies = {
+  protocolHost: ReturnType<typeof createEmberLendingSharedEmberHttpHost> | undefined;
+  executionSigner: ReturnType<typeof createEmberLendingLocalOwsExecutionSigner> | undefined;
+};
+
 function requireEnvValue(
   value: string | undefined,
   name: keyof EmberLendingGatewayEnv,
@@ -71,18 +76,7 @@ export function createEmberLendingAgentConfig(
 ): EmberLendingAgentConfig {
   const apiKey = requireEnvValue(env.OPENROUTER_API_KEY, 'OPENROUTER_API_KEY');
   const modelId = env.EMBER_LENDING_MODEL?.trim() || DEFAULT_EMBER_LENDING_MODEL;
-  const sharedEmberBaseUrl = resolveEmberLendingSharedEmberBaseUrl(env);
-  const localOwsBaseUrl = resolveEmberLendingLocalOwsBaseUrl(env);
-  const protocolHost = sharedEmberBaseUrl
-    ? createEmberLendingSharedEmberHttpHost({
-        baseUrl: sharedEmberBaseUrl,
-      })
-    : undefined;
-  const executionSigner = localOwsBaseUrl
-    ? createEmberLendingLocalOwsExecutionSigner({
-        baseUrl: localOwsBaseUrl,
-      })
-    : undefined;
+  const { protocolHost, executionSigner } = resolveEmberLendingGatewayDependencies(env);
 
   return {
     model: createOpenRouterModel(modelId),
@@ -99,5 +93,25 @@ export function createEmberLendingAgentConfig(
       },
       getApiKey: () => apiKey,
     },
+  };
+}
+
+export function resolveEmberLendingGatewayDependencies(
+  env: EmberLendingGatewayEnv = process.env,
+): EmberLendingGatewayDependencies {
+  const sharedEmberBaseUrl = resolveEmberLendingSharedEmberBaseUrl(env);
+  const localOwsBaseUrl = resolveEmberLendingLocalOwsBaseUrl(env);
+
+  return {
+    protocolHost: sharedEmberBaseUrl
+      ? createEmberLendingSharedEmberHttpHost({
+          baseUrl: sharedEmberBaseUrl,
+        })
+      : undefined,
+    executionSigner: localOwsBaseUrl
+      ? createEmberLendingLocalOwsExecutionSigner({
+          baseUrl: localOwsBaseUrl,
+        })
+      : undefined,
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.ts
@@ -23,16 +23,30 @@ function readErrorMessage(body: unknown): string | null {
   return typeof message === 'string' && message.trim().length > 0 ? message : null;
 }
 
-async function postJson(input: {
+function readWalletAddress(body: unknown): `0x${string}` | null {
+  if (!isRecord(body)) {
+    return null;
+  }
+
+  const walletAddress =
+    body['wallet_address'] ?? body['signer_wallet_address'] ?? body['signer_address'];
+
+  return typeof walletAddress === 'string' && walletAddress.startsWith('0x')
+    ? (walletAddress as `0x${string}`)
+    : null;
+}
+
+async function requestJson(input: {
   url: string;
-  body: unknown;
+  method?: 'GET' | 'POST';
+  body?: unknown;
 }): Promise<unknown> {
   const response = await fetch(input.url, {
-    method: 'POST',
+    method: input.method ?? 'POST',
     headers: {
       'content-type': jsonContentType,
     },
-    body: JSON.stringify(input.body),
+    body: input.body === undefined ? undefined : JSON.stringify(input.body),
   });
 
   const rawBody = await response.text();
@@ -63,15 +77,28 @@ export function createEmberLendingLocalOwsExecutionSigner(input: {
   const baseUrl = trimTrailingSlash(input.baseUrl);
 
   return {
+    async readSignerWalletAddress() {
+      const responseBody = await requestJson({
+        url: `${baseUrl}/identity`,
+        method: 'GET',
+      });
+      const walletAddress = readWalletAddress(responseBody);
+      if (!walletAddress) {
+        throw new Error('Local OWS signer identity response was missing a wallet address.');
+      }
+
+      return walletAddress;
+    },
+
     async signExecutionPackage(request) {
-      return (await postJson({
+      return (await requestJson({
         url: `${baseUrl}/sign/execution`,
         body: request,
       })) as Awaited<ReturnType<EmberLendingExecutionSigner['signExecutionPackage']>>;
     },
 
     async signRedelegationPackage(request) {
-      return (await postJson({
+      return (await requestJson({
         url: `${baseUrl}/sign/redelegation`,
         body: request,
       })) as Awaited<

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/localOwsExecutionSigner.unit.test.ts
@@ -29,7 +29,11 @@ describe('createEmberLendingLocalOwsExecutionSigner', () => {
     responseBody = null;
     server = createServer((request: IncomingMessage, response: ServerResponse) => {
       void (async () => {
-        if (request.url !== '/sign/execution' && request.url !== '/sign/redelegation') {
+        if (
+          request.url !== '/sign/execution' &&
+          request.url !== '/sign/redelegation' &&
+          request.url !== '/identity'
+        ) {
           response.writeHead(404);
           response.end();
           return;
@@ -40,11 +44,16 @@ describe('createEmberLendingLocalOwsExecutionSigner', () => {
         });
         response.end(
           JSON.stringify(
-            responseBody ?? {
-              ok: true,
-              path: request.url,
-              received: await readRequestBody(request),
-            },
+            responseBody ??
+              (request.url === '/identity'
+                ? {
+                    wallet_address: '0x00000000000000000000000000000000000000b1',
+                  }
+                : {
+                    ok: true,
+                    path: request.url,
+                    received: await readRequestBody(request),
+                  }),
           ),
         );
       })().catch((error: unknown) => {
@@ -196,6 +205,20 @@ describe('createEmberLendingLocalOwsExecutionSigner', () => {
         },
       }),
     ).rejects.toThrow('execution signer unavailable');
+  });
+
+  it('reads the local OWS signer wallet identity from the sidecar identity endpoint', async () => {
+    responseBody = {
+      wallet_address: '0x00000000000000000000000000000000000000b1',
+    };
+
+    const signer = createEmberLendingLocalOwsExecutionSigner({
+      baseUrl,
+    });
+
+    await expect(signer.readSignerWalletAddress?.()).resolves.toBe(
+      '0x00000000000000000000000000000000000000b1',
+    );
   });
 
   it('normalizes the optional local OWS base URL from env', () => {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
@@ -1,0 +1,177 @@
+import {
+  EMBER_LENDING_SHARED_EMBER_AGENT_ID,
+  type EmberLendingSharedEmberProtocolHost,
+} from './sharedEmberAdapter.js';
+
+type EnsureEmberLendingServiceIdentityInput = {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  readSignerWalletAddress: () => Promise<`0x${string}`>;
+  now?: () => Date;
+};
+
+type AgentServiceIdentity = {
+  identity_ref: string;
+  agent_id: string;
+  role: 'subagent';
+  wallet_address: `0x${string}`;
+  wallet_source: string;
+  capability_metadata: Record<string, unknown>;
+  registration_version: number;
+  registered_at: string;
+};
+
+const EMBER_LENDING_SERVICE_ROLE = 'subagent';
+const EMBER_LENDING_WALLET_SOURCE = 'ember_local_write';
+const EMBER_LENDING_CAPABILITY_METADATA = {
+  execution: true,
+  onboarding: true,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readHexAddress(value: unknown): `0x${string}` | null {
+  const normalized = readString(value);
+  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+}
+
+function readInt(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const identityRef = readString(value['identity_ref']);
+  const agentId = readString(value['agent_id']);
+  const walletAddress = readHexAddress(value['wallet_address']);
+  const walletSource = readString(value['wallet_source']);
+  const registrationVersion = readInt(value['registration_version']);
+  const registeredAt = readString(value['registered_at']);
+  const capabilityMetadata = isRecord(value['capability_metadata'])
+    ? value['capability_metadata']
+    : null;
+
+  if (
+    identityRef === null ||
+    agentId === null ||
+    walletAddress === null ||
+    walletSource === null ||
+    registrationVersion === null ||
+    registeredAt === null ||
+    capabilityMetadata === null
+  ) {
+    return null;
+  }
+
+  return {
+    identity_ref: identityRef,
+    agent_id: agentId,
+    role: EMBER_LENDING_SERVICE_ROLE,
+    wallet_address: walletAddress,
+    wallet_source: walletSource,
+    capability_metadata: capabilityMetadata,
+    registration_version: registrationVersion,
+    registered_at: registeredAt,
+  };
+}
+
+async function readCurrentIdentity(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+}): Promise<{
+  revision: number;
+  identity: AgentServiceIdentity | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-read',
+    method: 'orchestrator.readAgentServiceIdentity.v1',
+    params: {
+      agent_id: EMBER_LENDING_SHARED_EMBER_AGENT_ID,
+      role: EMBER_LENDING_SERVICE_ROLE,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']) ?? 0,
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
+  };
+}
+
+async function writeIdentity(input: {
+  protocolHost: EmberLendingSharedEmberProtocolHost;
+  expectedRevision: number;
+  identity: AgentServiceIdentity;
+}): Promise<{
+  revision: number | null;
+  identity: AgentServiceIdentity | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-write',
+    method: 'orchestrator.writeAgentServiceIdentity.v1',
+    params: {
+      idempotency_key: 'idem-ember-lending-subagent-service-identity-startup',
+      expected_revision: input.expectedRevision,
+      agent_service_identity: input.identity,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']),
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
+  };
+}
+
+export async function ensureEmberLendingServiceIdentity(
+  input: EnsureEmberLendingServiceIdentityInput,
+): Promise<{
+  revision: number | null;
+  wroteIdentity: boolean;
+  identity: Record<string, unknown> | null;
+}> {
+  const walletAddress = await input.readSignerWalletAddress();
+  const current = await readCurrentIdentity({
+    protocolHost: input.protocolHost,
+  });
+
+  if (current.identity?.wallet_address === walletAddress) {
+    return {
+      revision: current.revision,
+      wroteIdentity: false,
+      identity: current.identity,
+    };
+  }
+
+  const registrationVersion = (current.identity?.registration_version ?? 0) + 1;
+  const identity: AgentServiceIdentity = {
+    identity_ref: `agent-service-identity-${EMBER_LENDING_SHARED_EMBER_AGENT_ID}-${EMBER_LENDING_SERVICE_ROLE}-${registrationVersion}`,
+    agent_id: EMBER_LENDING_SHARED_EMBER_AGENT_ID,
+    role: EMBER_LENDING_SERVICE_ROLE,
+    wallet_address: walletAddress,
+    wallet_source: EMBER_LENDING_WALLET_SOURCE,
+    capability_metadata: EMBER_LENDING_CAPABILITY_METADATA,
+    registration_version: registrationVersion,
+    registered_at: (input.now ?? (() => new Date()))().toISOString(),
+  };
+  const written = await writeIdentity({
+    protocolHost: input.protocolHost,
+    expectedRevision: current.revision,
+    identity,
+  });
+
+  return {
+    revision: written.revision,
+    wroteIdentity: true,
+    identity: written.identity,
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
@@ -26,6 +26,8 @@ const EMBER_LENDING_CAPABILITY_METADATA = {
   execution: true,
   onboarding: true,
 };
+const UNCONFIRMED_SUBAGENT_IDENTITY_ERROR =
+  'Lending startup identity preflight failed because Shared Ember did not confirm the expected subagent identity.';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -119,7 +121,7 @@ async function writeIdentity(input: {
     id: 'rpc-agent-service-identity-write',
     method: 'orchestrator.writeAgentServiceIdentity.v1',
     params: {
-      idempotency_key: 'idem-ember-lending-subagent-service-identity-startup',
+      idempotency_key: `idem-agent-service-identity-${input.identity.identity_ref}`,
       expected_revision: input.expectedRevision,
       agent_service_identity: input.identity,
     },
@@ -132,12 +134,23 @@ async function writeIdentity(input: {
   };
 }
 
+function requireConfirmedIdentity(input: {
+  expectedWalletAddress: `0x${string}`;
+  identity: AgentServiceIdentity | null;
+}): AgentServiceIdentity {
+  if (input.identity?.wallet_address !== input.expectedWalletAddress) {
+    throw new Error(UNCONFIRMED_SUBAGENT_IDENTITY_ERROR);
+  }
+
+  return input.identity;
+}
+
 export async function ensureEmberLendingServiceIdentity(
   input: EnsureEmberLendingServiceIdentityInput,
 ): Promise<{
   revision: number | null;
   wroteIdentity: boolean;
-  identity: Record<string, unknown> | null;
+  identity: AgentServiceIdentity;
 }> {
   const walletAddress = await input.readSignerWalletAddress();
   const current = await readCurrentIdentity({
@@ -168,10 +181,14 @@ export async function ensureEmberLendingServiceIdentity(
     expectedRevision: current.revision,
     identity,
   });
+  const confirmedIdentity = requireConfirmedIdentity({
+    expectedWalletAddress: walletAddress,
+    identity: written.identity,
+  });
 
   return {
     revision: written.revision,
     wroteIdentity: true,
-    identity: written.identity,
+    identity: confirmedIdentity,
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
@@ -73,6 +73,14 @@ function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
     return null;
   }
 
+  if (agentId !== EMBER_LENDING_SHARED_EMBER_AGENT_ID) {
+    return null;
+  }
+
+  if (readString(value['role']) !== EMBER_LENDING_SERVICE_ROLE) {
+    return null;
+  }
+
   return {
     identity_ref: identityRef,
     agent_id: agentId,
@@ -135,10 +143,14 @@ async function writeIdentity(input: {
 }
 
 function requireConfirmedIdentity(input: {
-  expectedWalletAddress: `0x${string}`;
+  expectedIdentity: Pick<AgentServiceIdentity, 'agent_id' | 'role' | 'wallet_address'>;
   identity: AgentServiceIdentity | null;
 }): AgentServiceIdentity {
-  if (input.identity?.wallet_address !== input.expectedWalletAddress) {
+  if (
+    input.identity?.agent_id !== input.expectedIdentity.agent_id ||
+    input.identity?.role !== input.expectedIdentity.role ||
+    input.identity?.wallet_address !== input.expectedIdentity.wallet_address
+  ) {
     throw new Error(UNCONFIRMED_SUBAGENT_IDENTITY_ERROR);
   }
 
@@ -182,7 +194,7 @@ export async function ensureEmberLendingServiceIdentity(
     identity,
   });
   const confirmedIdentity = requireConfirmedIdentity({
-    expectedWalletAddress: walletAddress,
+    expectedIdentity: identity,
     identity: written.identity,
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.unit.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureEmberLendingServiceIdentity } from './serviceIdentityPreflight.js';
+
+describe('ensureEmberLendingServiceIdentity', () => {
+  it('reuses the durable subagent identity when the OWS signer wallet already matches', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 6,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-ember-lending-subagent-2',
+              agent_id: 'ember-lending',
+              role: 'subagent',
+              wallet_address: '0x00000000000000000000000000000000000000b1',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                execution: true,
+                onboarding: true,
+              },
+              registration_version: 2,
+              registered_at: '2026-04-01T09:00:00.000Z',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureEmberLendingServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readSignerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000b1',
+        ),
+      }),
+    ).resolves.toMatchObject({
+      revision: 6,
+      wroteIdentity: false,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000b1',
+        registration_version: 2,
+      },
+    });
+
+    expect(handleJsonRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the durable subagent identity when Shared Ember has no current record', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 4,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.idempotency_key).toBe(
+          'idem-ember-lending-subagent-service-identity-startup',
+        );
+        expect(jsonRpcRequest.params?.expected_revision).toBe(4);
+        expect(jsonRpcRequest.params?.agent_service_identity).toMatchObject({
+          identity_ref: 'agent-service-identity-ember-lending-subagent-1',
+          agent_id: 'ember-lending',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000b1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            execution: true,
+            onboarding: true,
+          },
+          registration_version: 1,
+          registered_at: '2026-04-02T09:00:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-agent-service-identity-1'],
+            agent_service_identity: jsonRpcRequest.params?.agent_service_identity,
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureEmberLendingServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readSignerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000b1',
+        ),
+        now: () => new Date('2026-04-02T09:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      revision: 5,
+      wroteIdentity: true,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000b1',
+        registration_version: 1,
+      },
+    });
+  });
+
+  it('rotates the durable subagent identity when the local OWS signer wallet changes', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 6,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-ember-lending-subagent-2',
+              agent_id: 'ember-lending',
+              role: 'subagent',
+              wallet_address: '0x00000000000000000000000000000000000000b0',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                execution: true,
+                onboarding: true,
+              },
+              registration_version: 2,
+              registered_at: '2026-04-01T09:00:00.000Z',
+            },
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.expected_revision).toBe(6);
+        expect(jsonRpcRequest.params?.agent_service_identity).toMatchObject({
+          identity_ref: 'agent-service-identity-ember-lending-subagent-3',
+          agent_id: 'ember-lending',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000b1',
+          registration_version: 3,
+          registered_at: '2026-04-02T09:15:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 7,
+            committed_event_ids: ['evt-agent-service-identity-2'],
+            agent_service_identity: jsonRpcRequest.params?.agent_service_identity,
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureEmberLendingServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readSignerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000b1',
+        ),
+        now: () => new Date('2026-04-02T09:15:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      revision: 7,
+      wroteIdentity: true,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000b1',
+        registration_version: 3,
+      },
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.unit.test.ts
@@ -81,7 +81,7 @@ describe('ensureEmberLendingServiceIdentity', () => {
 
       if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
         expect(jsonRpcRequest.params?.idempotency_key).toBe(
-          'idem-ember-lending-subagent-service-identity-startup',
+          'idem-agent-service-identity-agent-service-identity-ember-lending-subagent-1',
         );
         expect(jsonRpcRequest.params?.expected_revision).toBe(4);
         expect(jsonRpcRequest.params?.agent_service_identity).toMatchObject({
@@ -212,5 +212,157 @@ describe('ensureEmberLendingServiceIdentity', () => {
         registration_version: 3,
       },
     });
+  });
+
+  it('uses a distinct idempotency key for each distinct subagent identity write', async () => {
+    const writeKeys: string[] = [];
+    const readResponses = [
+      {
+        revision: 4,
+        agent_service_identity: null,
+      },
+      {
+        revision: 5,
+        agent_service_identity: {
+          identity_ref: 'agent-service-identity-ember-lending-subagent-1',
+          agent_id: 'ember-lending',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000b1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            execution: true,
+            onboarding: true,
+          },
+          registration_version: 1,
+          registered_at: '2026-04-02T09:00:00.000Z',
+        },
+      },
+    ];
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        const nextRead = readResponses.shift();
+        if (!nextRead) {
+          throw new Error('expected another read response');
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: nextRead.revision,
+            agent_service_identity: nextRead.agent_service_identity,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        const idempotencyKey = jsonRpcRequest.params?.idempotency_key;
+        if (typeof idempotencyKey !== 'string') {
+          throw new Error('expected write idempotency key');
+        }
+
+        writeKeys.push(idempotencyKey);
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: writeKeys.length + 4,
+            committed_event_ids: [`evt-agent-service-identity-${writeKeys.length}`],
+            agent_service_identity: jsonRpcRequest.params?.agent_service_identity,
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await ensureEmberLendingServiceIdentity({
+      protocolHost: {
+        handleJsonRpc,
+        readCommittedEventOutbox: vi.fn(),
+        acknowledgeCommittedEventOutbox: vi.fn(),
+      },
+      readSignerWalletAddress: vi.fn(
+        async () => '0x00000000000000000000000000000000000000b1',
+      ),
+      now: () => new Date('2026-04-02T09:00:00.000Z'),
+    });
+
+    await ensureEmberLendingServiceIdentity({
+      protocolHost: {
+        handleJsonRpc,
+        readCommittedEventOutbox: vi.fn(),
+        acknowledgeCommittedEventOutbox: vi.fn(),
+      },
+      readSignerWalletAddress: vi.fn(
+        async () => '0x00000000000000000000000000000000000000b2',
+      ),
+      now: () => new Date('2026-04-02T10:00:00.000Z'),
+    });
+
+    expect(writeKeys).toEqual([
+      'idem-agent-service-identity-agent-service-identity-ember-lending-subagent-1',
+      'idem-agent-service-identity-agent-service-identity-ember-lending-subagent-2',
+    ]);
+    expect(new Set(writeKeys)).toHaveLength(2);
+  });
+
+  it('fails when Shared Ember does not confirm the written subagent identity', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 4,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureEmberLendingServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readSignerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000b1',
+        ),
+        now: () => new Date('2026-04-02T09:00:00.000Z'),
+      }),
+    ).rejects.toThrow(
+      'Lending startup identity preflight failed because Shared Ember did not confirm the expected subagent identity.',
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.unit.test.ts
@@ -365,4 +365,58 @@ describe('ensureEmberLendingServiceIdentity', () => {
       'Lending startup identity preflight failed because Shared Ember did not confirm the expected subagent identity.',
     );
   });
+
+  it('fails when Shared Ember echoes the wrong role for the written subagent identity', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 4,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            agent_service_identity: {
+              ...(jsonRpcRequest.params?.agent_service_identity as Record<string, unknown>),
+              role: 'orchestrator',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureEmberLendingServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readSignerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000b1',
+        ),
+        now: () => new Date('2026-04-02T09:00:00.000Z'),
+      }),
+    ).rejects.toThrow(
+      'Lending startup identity preflight failed because Shared Ember did not confirm the expected subagent identity.',
+    );
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -7,6 +7,7 @@ export type EmberLendingSharedEmberProtocolHost = {
 };
 
 export type EmberLendingExecutionSigner = {
+  readSignerWalletAddress?: () => Promise<`0x${string}`>;
   signRedelegationPackage?: (input: {
     walletAddress: `0x${string}`;
     transactionPlanId: string;
@@ -29,6 +30,7 @@ export type EmberLendingExecutionSigner = {
 };
 
 export const EMBER_LENDING_INTERNAL_HYDRATE_COMMAND = 'hydrate_runtime_projection';
+export const EMBER_LENDING_SHARED_EMBER_AGENT_ID = 'ember-lending';
 
 export type EmberLendingLifecycleState = {
   phase: 'prehire' | 'onboarding' | 'active' | 'firing' | 'inactive';
@@ -1609,7 +1611,7 @@ function readEscalationResult(operationInput: unknown): unknown {
 export function createEmberLendingDomain(
   options: CreateEmberLendingDomainOptions = {},
 ): AgentRuntimeDomainConfig<EmberLendingLifecycleState> {
-  const agentId = options.agentId ?? 'ember-lending';
+  const agentId = options.agentId ?? EMBER_LENDING_SHARED_EMBER_AGENT_ID;
 
   return {
     lifecycle: {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/startupIdentityPreflight.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/startupIdentityPreflight.int.test.ts
@@ -1,0 +1,281 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createEmberLendingGatewayService } from './agUiServer.js';
+
+type StubRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+};
+
+type StubResponse = {
+  status?: number;
+  body?: unknown;
+};
+
+async function readRequestBody(request: IncomingMessage): Promise<Uint8Array> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function startJsonStubServer(
+  handler: (request: StubRequest) => Promise<StubResponse> | StubResponse,
+): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    void (async () => {
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+      const rawBody = await readRequestBody(request);
+      const body =
+        rawBody.length === 0 ? null : (JSON.parse(Buffer.from(rawBody).toString('utf8')) as unknown);
+      const result = await handler({
+        method: request.method ?? 'GET',
+        path: url.pathname,
+        body,
+      });
+
+      response.statusCode = result.status ?? 200;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(JSON.stringify(result.body ?? null));
+    })().catch((error: unknown) => {
+      response.statusCode = 500;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(
+        JSON.stringify({
+          message: error instanceof Error ? error.message : 'unknown error',
+        }),
+      );
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+function createInternalPostgresHooks() {
+  return {
+    ensureReady: vi.fn(async () => ({
+      databaseUrl: 'postgresql://postgres:postgres@127.0.0.1:55432/pi_runtime',
+    })),
+    loadInspectionState: vi.fn(async () => ({
+      threads: [],
+      executions: [],
+      automations: [],
+      automationRuns: [],
+      interrupts: [],
+      leases: [],
+      outboxIntents: [],
+      executionEvents: [],
+      threadActivities: [],
+    })),
+    executeStatements: vi.fn(async () => undefined),
+    persistDirectExecution: vi.fn(async () => undefined),
+  };
+}
+
+describe('ember-lending startup identity preflight integration', () => {
+  const cleanupFns: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanupFns.length > 0) {
+      const cleanup = cleanupFns.pop();
+      if (cleanup) {
+        await cleanup();
+      }
+    }
+  });
+
+  it('writes the subagent identity through the live Shared Ember and local OWS HTTP boundaries before boot succeeds', async () => {
+    const sharedEmberRequests: Array<Record<string, unknown>> = [];
+    const sharedEmber = await startJsonStubServer(async ({ path, body }) => {
+      if (path !== '/jsonrpc') {
+        return {
+          status: 404,
+          body: {
+            message: 'not found',
+          },
+        };
+      }
+
+      const request =
+        typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : {};
+      sharedEmberRequests.push(request);
+
+      if (request['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-read',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              agent_service_identity: null,
+            },
+          },
+        };
+      }
+
+      if (request['method'] === 'orchestrator.writeAgentServiceIdentity.v1') {
+        const params =
+          typeof request['params'] === 'object' && request['params'] !== null
+            ? (request['params'] as Record<string, unknown>)
+            : {};
+
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-write',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              agent_service_identity: params['agent_service_identity'] ?? null,
+            },
+          },
+        };
+      }
+
+      return {
+        status: 500,
+        body: {
+          message: `unexpected method ${String(request['method'])}`,
+        },
+      };
+    });
+    cleanupFns.push(sharedEmber.close);
+
+    const localOws = await startJsonStubServer(async ({ method, path }) => {
+      if (method === 'GET' && path === '/identity') {
+        return {
+          body: {
+            wallet_address: '0x00000000000000000000000000000000000000b1',
+          },
+        };
+      }
+
+      return {
+        status: 404,
+        body: {
+          message: 'not found',
+        },
+      };
+    });
+    cleanupFns.push(localOws.close);
+
+    const service = await createEmberLendingGatewayService({
+      env: {
+        OPENROUTER_API_KEY: 'test-openrouter-key',
+        SHARED_EMBER_BASE_URL: sharedEmber.baseUrl,
+        EMBER_LENDING_OWS_BASE_URL: localOws.baseUrl,
+      },
+      __internalPostgres: createInternalPostgresHooks(),
+    } as never);
+
+    await expect(service.control.inspectHealth()).resolves.toMatchObject({
+      status: 'ok',
+    });
+
+    expect(sharedEmberRequests).toHaveLength(2);
+    expect(sharedEmberRequests[0]).toMatchObject({
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'ember-lending',
+        role: 'subagent',
+      },
+    });
+    expect(sharedEmberRequests[1]).toMatchObject({
+      method: 'orchestrator.writeAgentServiceIdentity.v1',
+      params: {
+        expected_revision: 4,
+        agent_service_identity: {
+          agent_id: 'ember-lending',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000b1',
+          registration_version: 1,
+        },
+      },
+    });
+  });
+
+  it('fails closed before boot succeeds when the local OWS signer identity omits the wallet address', async () => {
+    const sharedEmberRequests: Array<Record<string, unknown>> = [];
+    const sharedEmber = await startJsonStubServer(async ({ path, body }) => {
+      if (path === '/jsonrpc' && typeof body === 'object' && body !== null) {
+        sharedEmberRequests.push(body as Record<string, unknown>);
+      }
+
+      return {
+        body: {
+          jsonrpc: '2.0',
+          id: 'unexpected',
+          result: {},
+        },
+      };
+    });
+    cleanupFns.push(sharedEmber.close);
+
+    const localOws = await startJsonStubServer(async ({ method, path }) => {
+      if (method === 'GET' && path === '/identity') {
+        return {
+          body: {
+            status: 'ok',
+          },
+        };
+      }
+
+      return {
+        status: 404,
+        body: {
+          message: 'not found',
+        },
+      };
+    });
+    cleanupFns.push(localOws.close);
+
+    await expect(
+      createEmberLendingGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: sharedEmber.baseUrl,
+          EMBER_LENDING_OWS_BASE_URL: localOws.baseUrl,
+        },
+        __internalPostgres: createInternalPostgresHooks(),
+      } as never),
+    ).rejects.toThrow('Local OWS signer identity response was missing a wallet address.');
+
+    expect(sharedEmberRequests).toHaveLength(0);
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/startupIdentityPreflight.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/startupIdentityPreflight.int.test.ts
@@ -230,6 +230,96 @@ describe('ember-lending startup identity preflight integration', () => {
     });
   });
 
+  it('fails closed before boot succeeds when Shared Ember does not confirm the subagent identity write', async () => {
+    const sharedEmberRequests: Array<Record<string, unknown>> = [];
+    const sharedEmber = await startJsonStubServer(async ({ path, body }) => {
+      if (path !== '/jsonrpc') {
+        return {
+          status: 404,
+          body: {
+            message: 'not found',
+          },
+        };
+      }
+
+      const request =
+        typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : {};
+      sharedEmberRequests.push(request);
+
+      if (request['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-read',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              agent_service_identity: null,
+            },
+          },
+        };
+      }
+
+      if (request['method'] === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-write',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              agent_service_identity: null,
+            },
+          },
+        };
+      }
+
+      return {
+        status: 500,
+        body: {
+          message: `unexpected method ${String(request['method'])}`,
+        },
+      };
+    });
+    cleanupFns.push(sharedEmber.close);
+
+    const localOws = await startJsonStubServer(async ({ method, path }) => {
+      if (method === 'GET' && path === '/identity') {
+        return {
+          body: {
+            wallet_address: '0x00000000000000000000000000000000000000b1',
+          },
+        };
+      }
+
+      return {
+        status: 404,
+        body: {
+          message: 'not found',
+        },
+      };
+    });
+    cleanupFns.push(localOws.close);
+
+    await expect(
+      createEmberLendingGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: sharedEmber.baseUrl,
+          EMBER_LENDING_OWS_BASE_URL: localOws.baseUrl,
+        },
+        __internalPostgres: createInternalPostgresHooks(),
+      } as never),
+    ).rejects.toThrow(
+      'Lending startup identity preflight failed because Shared Ember did not confirm the expected subagent identity.',
+    );
+
+    expect(sharedEmberRequests).toHaveLength(2);
+    expect(sharedEmberRequests[1]).toMatchObject({
+      method: 'orchestrator.writeAgentServiceIdentity.v1',
+    });
+  });
+
   it('fails closed before boot succeeds when the local OWS signer identity omits the wallet address', async () => {
     const sharedEmberRequests: Array<Record<string, unknown>> = [];
     const sharedEmber = await startJsonStubServer(async ({ path, body }) => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/.env.example
@@ -1,6 +1,28 @@
 # agent-portfolio-manager (.env.example)
-PORT=3420
+#
+# Copy to `.env` (gitignored) to override locally. The `pnpm dev` and `pnpm start`
+# scripts automatically load `.env`, falling back to this file when `.env` is absent.
+
+# Required for the real Pi-native agent loop.
 OPENROUTER_API_KEY=
-PORTFOLIO_MANAGER_MODEL=openai/gpt-5.4-mini
+
+# Optional: override the OpenRouter model id used by the portfolio-manager runtime.
+# Defaults to `openai/gpt-5.4-mini`.
+# PORTFOLIO_MANAGER_MODEL=openai/gpt-5.4-mini
+
+# Optional: bind the HTTP server to a different port.
+# PORT=3420
+
+# Optional: override the runtime-managed Postgres URL.
 # DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/pi_runtime
+
+# Optional: point the portfolio-manager runtime at the Shared Ember Domain Service
+# HTTP boundary. When this is set for the live managed-onboarding path,
+# `PORTFOLIO_MANAGER_OWS_BASE_URL` is also required so startup can resolve the
+# local controller wallet and confirm or rewrite the durable orchestrator identity.
 # SHARED_EMBER_BASE_URL=http://127.0.0.1:4010
+
+# Optional: point the portfolio-manager runtime at the local OWS controller
+# boundary used to resolve the controller wallet for startup identity preflight.
+# Required whenever `SHARED_EMBER_BASE_URL` is set for live onboarding.
+# PORTFOLIO_MANAGER_OWS_BASE_URL=http://127.0.0.1:4030

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
@@ -32,7 +32,11 @@ Runtime wiring:
   before the runtime is considered ready
 - if the durable orchestrator identity is missing or points at a different
   wallet than the current OWS-resolved controller wallet, startup rewrites the
-  durable identity record instead of continuing with stale state
+  durable identity record instead of continuing with stale state, using a fresh
+  identity-scoped idempotency key for each distinct write
+- startup treats the Shared Ember write as successful only when the response
+  echoes back the confirmed `portfolio-manager` / `orchestrator` identity; if
+  the confirmation is missing or mismatched, the runtime fails closed
 - onboarding re-reads both required durable service identities before rooted
   bootstrap and blocks activation if either `portfolio-manager` /
   `orchestrator` or `ember-lending` / `subagent` is missing or unverified

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
@@ -67,3 +67,18 @@ For real Shared Ember integration coverage, use the opt-in sidecar lane:
 When `EMBER_ORCHESTRATION_V1_SPEC_ROOT` is set, the integration test imports
 the private repo's repo-local harness only to boot the HTTP service. The
 assertions themselves still run against the HTTP/JSON-RPC boundary.
+
+For the audited managed-onboarding proof on the current downstream boundary,
+run from `typescript/clients/web-ag-ui/`:
+
+- `pnpm smoke:managed-identities`
+
+That smoke confirms:
+
+- `portfolio-manager` / `orchestrator` resolves non-null in Shared Ember
+- `ember-lending` / `subagent` resolves non-null in Shared Ember
+- after rooted bootstrap, `subagent.readExecutionContext.v1` returns a non-null
+  `subagent_wallet_address`
+
+The smoke intentionally uses the current downstream OWS-facing HTTP seam rather
+than solving the separate follow-on OWS-internals issue.

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
@@ -20,6 +20,26 @@ completion, so Shared Ember creates the initial `ember-lending` lane during
 rooted bootstrap instead of reserving that capital under the portfolio-manager
 agent id.
 
+Runtime wiring:
+
+- `SHARED_EMBER_BASE_URL` points the app at the bounded Shared Ember HTTP
+  surface.
+- `PORTFOLIO_MANAGER_OWS_BASE_URL` points the app at the local OWS controller
+  identity surface.
+- when `SHARED_EMBER_BASE_URL` is set for the live managed-onboarding path,
+  startup now resolves the local controller wallet from OWS and confirms the
+  durable `portfolio-manager` / `orchestrator` service identity in Shared Ember
+  before the runtime is considered ready
+- if the durable orchestrator identity is missing or points at a different
+  wallet than the current OWS-resolved controller wallet, startup rewrites the
+  durable identity record instead of continuing with stale state
+- onboarding re-reads both required durable service identities before rooted
+  bootstrap and blocks activation if either `portfolio-manager` /
+  `orchestrator` or `ember-lending` / `subagent` is missing or unverified
+- if OWS is unavailable or does not resolve a controller wallet while Shared
+  Ember is configured, the runtime fails closed before managed onboarding can
+  proceed
+
 ## Shared Ember sidecar testing
 
 This package does not vendor or commit private `ember-orchestration-v1-spec`
@@ -31,6 +51,8 @@ For real Shared Ember integration coverage, use the opt-in sidecar lane:
 - set `SHARED_EMBER_BASE_URL` to an already running Shared Ember HTTP service
   or set `EMBER_ORCHESTRATION_V1_SPEC_ROOT` to a local private checkout with
   dependencies installed
+- set `PORTFOLIO_MANAGER_OWS_BASE_URL` when exercising the live startup
+  identity-preflight path
 - run `pnpm test:int`
 
 When `EMBER_ORCHESTRATION_V1_SPEC_ROOT` is set, the integration test imports

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
@@ -35,11 +35,16 @@ Runtime wiring:
   durable identity record instead of continuing with stale state, using a fresh
   identity-scoped idempotency key for each distinct write
 - startup treats the Shared Ember write as successful only when the response
-  echoes back the confirmed `portfolio-manager` / `orchestrator` identity; if
-  the confirmation is missing or mismatched, the runtime fails closed
+  echoes back the confirmed `portfolio-manager` / `orchestrator` identity with
+  the expected `agent_id`, `role`, and wallet address; if any part of that
+  confirmation is missing or mismatched, the runtime fails closed
 - onboarding re-reads both required durable service identities before rooted
   bootstrap and blocks activation if either `portfolio-manager` /
   `orchestrator` or `ember-lending` / `subagent` is missing or unverified
+- after rooted bootstrap succeeds, onboarding also reads
+  `subagent.readExecutionContext.v1` for `ember-lending` and refuses to mark
+  the portfolio manager active until Shared Ember exposes a non-null
+  `subagent_wallet_address` for the managed lending lane
 - if OWS is unavailable or does not resolve a controller wallet while Shared
   Ember is configured, the runtime fails closed before managed onboarding can
   proceed

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -735,6 +735,128 @@ describe('agent-portfolio-manager AG-UI integration', () => {
     );
   });
 
+  it('blocks onboarding over AG-UI when the portfolio-manager orchestrator identity is missing', async () => {
+    protocolHost.handleJsonRpc.mockImplementation(async (input: unknown): Promise<unknown> => {
+      const request =
+        typeof input === 'object' && input !== null
+          ? (input as { method?: unknown; params?: Record<string, unknown> })
+          : {};
+
+      if (request.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        if (
+          request.params?.['agent_id'] === 'portfolio-manager' &&
+          request.params['role'] === 'orchestrator'
+        ) {
+          return {
+            jsonrpc: '2.0',
+            id: 'rpc-agent-service-identity-read',
+            result: {
+              protocol_version: 'v1',
+              revision: 0,
+              agent_service_identity: null,
+            },
+          };
+        }
+      }
+
+      return handleDefaultSharedEmberJsonRpc(input);
+    });
+
+    const hireResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-blocked-orchestrator',
+        runId: 'run-hire',
+        forwardedProps: {
+          command: {
+            name: 'hire',
+          },
+        },
+      }),
+    });
+    expect(hireResponse.ok).toBe(true);
+
+    const setupResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-blocked-orchestrator',
+        runId: 'run-setup',
+        forwardedProps: {
+          command: {
+            resume: JSON.stringify(createPortfolioManagerSetupInput()),
+          },
+        },
+      }),
+    });
+    expect(setupResponse.ok).toBe(true);
+
+    const signingResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-blocked-orchestrator',
+        runId: 'run-signing',
+        forwardedProps: {
+          command: {
+            resume: JSON.stringify({
+              outcome: 'signed',
+              signedDelegations: [
+                {
+                  delegate: '0x2222222222222222222222222222222222222222',
+                  delegator: '0x00000000000000000000000000000000000000a1',
+                  authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                  caveats: [],
+                  salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+                  signature: '0x1234',
+                },
+              ],
+            }),
+          },
+        },
+      }),
+    });
+
+    expect(signingResponse.ok).toBe(true);
+    const signingEvents = parseEventStreamBody(await signingResponse.text());
+    const signingSnapshot = findStateSnapshot(signingEvents);
+
+    expect(signingSnapshot).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        thread: {
+          lifecycle: {
+            phase: 'onboarding',
+            activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+            pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          },
+          task: {
+            taskStatus: {
+              state: 'failed',
+              message: {
+                content:
+                  'Portfolio manager onboarding is blocked until the portfolio-manager service registers its orchestrator identity in Shared Ember.',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+      }),
+    );
+  });
+
   it('clears wallet-local onboarding state when delegation signing is rejected', async () => {
     const hireResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
       method: 'POST',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -192,6 +192,18 @@ async function handleDefaultSharedEmberJsonRpc(input: unknown): Promise<unknown>
           },
         },
       };
+    case 'subagent.readExecutionContext.v1':
+      return {
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-read-execution-context',
+        result: {
+          protocol_version: 'v1',
+          revision: 4,
+          execution_context: {
+            subagent_wallet_address: '0x00000000000000000000000000000000000000b1',
+          },
+        },
+      };
     default:
       throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
   }
@@ -547,6 +559,14 @@ describe('agent-portfolio-manager AG-UI integration', () => {
             orchestrator_wallet: '0x2222222222222222222222222222222222222222',
           }),
         }),
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.readExecutionContext.v1',
+        params: {
+          agent_id: 'ember-lending',
+        },
       }),
     );
 
@@ -944,5 +964,13 @@ describe('agent-portfolio-manager AG-UI integration', () => {
         },
       },
     });
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.readExecutionContext.v1',
+        params: {
+          agent_id: 'ember-lending',
+        },
+      }),
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -94,51 +94,114 @@ function createPortfolioManagerSetupInput() {
   };
 }
 
+function createAgentServiceIdentityResponse(input: {
+  agentId: string;
+  role: 'orchestrator' | 'subagent';
+  walletAddress: `0x${string}`;
+  revision?: number;
+}) {
+  return {
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-read',
+    result: {
+      protocol_version: 'v1',
+      revision: input.revision ?? 0,
+      agent_service_identity: {
+        identity_ref: `agent-service-identity-${input.agentId}-${input.role}-1`,
+        agent_id: input.agentId,
+        role: input.role,
+        wallet_address: input.walletAddress,
+        wallet_source: 'ember_local_write',
+        capability_metadata:
+          input.role === 'orchestrator'
+            ? {
+                onboarding: true,
+                root_registration: true,
+              }
+            : {
+                execution: true,
+                onboarding: true,
+              },
+        registration_version: 1,
+        registered_at: '2026-04-02T09:00:00.000Z',
+      },
+    },
+  };
+}
+
+async function handleDefaultSharedEmberJsonRpc(input: unknown): Promise<unknown> {
+  const request =
+    typeof input === 'object' && input !== null
+      ? (input as { method?: unknown; params?: Record<string, unknown> })
+      : {};
+
+  switch (request.method) {
+    case 'orchestrator.readAgentServiceIdentity.v1':
+      if (
+        request.params?.['agent_id'] === 'portfolio-manager' &&
+        request.params['role'] === 'orchestrator'
+      ) {
+        return createAgentServiceIdentityResponse({
+          agentId: 'portfolio-manager',
+          role: 'orchestrator',
+          walletAddress: '0x2222222222222222222222222222222222222222',
+        });
+      }
+
+      if (
+        request.params?.['agent_id'] === 'ember-lending' &&
+        request.params['role'] === 'subagent'
+      ) {
+        return createAgentServiceIdentityResponse({
+          agentId: 'ember-lending',
+          role: 'subagent',
+          walletAddress: '0x00000000000000000000000000000000000000b1',
+        });
+      }
+
+      throw new Error(
+        `Unexpected Shared Ember identity lookup: ${JSON.stringify(request.params ?? {})}`,
+      );
+    case 'subagent.readPortfolioState.v1':
+      return {
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-read-current-revision',
+        result: {
+          protocol_version: 'v1',
+          revision: 0,
+          portfolio_state: {
+            agent_id: 'portfolio-manager',
+            owned_units: [],
+            reservations: [],
+          },
+        },
+      };
+    case 'orchestrator.completeRootedBootstrapFromUserSigning.v1':
+      return {
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-complete-rooted-bootstrap',
+        result: {
+          protocol_version: 'v1',
+          revision: 3,
+          committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
+          rooted_wallet_context_id: 'rwc-thread10x00000000000000000000000000000000000000a1',
+          root_delegation: {
+            root_delegation_id: 'root-thread10x00000000000000000000000000000000000000a1',
+            user_wallet: '0x00000000000000000000000000000000000000a1',
+            status: 'active',
+          },
+        },
+      };
+    default:
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
+  }
+}
+
 describe('agent-portfolio-manager AG-UI integration', () => {
   let server: Server;
   let baseUrl: string;
   const protocolHost = {
-    handleJsonRpc: vi.fn(async (input: unknown) => {
-      const request =
-        typeof input === 'object' && input !== null
-          ? (input as { method?: unknown })
-          : {};
-
-      switch (request.method) {
-        case 'subagent.readPortfolioState.v1':
-          return {
-            jsonrpc: '2.0',
-            id: 'shared-ember-thread-1-read-current-revision',
-            result: {
-              protocol_version: 'v1',
-              revision: 0,
-              portfolio_state: {
-                agent_id: 'portfolio-manager',
-                owned_units: [],
-                reservations: [],
-              },
-            },
-          };
-        case 'orchestrator.completeRootedBootstrapFromUserSigning.v1':
-          return {
-            jsonrpc: '2.0',
-            id: 'shared-ember-thread-1-complete-rooted-bootstrap',
-            result: {
-              protocol_version: 'v1',
-              revision: 3,
-              committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
-              rooted_wallet_context_id: 'rwc-thread10x00000000000000000000000000000000000000a1',
-              root_delegation: {
-                root_delegation_id: 'root-thread10x00000000000000000000000000000000000000a1',
-                user_wallet: '0x00000000000000000000000000000000000000a1',
-                status: 'active',
-              },
-            },
-          };
-        default:
-          throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(request.method)}`);
-      }
-    }),
+    handleJsonRpc: vi.fn(handleDefaultSharedEmberJsonRpc),
     readCommittedEventOutbox: vi.fn(async () => ({
       protocol_version: 'v1',
       revision: 3,
@@ -153,6 +216,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
   };
 
   beforeEach(async () => {
+    protocolHost.handleJsonRpc.mockImplementation(handleDefaultSharedEmberJsonRpc);
     const service = await createPortfolioManagerGatewayService({
       runtimeConfig: {
         model: {
@@ -238,7 +302,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
         resolve();
       });
     });
-    protocolHost.handleJsonRpc.mockClear();
+    protocolHost.handleJsonRpc.mockReset();
     protocolHost.readCommittedEventOutbox.mockClear();
     protocolHost.acknowledgeCommittedEventOutbox.mockClear();
   });
@@ -516,6 +580,139 @@ describe('agent-portfolio-manager AG-UI integration', () => {
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('ownedUnits');
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('reservations');
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('policySnapshots');
+  });
+
+  it('blocks onboarding over AG-UI when the managed ember-lending identity is missing', async () => {
+    protocolHost.handleJsonRpc.mockImplementation(async (input: unknown): Promise<unknown> => {
+      const request =
+        typeof input === 'object' && input !== null
+          ? (input as { method?: unknown; params?: Record<string, unknown> })
+          : {};
+
+      if (request.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        if (
+          request.params?.['agent_id'] === 'portfolio-manager' &&
+          request.params['role'] === 'orchestrator'
+        ) {
+          return createAgentServiceIdentityResponse({
+            agentId: 'portfolio-manager',
+            role: 'orchestrator',
+            walletAddress: '0x2222222222222222222222222222222222222222',
+          });
+        }
+
+        if (
+          request.params?.['agent_id'] === 'ember-lending' &&
+          request.params['role'] === 'subagent'
+        ) {
+          return {
+            jsonrpc: '2.0',
+            id: 'rpc-agent-service-identity-read',
+            result: {
+              protocol_version: 'v1',
+              revision: 0,
+              agent_service_identity: null,
+            },
+          };
+        }
+      }
+
+      return handleDefaultSharedEmberJsonRpc(input);
+    });
+
+    const hireResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-blocked',
+        runId: 'run-hire',
+        forwardedProps: {
+          command: {
+            name: 'hire',
+          },
+        },
+      }),
+    });
+    expect(hireResponse.ok).toBe(true);
+
+    const setupResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-blocked',
+        runId: 'run-setup',
+        forwardedProps: {
+          command: {
+            resume: JSON.stringify(createPortfolioManagerSetupInput()),
+          },
+        },
+      }),
+    });
+    expect(setupResponse.ok).toBe(true);
+
+    const signingResponse = await fetch(`${baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-blocked',
+        runId: 'run-signing',
+        forwardedProps: {
+          command: {
+            resume: JSON.stringify({
+              outcome: 'signed',
+              signedDelegations: [
+                {
+                  delegate: '0x2222222222222222222222222222222222222222',
+                  delegator: '0x00000000000000000000000000000000000000a1',
+                  authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                  caveats: [],
+                  salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+                  signature: '0x1234',
+                },
+              ],
+            }),
+          },
+        },
+      }),
+    });
+
+    expect(signingResponse.ok).toBe(true);
+    const signingEvents = parseEventStreamBody(await signingResponse.text());
+    const signingSnapshot = findStateSnapshot(signingEvents);
+
+    expect(signingSnapshot).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        thread: {
+          lifecycle: {
+            phase: 'onboarding',
+            activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+            pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          },
+          task: {
+            taskStatus: {
+              state: 'failed',
+              message: {
+                content:
+                  'Portfolio manager onboarding is blocked until the ember-lending service registers its subagent identity in Shared Ember.',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+      }),
+    );
   });
 
   it('clears wallet-local onboarding state when delegation signing is rejected', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
@@ -63,16 +63,14 @@ export async function createPortfolioManagerGatewayService(
         protocolHost: dependencies.protocolHost,
         readControllerWalletAddress,
       });
-      const identity =
-        typeof ensuredIdentity.identity === 'object' && ensuredIdentity.identity !== null
-          ? ensuredIdentity.identity
-          : null;
-      const walletAddress =
-        identity && 'wallet_address' in identity && typeof identity['wallet_address'] === 'string'
-          ? identity['wallet_address']
-          : null;
-      controllerWalletAddress =
-        walletAddress?.startsWith('0x') ? (walletAddress as `0x${string}`) : undefined;
+      const walletAddress = ensuredIdentity.identity.wallet_address;
+      if (!walletAddress.startsWith('0x')) {
+        throw new Error(
+          'Portfolio-manager startup identity preflight failed because Shared Ember did not return a confirmed orchestrator wallet address.',
+        );
+      }
+
+      controllerWalletAddress = walletAddress;
     }
   }
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
@@ -4,7 +4,9 @@ import {
   createPortfolioManagerAgentConfig,
   type PortfolioManagerAgentConfig,
   type PortfolioManagerGatewayEnv,
+  resolvePortfolioManagerGatewayDependencies,
 } from './portfolioManagerFoundation.js';
+import { ensurePortfolioManagerServiceIdentity } from './serviceIdentityPreflight.js';
 
 export const PORTFOLIO_MANAGER_AGENT_ID = 'agent-portfolio-manager';
 export const PORTFOLIO_MANAGER_AG_UI_BASE_PATH = '/ag-ui';
@@ -23,6 +25,8 @@ type PortfolioManagerGatewayServiceOptions = {
 };
 
 type PortfolioManagerGatewayInternalOptions = PortfolioManagerGatewayServiceOptions & {
+  __internalCreateAgentRuntime?: typeof createAgentRuntime;
+  __internalEnsureServiceIdentity?: typeof ensurePortfolioManagerServiceIdentity;
   __internalPostgres?: {
     ensureReady?: (options?: { env?: { DATABASE_URL?: string } }) => Promise<{
       databaseUrl: string;
@@ -39,8 +43,45 @@ export async function createPortfolioManagerGatewayService(
 export async function createPortfolioManagerGatewayService(
   options: PortfolioManagerGatewayInternalOptions = {},
 ): Promise<AgentRuntimeService> {
-  const runtimeConfig = options.runtimeConfig ?? createPortfolioManagerAgentConfig(options.env);
-  const runtime = await createAgentRuntime({
+  const createAgentRuntimeImpl = options.__internalCreateAgentRuntime ?? createAgentRuntime;
+  let controllerWalletAddress: `0x${string}` | undefined;
+
+  if (options.runtimeConfig === undefined) {
+    const dependencies = resolvePortfolioManagerGatewayDependencies(options.env);
+    if (dependencies.protocolHost) {
+      const readControllerWalletAddress =
+        dependencies.controllerWallet?.readControllerWalletAddress;
+      if (!readControllerWalletAddress) {
+        throw new Error(
+          'Portfolio-manager startup identity preflight requires PORTFOLIO_MANAGER_OWS_BASE_URL to resolve the local controller wallet.',
+        );
+      }
+
+      const ensuredIdentity = await (
+        options.__internalEnsureServiceIdentity ?? ensurePortfolioManagerServiceIdentity
+      )({
+        protocolHost: dependencies.protocolHost,
+        readControllerWalletAddress,
+      });
+      const identity =
+        typeof ensuredIdentity.identity === 'object' && ensuredIdentity.identity !== null
+          ? ensuredIdentity.identity
+          : null;
+      const walletAddress =
+        identity && 'wallet_address' in identity && typeof identity['wallet_address'] === 'string'
+          ? identity['wallet_address']
+          : null;
+      controllerWalletAddress =
+        walletAddress?.startsWith('0x') ? (walletAddress as `0x${string}`) : undefined;
+    }
+  }
+
+  const runtimeConfig =
+    options.runtimeConfig ??
+    createPortfolioManagerAgentConfig(options.env, {
+      ...(controllerWalletAddress ? { controllerWalletAddress } : {}),
+    });
+  const runtime = await createAgentRuntimeImpl({
     ...runtimeConfig,
     ...(options.now ? { now: options.now } : {}),
     ...(options.__internalPostgres ? { __internalPostgres: options.__internalPostgres } : {}),

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentRuntimeService } from 'agent-runtime';
+
+import { createPortfolioManagerGatewayService } from './agUiServer.js';
+
+function createStubService(): AgentRuntimeService {
+  return {
+    connect: async () => [],
+    run: async () => [],
+    stop: async () => [],
+    control: {
+      inspectHealth: async () => ({ status: 'ok' }),
+      listThreads: async () => [],
+      listExecutions: async () => [],
+      listAutomations: async () => [],
+      listAutomationRuns: async () => [],
+      inspectScheduler: async () => ({ dueAutomationIds: [], leases: [] }),
+      inspectOutbox: async () => ({ dueOutboxIds: [], intents: [] }),
+      inspectMaintenance: async () => ({ recovery: {}, archival: {} }),
+    },
+    createAgUiHandler: () => async () => new Response(null),
+  };
+}
+
+describe('createPortfolioManagerGatewayService', () => {
+  it('runs controller-wallet identity preflight before runtime creation when the live Shared Ember path is configured', async () => {
+    const service = createStubService();
+    const ensureServiceIdentity = vi.fn(async () => ({
+      revision: 2,
+      wroteIdentity: false,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000c1',
+      },
+    }));
+    const createAgentRuntime = vi.fn(async () => ({
+      service,
+    }));
+
+    await expect(
+      createPortfolioManagerGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: 'http://127.0.0.1:56436',
+          PORTFOLIO_MANAGER_OWS_BASE_URL: 'http://127.0.0.1:4030',
+        },
+        __internalEnsureServiceIdentity: ensureServiceIdentity,
+        __internalCreateAgentRuntime: createAgentRuntime,
+      } as never),
+    ).resolves.toBe(service);
+
+    expect(ensureServiceIdentity).toHaveBeenCalledOnce();
+    expect(createAgentRuntime).toHaveBeenCalledOnce();
+    const ensureInvocationOrder = ensureServiceIdentity.mock.invocationCallOrder[0];
+    const runtimeInvocationOrder = createAgentRuntime.mock.invocationCallOrder[0];
+    expect(ensureInvocationOrder).toEqual(expect.any(Number));
+    expect(runtimeInvocationOrder).toEqual(expect.any(Number));
+    if (ensureInvocationOrder === undefined || runtimeInvocationOrder === undefined) {
+      throw new Error('expected both preflight and runtime creation to be invoked');
+    }
+    expect(ensureInvocationOrder).toBeLessThan(runtimeInvocationOrder);
+  });
+
+  it('fails closed before runtime creation when the controller wallet identity cannot be established', async () => {
+    const ensureServiceIdentity = vi.fn(async () => {
+      throw new Error(
+        'Portfolio-manager startup identity preflight failed because the local OWS controller did not resolve a wallet address.',
+      );
+    });
+    const createAgentRuntime = vi.fn(async () => ({
+      service: createStubService(),
+    }));
+
+    await expect(
+      createPortfolioManagerGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: 'http://127.0.0.1:56436',
+          PORTFOLIO_MANAGER_OWS_BASE_URL: 'http://127.0.0.1:4030',
+        },
+        __internalEnsureServiceIdentity: ensureServiceIdentity,
+        __internalCreateAgentRuntime: createAgentRuntime,
+      } as never),
+    ).rejects.toThrow(
+      'Portfolio-manager startup identity preflight failed because the local OWS controller did not resolve a wallet address.',
+    );
+
+    expect(createAgentRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/localOwsControllerWallet.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/localOwsControllerWallet.ts
@@ -1,0 +1,89 @@
+type PortfolioManagerLocalOwsControllerWalletEnv = NodeJS.ProcessEnv & {
+  PORTFOLIO_MANAGER_OWS_BASE_URL?: string;
+};
+
+const jsonContentType = 'application/json; charset=utf-8';
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readErrorMessage(body: unknown): string | null {
+  if (!isRecord(body)) {
+    return null;
+  }
+
+  const message = body['message'];
+  return typeof message === 'string' && message.trim().length > 0 ? message : null;
+}
+
+function readControllerWalletAddress(body: unknown): `0x${string}` | null {
+  if (!isRecord(body)) {
+    return null;
+  }
+
+  const walletAddress =
+    body['controller_wallet_address'] ?? body['controller_address'] ?? body['wallet_address'];
+
+  return typeof walletAddress === 'string' && walletAddress.startsWith('0x')
+    ? (walletAddress as `0x${string}`)
+    : null;
+}
+
+async function requestJson(input: {
+  url: string;
+}): Promise<unknown> {
+  const response = await fetch(input.url, {
+    method: 'GET',
+    headers: {
+      'content-type': jsonContentType,
+    },
+  });
+
+  const rawBody = await response.text();
+  const parsedBody = rawBody.length === 0 ? null : (JSON.parse(rawBody) as unknown);
+
+  if (!response.ok) {
+    throw new Error(`Local OWS controller HTTP request failed with status ${response.status}.`);
+  }
+
+  const errorMessage = readErrorMessage(parsedBody);
+  if (errorMessage) {
+    throw new Error(`Local OWS controller error: ${errorMessage}`);
+  }
+
+  return parsedBody;
+}
+
+export function resolvePortfolioManagerLocalOwsBaseUrl(
+  env: PortfolioManagerLocalOwsControllerWalletEnv = process.env,
+): string | null {
+  const normalized = env.PORTFOLIO_MANAGER_OWS_BASE_URL?.trim();
+  return normalized ? trimTrailingSlash(normalized) : null;
+}
+
+export function createPortfolioManagerLocalOwsControllerWallet(input: {
+  baseUrl: string;
+}): {
+  readControllerWalletAddress: () => Promise<`0x${string}`>;
+} {
+  const baseUrl = trimTrailingSlash(input.baseUrl);
+
+  return {
+    async readControllerWalletAddress() {
+      const responseBody = await requestJson({
+        url: `${baseUrl}/identity`,
+      });
+      const walletAddress = readControllerWalletAddress(responseBody);
+      if (!walletAddress) {
+        throw new Error('Local OWS controller identity response was missing a wallet address.');
+      }
+
+      return walletAddress;
+    },
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/localOwsControllerWallet.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/localOwsControllerWallet.unit.test.ts
@@ -1,0 +1,88 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createPortfolioManagerLocalOwsControllerWallet,
+  resolvePortfolioManagerLocalOwsBaseUrl,
+} from './localOwsControllerWallet.js';
+
+describe('createPortfolioManagerLocalOwsControllerWallet', () => {
+  let server: Server;
+  let baseUrl: string;
+  let responseStatus: number;
+  let responseBody: unknown;
+
+  beforeEach(async () => {
+    responseStatus = 200;
+    responseBody = null;
+    server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      void (async () => {
+        if (request.url !== '/identity') {
+          response.writeHead(404);
+          response.end();
+          return;
+        }
+
+        response.writeHead(responseStatus, {
+          'content-type': 'application/json; charset=utf-8',
+        });
+        response.end(
+          JSON.stringify(
+            responseBody ?? {
+              controller_wallet_address: '0x00000000000000000000000000000000000000c1',
+            },
+          ),
+        );
+      })().catch((error: unknown) => {
+        response.writeHead(500);
+        response.end(error instanceof Error ? error.message : 'unknown error');
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}/`;
+  });
+
+  afterEach(async () => {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  });
+
+  it('reads the controller wallet identity from the local OWS sidecar', async () => {
+    const wallet = createPortfolioManagerLocalOwsControllerWallet({
+      baseUrl,
+    });
+
+    await expect(wallet.readControllerWalletAddress()).resolves.toBe(
+      '0x00000000000000000000000000000000000000c1',
+    );
+  });
+
+  it('normalizes the optional local OWS base URL from env', () => {
+    expect(
+      resolvePortfolioManagerLocalOwsBaseUrl({
+        PORTFOLIO_MANAGER_OWS_BASE_URL: 'http://127.0.0.1:4030/',
+      }),
+    ).toBe('http://127.0.0.1:4030');
+    expect(resolvePortfolioManagerLocalOwsBaseUrl({})).toBeNull();
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -11,6 +11,10 @@ import {
 import { createPortfolioManagerDiagnosticTool } from './diagnosticTool.js';
 import { createPortfolioManagerWalletAccountingTool } from './walletAccountingTool.js';
 import { PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID } from './sharedEmberOnboardingState.js';
+import {
+  createPortfolioManagerLocalOwsControllerWallet,
+  resolvePortfolioManagerLocalOwsBaseUrl,
+} from './localOwsControllerWallet.js';
 
 const DEFAULT_PORTFOLIO_MANAGER_MODEL = 'openai/gpt-5.4-mini';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
@@ -23,6 +27,7 @@ export type PortfolioManagerGatewayEnv = NodeJS.ProcessEnv & {
   PORTFOLIO_MANAGER_ENABLE_DIAGNOSTIC_TOOLS?: string;
   DATABASE_URL?: string;
   SHARED_EMBER_BASE_URL?: string;
+  PORTFOLIO_MANAGER_OWS_BASE_URL?: string;
 };
 
 type PortfolioManagerAgentRuntimeOptions = CreateAgentRuntimeOptions<PortfolioManagerLifecycleState>;
@@ -33,6 +38,15 @@ export type PortfolioManagerAgentConfig = Pick<
 >;
 
 type PortfolioManagerGatewayModel = PortfolioManagerAgentConfig['model'];
+
+export type PortfolioManagerGatewayDependencies = {
+  protocolHost: ReturnType<typeof createPortfolioManagerSharedEmberHttpHost> | null;
+  controllerWallet: ReturnType<typeof createPortfolioManagerLocalOwsControllerWallet> | undefined;
+};
+
+type CreatePortfolioManagerAgentConfigOptions = {
+  controllerWalletAddress?: `0x${string}`;
+};
 
 function requireEnvValue(
   value: string | undefined,
@@ -68,16 +82,12 @@ function createOpenRouterModel(modelId: string): PortfolioManagerGatewayModel {
 
 export function createPortfolioManagerAgentConfig(
   env: PortfolioManagerGatewayEnv = process.env,
+  options: CreatePortfolioManagerAgentConfigOptions = {},
 ): PortfolioManagerAgentConfig {
   const apiKey = requireEnvValue(env.OPENROUTER_API_KEY, 'OPENROUTER_API_KEY');
   const modelId = env.PORTFOLIO_MANAGER_MODEL?.trim() || DEFAULT_PORTFOLIO_MANAGER_MODEL;
   const enableDiagnosticTools = env.PORTFOLIO_MANAGER_ENABLE_DIAGNOSTIC_TOOLS?.trim() === '1';
-  const sharedEmberBaseUrl = resolvePortfolioManagerSharedEmberBaseUrl(env);
-  const protocolHost = sharedEmberBaseUrl
-    ? createPortfolioManagerSharedEmberHttpHost({
-        baseUrl: sharedEmberBaseUrl,
-      })
-    : null;
+  const { protocolHost } = resolvePortfolioManagerGatewayDependencies(env);
 
   return {
     model: createOpenRouterModel(modelId),
@@ -100,6 +110,11 @@ export function createPortfolioManagerAgentConfig(
             protocolHost,
           }
         : {}),
+      ...(options.controllerWalletAddress
+        ? {
+            controllerWalletAddress: options.controllerWalletAddress,
+          }
+        : {}),
     }),
     agentOptions: {
       initialState: {
@@ -107,5 +122,25 @@ export function createPortfolioManagerAgentConfig(
       },
       getApiKey: () => apiKey,
     },
+  };
+}
+
+export function resolvePortfolioManagerGatewayDependencies(
+  env: PortfolioManagerGatewayEnv = process.env,
+): PortfolioManagerGatewayDependencies {
+  const sharedEmberBaseUrl = resolvePortfolioManagerSharedEmberBaseUrl(env);
+  const localOwsBaseUrl = resolvePortfolioManagerLocalOwsBaseUrl(env);
+
+  return {
+    protocolHost: sharedEmberBaseUrl
+      ? createPortfolioManagerSharedEmberHttpHost({
+          baseUrl: sharedEmberBaseUrl,
+        })
+      : null,
+    controllerWallet: localOwsBaseUrl
+      ? createPortfolioManagerLocalOwsControllerWallet({
+          baseUrl: localOwsBaseUrl,
+        })
+      : undefined,
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
@@ -1,0 +1,177 @@
+import {
+  PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
+  type PortfolioManagerSharedEmberProtocolHost,
+} from './sharedEmberAdapter.js';
+
+type EnsurePortfolioManagerServiceIdentityInput = {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  readControllerWalletAddress: () => Promise<`0x${string}`>;
+  now?: () => Date;
+};
+
+type AgentServiceIdentity = {
+  identity_ref: string;
+  agent_id: string;
+  role: 'orchestrator';
+  wallet_address: `0x${string}`;
+  wallet_source: string;
+  capability_metadata: Record<string, unknown>;
+  registration_version: number;
+  registered_at: string;
+};
+
+const PORTFOLIO_MANAGER_SERVICE_ROLE = 'orchestrator';
+const PORTFOLIO_MANAGER_WALLET_SOURCE = 'ember_local_write';
+const PORTFOLIO_MANAGER_CAPABILITY_METADATA = {
+  onboarding: true,
+  root_registration: true,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readHexAddress(value: unknown): `0x${string}` | null {
+  const normalized = readString(value);
+  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+}
+
+function readInt(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const identityRef = readString(value['identity_ref']);
+  const agentId = readString(value['agent_id']);
+  const walletAddress = readHexAddress(value['wallet_address']);
+  const walletSource = readString(value['wallet_source']);
+  const registrationVersion = readInt(value['registration_version']);
+  const registeredAt = readString(value['registered_at']);
+  const capabilityMetadata = isRecord(value['capability_metadata'])
+    ? value['capability_metadata']
+    : null;
+
+  if (
+    identityRef === null ||
+    agentId === null ||
+    walletAddress === null ||
+    walletSource === null ||
+    registrationVersion === null ||
+    registeredAt === null ||
+    capabilityMetadata === null
+  ) {
+    return null;
+  }
+
+  return {
+    identity_ref: identityRef,
+    agent_id: agentId,
+    role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+    wallet_address: walletAddress,
+    wallet_source: walletSource,
+    capability_metadata: capabilityMetadata,
+    registration_version: registrationVersion,
+    registered_at: registeredAt,
+  };
+}
+
+async function readCurrentIdentity(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+}): Promise<{
+  revision: number;
+  identity: AgentServiceIdentity | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-read',
+    method: 'orchestrator.readAgentServiceIdentity.v1',
+    params: {
+      agent_id: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
+      role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']) ?? 0,
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
+  };
+}
+
+async function writeIdentity(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  expectedRevision: number;
+  identity: AgentServiceIdentity;
+}): Promise<{
+  revision: number | null;
+  identity: AgentServiceIdentity | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-write',
+    method: 'orchestrator.writeAgentServiceIdentity.v1',
+    params: {
+      idempotency_key: 'idem-portfolio-manager-orchestrator-service-identity-startup',
+      expected_revision: input.expectedRevision,
+      agent_service_identity: input.identity,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']),
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
+  };
+}
+
+export async function ensurePortfolioManagerServiceIdentity(
+  input: EnsurePortfolioManagerServiceIdentityInput,
+): Promise<{
+  revision: number | null;
+  wroteIdentity: boolean;
+  identity: Record<string, unknown> | null;
+}> {
+  const walletAddress = await input.readControllerWalletAddress();
+  const current = await readCurrentIdentity({
+    protocolHost: input.protocolHost,
+  });
+
+  if (current.identity?.wallet_address === walletAddress) {
+    return {
+      revision: current.revision,
+      wroteIdentity: false,
+      identity: current.identity,
+    };
+  }
+
+  const registrationVersion = (current.identity?.registration_version ?? 0) + 1;
+  const identity: AgentServiceIdentity = {
+    identity_ref: `agent-service-identity-${PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID}-${PORTFOLIO_MANAGER_SERVICE_ROLE}-${registrationVersion}`,
+    agent_id: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
+    role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+    wallet_address: walletAddress,
+    wallet_source: PORTFOLIO_MANAGER_WALLET_SOURCE,
+    capability_metadata: PORTFOLIO_MANAGER_CAPABILITY_METADATA,
+    registration_version: registrationVersion,
+    registered_at: (input.now ?? (() => new Date()))().toISOString(),
+  };
+  const written = await writeIdentity({
+    protocolHost: input.protocolHost,
+    expectedRevision: current.revision,
+    identity,
+  });
+
+  return {
+    revision: written.revision,
+    wroteIdentity: true,
+    identity: written.identity,
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
@@ -73,6 +73,14 @@ function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
     return null;
   }
 
+  if (agentId !== PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID) {
+    return null;
+  }
+
+  if (readString(value['role']) !== PORTFOLIO_MANAGER_SERVICE_ROLE) {
+    return null;
+  }
+
   return {
     identity_ref: identityRef,
     agent_id: agentId,
@@ -135,10 +143,14 @@ async function writeIdentity(input: {
 }
 
 function requireConfirmedIdentity(input: {
-  expectedWalletAddress: `0x${string}`;
+  expectedIdentity: Pick<AgentServiceIdentity, 'agent_id' | 'role' | 'wallet_address'>;
   identity: AgentServiceIdentity | null;
 }): AgentServiceIdentity {
-  if (input.identity?.wallet_address !== input.expectedWalletAddress) {
+  if (
+    input.identity?.agent_id !== input.expectedIdentity.agent_id ||
+    input.identity?.role !== input.expectedIdentity.role ||
+    input.identity?.wallet_address !== input.expectedIdentity.wallet_address
+  ) {
     throw new Error(UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR);
   }
 
@@ -182,7 +194,7 @@ export async function ensurePortfolioManagerServiceIdentity(
     identity,
   });
   const confirmedIdentity = requireConfirmedIdentity({
-    expectedWalletAddress: walletAddress,
+    expectedIdentity: identity,
     identity: written.identity,
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
@@ -26,6 +26,8 @@ const PORTFOLIO_MANAGER_CAPABILITY_METADATA = {
   onboarding: true,
   root_registration: true,
 };
+const UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR =
+  'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -119,7 +121,7 @@ async function writeIdentity(input: {
     id: 'rpc-agent-service-identity-write',
     method: 'orchestrator.writeAgentServiceIdentity.v1',
     params: {
-      idempotency_key: 'idem-portfolio-manager-orchestrator-service-identity-startup',
+      idempotency_key: `idem-agent-service-identity-${input.identity.identity_ref}`,
       expected_revision: input.expectedRevision,
       agent_service_identity: input.identity,
     },
@@ -132,12 +134,23 @@ async function writeIdentity(input: {
   };
 }
 
+function requireConfirmedIdentity(input: {
+  expectedWalletAddress: `0x${string}`;
+  identity: AgentServiceIdentity | null;
+}): AgentServiceIdentity {
+  if (input.identity?.wallet_address !== input.expectedWalletAddress) {
+    throw new Error(UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR);
+  }
+
+  return input.identity;
+}
+
 export async function ensurePortfolioManagerServiceIdentity(
   input: EnsurePortfolioManagerServiceIdentityInput,
 ): Promise<{
   revision: number | null;
   wroteIdentity: boolean;
-  identity: Record<string, unknown> | null;
+  identity: AgentServiceIdentity;
 }> {
   const walletAddress = await input.readControllerWalletAddress();
   const current = await readCurrentIdentity({
@@ -168,10 +181,14 @@ export async function ensurePortfolioManagerServiceIdentity(
     expectedRevision: current.revision,
     identity,
   });
+  const confirmedIdentity = requireConfirmedIdentity({
+    expectedWalletAddress: walletAddress,
+    identity: written.identity,
+  });
 
   return {
     revision: written.revision,
     wroteIdentity: true,
-    identity: written.identity,
+    identity: confirmedIdentity,
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
@@ -81,7 +81,7 @@ describe('ensurePortfolioManagerServiceIdentity', () => {
 
       if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
         expect(jsonRpcRequest.params?.['idempotency_key']).toBe(
-          'idem-portfolio-manager-orchestrator-service-identity-startup',
+          'idem-agent-service-identity-agent-service-identity-portfolio-manager-orchestrator-1',
         );
         expect(jsonRpcRequest.params?.['expected_revision']).toBe(2);
         expect(jsonRpcRequest.params?.['agent_service_identity']).toMatchObject({
@@ -212,5 +212,157 @@ describe('ensurePortfolioManagerServiceIdentity', () => {
         registration_version: 4,
       },
     });
+  });
+
+  it('uses a distinct idempotency key for each distinct orchestrator identity write', async () => {
+    const writeKeys: string[] = [];
+    const readResponses = [
+      {
+        revision: 2,
+        agent_service_identity: null,
+      },
+      {
+        revision: 3,
+        agent_service_identity: {
+          identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-1',
+          agent_id: 'portfolio-manager',
+          role: 'orchestrator',
+          wallet_address: '0x00000000000000000000000000000000000000c1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            onboarding: true,
+            root_registration: true,
+          },
+          registration_version: 1,
+          registered_at: '2026-04-02T09:30:00.000Z',
+        },
+      },
+    ];
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        const nextRead = readResponses.shift();
+        if (!nextRead) {
+          throw new Error('expected another read response');
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: nextRead.revision,
+            agent_service_identity: nextRead.agent_service_identity,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        const idempotencyKey = jsonRpcRequest.params?.['idempotency_key'];
+        if (typeof idempotencyKey !== 'string') {
+          throw new Error('expected write idempotency key');
+        }
+
+        writeKeys.push(idempotencyKey);
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: writeKeys.length + 2,
+            committed_event_ids: [`evt-agent-service-identity-${writeKeys.length}`],
+            agent_service_identity: jsonRpcRequest.params?.['agent_service_identity'],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await ensurePortfolioManagerServiceIdentity({
+      protocolHost: {
+        handleJsonRpc,
+        readCommittedEventOutbox: vi.fn(),
+        acknowledgeCommittedEventOutbox: vi.fn(),
+      },
+      readControllerWalletAddress: vi.fn(
+        async () => '0x00000000000000000000000000000000000000c1' as const,
+      ),
+      now: () => new Date('2026-04-02T09:30:00.000Z'),
+    });
+
+    await ensurePortfolioManagerServiceIdentity({
+      protocolHost: {
+        handleJsonRpc,
+        readCommittedEventOutbox: vi.fn(),
+        acknowledgeCommittedEventOutbox: vi.fn(),
+      },
+      readControllerWalletAddress: vi.fn(
+        async () => '0x00000000000000000000000000000000000000c2' as const,
+      ),
+      now: () => new Date('2026-04-02T10:30:00.000Z'),
+    });
+
+    expect(writeKeys).toEqual([
+      'idem-agent-service-identity-agent-service-identity-portfolio-manager-orchestrator-1',
+      'idem-agent-service-identity-agent-service-identity-portfolio-manager-orchestrator-2',
+    ]);
+    expect(new Set(writeKeys)).toHaveLength(2);
+  });
+
+  it('fails when Shared Ember does not confirm the written orchestrator identity', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 2,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensurePortfolioManagerServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readControllerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000c1' as const,
+        ),
+        now: () => new Date('2026-04-02T09:30:00.000Z'),
+      }),
+    ).rejects.toThrow(
+      'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.',
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensurePortfolioManagerServiceIdentity } from './serviceIdentityPreflight.js';
+
+describe('ensurePortfolioManagerServiceIdentity', () => {
+  it('reuses the durable orchestrator identity when the OWS controller wallet already matches', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 7,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-3',
+              agent_id: 'portfolio-manager',
+              role: 'orchestrator',
+              wallet_address: '0x00000000000000000000000000000000000000c1',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                onboarding: true,
+                root_registration: true,
+              },
+              registration_version: 3,
+              registered_at: '2026-04-01T09:30:00.000Z',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensurePortfolioManagerServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readControllerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000c1' as const,
+        ),
+      }),
+    ).resolves.toMatchObject({
+      revision: 7,
+      wroteIdentity: false,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000c1',
+        registration_version: 3,
+      },
+    });
+
+    expect(handleJsonRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the durable orchestrator identity when Shared Ember has no current record', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 2,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.['idempotency_key']).toBe(
+          'idem-portfolio-manager-orchestrator-service-identity-startup',
+        );
+        expect(jsonRpcRequest.params?.['expected_revision']).toBe(2);
+        expect(jsonRpcRequest.params?.['agent_service_identity']).toMatchObject({
+          identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-1',
+          agent_id: 'portfolio-manager',
+          role: 'orchestrator',
+          wallet_address: '0x00000000000000000000000000000000000000c1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            onboarding: true,
+            root_registration: true,
+          },
+          registration_version: 1,
+          registered_at: '2026-04-02T09:30:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            committed_event_ids: ['evt-agent-service-identity-1'],
+            agent_service_identity: jsonRpcRequest.params?.['agent_service_identity'],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensurePortfolioManagerServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readControllerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000c1' as const,
+        ),
+        now: () => new Date('2026-04-02T09:30:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      revision: 3,
+      wroteIdentity: true,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000c1',
+        registration_version: 1,
+      },
+    });
+  });
+
+  it('rotates the durable orchestrator identity when the local OWS controller wallet changes', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 7,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-3',
+              agent_id: 'portfolio-manager',
+              role: 'orchestrator',
+              wallet_address: '0x00000000000000000000000000000000000000c0',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                onboarding: true,
+                root_registration: true,
+              },
+              registration_version: 3,
+              registered_at: '2026-04-01T09:30:00.000Z',
+            },
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.['expected_revision']).toBe(7);
+        expect(jsonRpcRequest.params?.['agent_service_identity']).toMatchObject({
+          identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-4',
+          agent_id: 'portfolio-manager',
+          role: 'orchestrator',
+          wallet_address: '0x00000000000000000000000000000000000000c1',
+          registration_version: 4,
+          registered_at: '2026-04-02T10:00:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 8,
+            committed_event_ids: ['evt-agent-service-identity-2'],
+            agent_service_identity: jsonRpcRequest.params?.['agent_service_identity'],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensurePortfolioManagerServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readControllerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000c1' as const,
+        ),
+        now: () => new Date('2026-04-02T10:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      revision: 8,
+      wroteIdentity: true,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000c1',
+        registration_version: 4,
+      },
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
@@ -365,4 +365,58 @@ describe('ensurePortfolioManagerServiceIdentity', () => {
       'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.',
     );
   });
+
+  it('fails when Shared Ember echoes the wrong agent_id for the written orchestrator identity', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 2,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            agent_service_identity: {
+              ...(jsonRpcRequest.params?.['agent_service_identity'] as Record<string, unknown>),
+              agent_id: 'ember-lending',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensurePortfolioManagerServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readControllerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000c1' as const,
+        ),
+        now: () => new Date('2026-04-02T09:30:00.000Z'),
+      }),
+    ).rejects.toThrow(
+      'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.',
+    );
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -511,5 +511,25 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
         },
       },
     });
+
+    await expect(
+      protocolHost.handleJsonRpc({
+        jsonrpc: '2.0',
+        id: `rpc-shared-ember-int-read-execution-context-signing-${suffix}`,
+        method: 'subagent.readExecutionContext.v1',
+        params: {
+          agent_id: 'ember-lending',
+        },
+      }),
+    ).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      id: `rpc-shared-ember-int-read-execution-context-signing-${suffix}`,
+      result: {
+        protocol_version: 'v1',
+        execution_context: {
+          subagent_wallet_address: expect.stringMatching(/^0x/),
+        },
+      },
+    });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -125,6 +125,7 @@ function readInt(value: unknown): number | null {
 
 function readAgentServiceIdentity(
   value: unknown,
+  expectedAgentId: string,
   expectedRole: AgentServiceIdentityRole,
 ): AgentServiceIdentity | null {
   if (!isRecord(value)) {
@@ -144,6 +145,8 @@ function readAgentServiceIdentity(
   if (
     identityRef === null ||
     agentId === null ||
+    agentId !== expectedAgentId ||
+    readString(value['role']) !== expectedRole ||
     walletAddress === null ||
     walletSource === null ||
     registrationVersion === null ||
@@ -238,7 +241,11 @@ async function readSharedEmberAgentServiceIdentity(input: {
 
   return {
     revision: readInt(result?.['revision']) ?? 0,
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null, input.role),
+    identity: readAgentServiceIdentity(
+      result?.['agent_service_identity'] ?? null,
+      input.agentId,
+      input.role,
+    ),
   };
 }
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -242,6 +242,30 @@ async function readSharedEmberAgentServiceIdentity(input: {
   };
 }
 
+async function readSharedEmberSubagentWalletAddress(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  agentId: string;
+}): Promise<{
+  revision: number | null;
+  walletAddress: `0x${string}` | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'shared-ember-read-managed-subagent-execution-context',
+    method: 'subagent.readExecutionContext.v1',
+    params: {
+      agent_id: input.agentId,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+  const executionContext = isRecord(result?.['execution_context']) ? result['execution_context'] : null;
+
+  return {
+    revision: readInt(result?.['revision']),
+    walletAddress: readHexAddress(executionContext?.['subagent_wallet_address']),
+  };
+}
+
 const PORTFOLIO_MANAGER_SETUP_INTERRUPT_TYPE = 'portfolio-manager-setup-request';
 const PORTFOLIO_MANAGER_SETUP_MESSAGE =
   'Connect the wallet you want the portfolio manager to onboard.';
@@ -1150,11 +1174,53 @@ export function createPortfolioManagerDomain(
               },
             }),
           });
+          const managedSubagentExecutionContext = await readSharedEmberSubagentWalletAddress({
+            protocolHost: options.protocolHost,
+            agentId: FIRST_MANAGED_AGENT_TYPE,
+          });
+          const nextRevision =
+            managedSubagentExecutionContext.revision ?? response.result?.revision ?? null;
+
+          if (!managedSubagentExecutionContext.walletAddress) {
+            const nextState: PortfolioManagerLifecycleState = {
+              phase: 'onboarding',
+              lastPortfolioState: currentState.lastPortfolioState,
+              lastSharedEmberRevision: nextRevision,
+              lastRootDelegation: response.result?.root_delegation ?? currentState.lastRootDelegation,
+              lastOnboardingBootstrap: onboarding,
+              lastRootedWalletContextId: response.result?.rooted_wallet_context_id ?? null,
+              activeWalletAddress: walletAddress,
+              pendingOnboardingWalletAddress: walletAddress,
+              pendingApprovedMandateEnvelope: approvedMandateEnvelope,
+            };
+
+            return {
+              state: nextState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Portfolio manager onboarding is blocked because ember-lending did not expose a non-null subagent wallet in Shared Ember execution context after rooted bootstrap.',
+                },
+                artifacts: [
+                  {
+                    data: {
+                      type: 'shared-ember-rooted-bootstrap',
+                      revision: nextState.lastSharedEmberRevision,
+                      committedEventIds: response.result?.committed_event_ids ?? [],
+                      rootedWalletContextId: nextState.lastRootedWalletContextId,
+                      rootDelegation: nextState.lastRootDelegation,
+                    },
+                  },
+                ],
+              },
+            };
+          }
 
           const nextState: PortfolioManagerLifecycleState = {
             phase: 'active',
             lastPortfolioState: currentState.lastPortfolioState,
-            lastSharedEmberRevision: response.result?.revision ?? null,
+            lastSharedEmberRevision: nextRevision,
             lastRootDelegation: response.result?.root_delegation ?? currentState.lastRootDelegation,
             lastOnboardingBootstrap: onboarding,
             lastRootedWalletContextId: response.result?.rooted_wallet_context_id ?? null,

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -12,6 +12,8 @@ export type PortfolioManagerSharedEmberProtocolHost = {
   acknowledgeCommittedEventOutbox: (input: unknown) => Promise<unknown>;
 };
 
+export const PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID = 'portfolio-manager';
+
 export type PortfolioManagerLifecycleState = {
   phase: 'prehire' | 'onboarding' | 'active';
   lastPortfolioState: unknown;
@@ -27,6 +29,7 @@ export type PortfolioManagerLifecycleState = {
 type CreatePortfolioManagerDomainOptions = {
   protocolHost?: PortfolioManagerSharedEmberProtocolHost;
   agentId?: string;
+  controllerWalletAddress?: `0x${string}`;
 };
 
 type SharedEmberRevisionResponse = {
@@ -39,6 +42,19 @@ type OnboardingMandateSource = {
   mandate_ref: string;
   agent_id: string;
   mandate_summary: string;
+};
+
+type AgentServiceIdentityRole = 'orchestrator' | 'subagent';
+
+type AgentServiceIdentity = {
+  identity_ref: string;
+  agent_id: string;
+  role: AgentServiceIdentityRole;
+  wallet_address: `0x${string}`;
+  wallet_source: string;
+  capability_metadata: Record<string, unknown>;
+  registration_version: number;
+  registered_at: string;
 };
 
 function buildDefaultLifecycleState(): PortfolioManagerLifecycleState {
@@ -88,6 +104,65 @@ function escapeXml(value: string): string {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&apos;');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readHexAddress(value: unknown): `0x${string}` | null {
+  const normalized = readString(value);
+  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+}
+
+function readInt(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readAgentServiceIdentity(
+  value: unknown,
+  expectedRole: AgentServiceIdentityRole,
+): AgentServiceIdentity | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const identityRef = readString(value['identity_ref']);
+  const agentId = readString(value['agent_id']);
+  const walletAddress = readHexAddress(value['wallet_address']);
+  const walletSource = readString(value['wallet_source']);
+  const registrationVersion = readInt(value['registration_version']);
+  const registeredAt = readString(value['registered_at']);
+  const capabilityMetadata = isRecord(value['capability_metadata'])
+    ? value['capability_metadata']
+    : null;
+
+  if (
+    identityRef === null ||
+    agentId === null ||
+    walletAddress === null ||
+    walletSource === null ||
+    registrationVersion === null ||
+    registeredAt === null ||
+    capabilityMetadata === null
+  ) {
+    return null;
+  }
+
+  return {
+    identity_ref: identityRef,
+    agent_id: agentId,
+    role: expectedRole,
+    wallet_address: walletAddress,
+    wallet_source: walletSource,
+    capability_metadata: capabilityMetadata,
+    registration_version: registrationVersion,
+    registered_at: registeredAt,
+  };
 }
 
 function isSharedEmberRevisionConflict(error: unknown): boolean {
@@ -140,6 +215,31 @@ async function runSharedEmberCommandWithResolvedRevision<T>(input: {
     expectedRevision = refreshedRevision;
     return (await input.protocolHost.handleJsonRpc(input.buildRequest(expectedRevision))) as T;
   }
+}
+
+async function readSharedEmberAgentServiceIdentity(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  agentId: string;
+  role: AgentServiceIdentityRole;
+}): Promise<{
+  revision: number;
+  identity: AgentServiceIdentity | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-read',
+    method: 'orchestrator.readAgentServiceIdentity.v1',
+    params: {
+      agent_id: input.agentId,
+      role: input.role,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']) ?? 0,
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null, input.role),
+  };
 }
 
 const PORTFOLIO_MANAGER_SETUP_INTERRUPT_TYPE = 'portfolio-manager-setup-request';
@@ -486,9 +586,10 @@ function isPortfolioManagerSigningRejected(input: unknown): boolean {
 
 function buildPortfolioManagerUnsignedDelegation(
   walletAddress: `0x${string}`,
+  controllerWalletAddress: `0x${string}`,
 ): PortfolioManagerUnsignedDelegation {
   return {
-    delegate: PORTFOLIO_MANAGER_ORCHESTRATOR_WALLET,
+    delegate: controllerWalletAddress,
     delegator: walletAddress,
     authority: PORTFOLIO_MANAGER_ROOT_AUTHORITY,
     caveats: [],
@@ -496,7 +597,10 @@ function buildPortfolioManagerUnsignedDelegation(
   };
 }
 
-function buildPortfolioManagerSigningInterrupt(setup: PortfolioManagerSetupInput) {
+function buildPortfolioManagerSigningInterrupt(
+  setup: PortfolioManagerSetupInput,
+  controllerWalletAddress: `0x${string}`,
+) {
   return {
     type: PORTFOLIO_MANAGER_SIGNING_INTERRUPT_TYPE,
     surfacedInThread: true,
@@ -505,8 +609,10 @@ function buildPortfolioManagerSigningInterrupt(setup: PortfolioManagerSetupInput
       chainId: PORTFOLIO_MANAGER_CHAIN_ID,
       delegationManager: PORTFOLIO_MANAGER_DELEGATION_MANAGER,
       delegatorAddress: setup.walletAddress,
-      delegateeAddress: PORTFOLIO_MANAGER_ORCHESTRATOR_WALLET,
-      delegationsToSign: [buildPortfolioManagerUnsignedDelegation(setup.walletAddress)],
+      delegateeAddress: controllerWalletAddress,
+      delegationsToSign: [
+        buildPortfolioManagerUnsignedDelegation(setup.walletAddress, controllerWalletAddress),
+      ],
       descriptions: ['Authorize the portfolio manager to operate through your root delegation.'],
       warnings: ['Only continue if you trust this portfolio-manager session.'],
     },
@@ -615,7 +721,9 @@ function buildPortfolioManagerRootDelegationHandoff(params: {
 export function createPortfolioManagerDomain(
   options: CreatePortfolioManagerDomainOptions = {},
 ): AgentRuntimeDomainConfig<PortfolioManagerLifecycleState> {
-  const agentId = options.agentId ?? 'portfolio-manager';
+  const agentId = options.agentId ?? PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID;
+  const controllerWalletAddress =
+    options.controllerWalletAddress ?? PORTFOLIO_MANAGER_ORCHESTRATOR_WALLET;
 
   return {
     lifecycle: {
@@ -896,15 +1004,18 @@ export function createPortfolioManagerDomain(
 
           return {
             state: nextState,
-            outputs: {
-              status: {
-                executionStatus: 'interrupted',
-                statusMessage: PORTFOLIO_MANAGER_SIGNING_MESSAGE,
+              outputs: {
+                status: {
+                  executionStatus: 'interrupted',
+                  statusMessage: PORTFOLIO_MANAGER_SIGNING_MESSAGE,
+                },
+                interrupt: buildPortfolioManagerSigningInterrupt(
+                  setupInput,
+                  controllerWalletAddress,
+                ),
               },
-              interrupt: buildPortfolioManagerSigningInterrupt(setupInput),
-            },
-          };
-        }
+            };
+          }
         case PORTFOLIO_MANAGER_SIGNING_INTERRUPT_TYPE: {
           if (isPortfolioManagerSigningRejected(operation.input)) {
             return {
@@ -950,6 +1061,55 @@ export function createPortfolioManagerDomain(
                 status: {
                   executionStatus: 'failed',
                   statusMessage: 'Shared Ember Domain Service host is not configured.',
+                },
+              },
+            };
+          }
+
+          const orchestratorIdentity = await readSharedEmberAgentServiceIdentity({
+            protocolHost: options.protocolHost,
+            agentId,
+            role: 'orchestrator',
+          });
+          if (!orchestratorIdentity.identity) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Portfolio manager onboarding is blocked until the portfolio-manager service registers its orchestrator identity in Shared Ember.',
+                },
+              },
+            };
+          }
+
+          if (orchestratorIdentity.identity.wallet_address !== controllerWalletAddress) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Portfolio manager onboarding is blocked because the registered portfolio-manager orchestrator wallet does not match this session controller wallet.',
+                },
+              },
+            };
+          }
+
+          const managedSubagentIdentity = await readSharedEmberAgentServiceIdentity({
+            protocolHost: options.protocolHost,
+            agentId: FIRST_MANAGED_AGENT_TYPE,
+            role: 'subagent',
+          });
+          if (!managedSubagentIdentity.identity) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Portfolio manager onboarding is blocked until the ember-lending service registers its subagent identity in Shared Ember.',
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -263,6 +263,30 @@ describe('createPortfolioManagerDomain', () => {
           }
         }
 
+        if (jsonRpcRequest?.['method'] === 'subagent.readExecutionContext.v1') {
+          expect(params?.['agent_id']).toBe('ember-lending');
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-read-execution-context',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              execution_context: {
+                generated_at: '2026-04-02T15:00:00.000Z',
+                network: 'arbitrum',
+                mandate_ref: 'mandate-ember-lending-001',
+                mandate_summary:
+                  'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+                mandate_context: null,
+                subagent_wallet_address: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+                owned_units: [],
+                wallet_contents: [],
+              },
+            },
+          };
+        }
+
         return {
           jsonrpc: '2.0',
           id: 'shared-ember-thread-1-complete-rooted-bootstrap',
@@ -326,7 +350,7 @@ describe('createPortfolioManagerDomain', () => {
     ).resolves.toMatchObject({
       state: {
         phase: 'active',
-        lastSharedEmberRevision: 3,
+        lastSharedEmberRevision: 4,
         lastRootDelegation: {
           root_delegation_id: 'root-user-protocol-001',
           user_wallet: '0x00000000000000000000000000000000000000a1',
@@ -418,6 +442,15 @@ describe('createPortfolioManagerDomain', () => {
             signer_kind: 'delegation_toolkit',
           }),
         }),
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonrpc: '2.0',
+        method: 'subagent.readExecutionContext.v1',
+        params: {
+          agent_id: 'ember-lending',
+        },
       }),
     );
 
@@ -608,6 +641,156 @@ describe('createPortfolioManagerDomain', () => {
         method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
       }),
     );
+  });
+
+  it('fails closed after rooted bootstrap when the managed ember-lending execution context still has no subagent wallet', async () => {
+    const signedDelegation = {
+      delegate: '0x00000000000000000000000000000000000000c1',
+      delegator: '0x00000000000000000000000000000000000000a1',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [],
+      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      signature: '0x1234',
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+          if (params?.['agent_id'] === 'portfolio-manager' && params['role'] === 'orchestrator') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: '0x2222222222222222222222222222222222222222',
+            });
+          }
+
+          if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'ember-lending',
+              role: 'subagent',
+              walletAddress: '0x00000000000000000000000000000000000000e1',
+            });
+          }
+        }
+
+        if (jsonRpcRequest?.['method'] === 'subagent.readExecutionContext.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-read-execution-context',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              execution_context: {
+                generated_at: '2026-04-02T15:15:00.000Z',
+                network: 'arbitrum',
+                mandate_ref: 'mandate-ember-lending-001',
+                mandate_summary:
+                  'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+                mandate_context: null,
+                subagent_wallet_address: null,
+                root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+                owned_units: [],
+                wallet_contents: [],
+              },
+            },
+          };
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-complete-rooted-bootstrap',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
+            rooted_wallet_context_id: 'rwc-user-protocol-001',
+            root_delegation: {
+              root_delegation_id: 'root-user-protocol-001',
+              user_wallet: '0x00000000000000000000000000000000000000a1',
+              status: 'active',
+            },
+          },
+        };
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 4,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 4,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'onboarding',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 0,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: null,
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingApprovedMandateEnvelope: {
+            portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+            managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-delegation-signing-request',
+          input: {
+            outcome: 'signed',
+            signedDelegations: [signedDelegation],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'onboarding',
+        lastSharedEmberRevision: 4,
+        lastRootDelegation: {
+          root_delegation_id: 'root-user-protocol-001',
+          user_wallet: '0x00000000000000000000000000000000000000a1',
+          status: 'active',
+        },
+        lastRootedWalletContextId: 'rwc-user-protocol-001',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Portfolio manager onboarding is blocked because ember-lending did not expose a non-null subagent wallet in Shared Ember execution context after rooted bootstrap.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'shared-ember-rooted-bootstrap',
+              rootedWalletContextId: 'rwc-user-protocol-001',
+            },
+          },
+        ],
+      },
+    });
   });
 
   it('fails fast before subagent activation when the registered orchestrator wallet does not match the session controller wallet', async () => {
@@ -821,6 +1004,34 @@ describe('createPortfolioManagerDomain', () => {
           };
         }
 
+        if (
+          typeof request === 'object' &&
+          request !== null &&
+          'method' in request &&
+          request.method === 'subagent.readExecutionContext.v1'
+        ) {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-read-execution-context',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              execution_context: {
+                generated_at: '2026-04-02T15:10:00.000Z',
+                network: 'arbitrum',
+                mandate_ref: 'mandate-ember-lending-001',
+                mandate_summary:
+                  'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+                mandate_context: null,
+                subagent_wallet_address: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+                owned_units: [],
+                wallet_contents: [],
+              },
+            },
+          };
+        }
+
         return {
           jsonrpc: '2.0',
           id: 'shared-ember-thread-1-complete-rooted-bootstrap',
@@ -924,6 +1135,14 @@ describe('createPortfolioManagerDomain', () => {
         }),
       }),
     );
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(5, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-read-managed-subagent-execution-context',
+      method: 'subagent.readExecutionContext.v1',
+      params: {
+        agent_id: 'ember-lending',
+      },
+    });
   });
 
   it('moves back to prehire on fire and allows hire to start again', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -2,6 +2,40 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createPortfolioManagerDomain } from './sharedEmberAdapter.js';
 
+function createAgentServiceIdentityResponse(input: {
+  agentId: string;
+  role: 'orchestrator' | 'subagent';
+  walletAddress: `0x${string}`;
+  revision?: number;
+}) {
+  return {
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-read',
+    result: {
+      revision: input.revision ?? 2,
+      agent_service_identity: {
+        identity_ref: `agent-service-identity-${input.agentId}-${input.role}-1`,
+        agent_id: input.agentId,
+        role: input.role,
+        wallet_address: input.walletAddress,
+        wallet_source: 'ember_local_write',
+        capability_metadata:
+          input.role === 'orchestrator'
+            ? {
+                onboarding: true,
+                root_registration: true,
+              }
+            : {
+                execution: true,
+                onboarding: true,
+              },
+        registration_version: 1,
+        registered_at: '2026-04-01T00:00:00.000Z',
+      },
+    },
+  };
+}
+
 function createPortfolioManagerSetupInput() {
   return {
     walletAddress: '0x00000000000000000000000000000000000000a1' as const,
@@ -203,21 +237,48 @@ describe('createPortfolioManagerDomain', () => {
       signature: '0x1234',
     };
     const protocolHost = {
-      handleJsonRpc: vi.fn(async () => ({
-        jsonrpc: '2.0',
-        id: 'shared-ember-thread-1-complete-rooted-bootstrap',
-        result: {
-          protocol_version: 'v1',
-          revision: 3,
-          committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
-          rooted_wallet_context_id: 'rwc-user-protocol-001',
-          root_delegation: {
-            root_delegation_id: 'root-user-protocol-001',
-            user_wallet: '0x00000000000000000000000000000000000000a1',
-            status: 'active',
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+          if (params?.['agent_id'] === 'portfolio-manager' && params['role'] === 'orchestrator') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: '0x2222222222222222222222222222222222222222',
+            });
+          }
+
+          if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'ember-lending',
+              role: 'subagent',
+              walletAddress: '0x00000000000000000000000000000000000000e1',
+            });
+          }
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-complete-rooted-bootstrap',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
+            rooted_wallet_context_id: 'rwc-user-protocol-001',
+            root_delegation: {
+              root_delegation_id: 'root-user-protocol-001',
+              user_wallet: '0x00000000000000000000000000000000000000a1',
+              status: 'active',
+            },
           },
-        },
-      })),
+        };
+      }),
       readCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
         revision: 3,
@@ -360,9 +421,15 @@ describe('createPortfolioManagerDomain', () => {
       }),
     );
 
-    const rootedBootstrapCall = (protocolHost.handleJsonRpc.mock.calls as unknown as Array<
-      [unknown]
-    >)[0];
+    const rootedBootstrapCall = (
+      protocolHost.handleJsonRpc.mock.calls as unknown as Array<[unknown]>
+    ).find(
+      ([request]) =>
+        typeof request === 'object' &&
+        request !== null &&
+        'method' in request &&
+        request.method === 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+    );
     expect(rootedBootstrapCall).toBeDefined();
     if (!rootedBootstrapCall) {
       throw new Error('expected rooted bootstrap Shared Ember request');
@@ -392,6 +459,263 @@ describe('createPortfolioManagerDomain', () => {
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('ownedUnits');
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('reservations');
     expect(rootedBootstrapRequest.params?.onboarding).not.toHaveProperty('policySnapshots');
+  });
+
+  it('fails fast before rooted bootstrap when the managed ember-lending identity is missing', async () => {
+    const signedDelegation = {
+      delegate: '0x00000000000000000000000000000000000000c1',
+      delegator: '0x00000000000000000000000000000000000000a1',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [],
+      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      signature: '0x1234',
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+          const params =
+            typeof jsonRpcRequest['params'] === 'object' && jsonRpcRequest['params'] !== null
+              ? (jsonRpcRequest['params'] as Record<string, unknown>)
+              : null;
+
+          if (
+            params?.['agent_id'] === 'portfolio-manager' &&
+            params['role'] === 'orchestrator'
+          ) {
+            return {
+              jsonrpc: '2.0',
+              id: 'rpc-agent-service-identity-read',
+              result: {
+                revision: 2,
+                agent_service_identity: {
+                  identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-1',
+                  agent_id: 'portfolio-manager',
+                  role: 'orchestrator',
+                  wallet_address: '0x00000000000000000000000000000000000000c1',
+                  wallet_source: 'ember_local_write',
+                  capability_metadata: {
+                    onboarding: true,
+                    root_registration: true,
+                  },
+                  registration_version: 1,
+                  registered_at: '2026-04-01T00:00:00.000Z',
+                },
+              },
+            };
+          }
+
+          if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
+            return {
+              jsonrpc: '2.0',
+              id: 'rpc-agent-service-identity-read',
+              result: {
+                revision: 2,
+                agent_service_identity: null,
+              },
+            };
+          }
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'unexpected',
+          result: {},
+        };
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x00000000000000000000000000000000000000c1',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'onboarding',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 2,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: null,
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingApprovedMandateEnvelope: {
+            portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+            managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-delegation-signing-request',
+          input: {
+            outcome: 'signed',
+            signedDelegations: [signedDelegation],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'onboarding',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Portfolio manager onboarding is blocked until the ember-lending service registers its subagent identity in Shared Ember.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'ember-lending',
+        role: 'subagent',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+      }),
+    );
+  });
+
+  it('fails fast before subagent activation when the registered orchestrator wallet does not match the session controller wallet', async () => {
+    const signedDelegation = {
+      delegate: '0x00000000000000000000000000000000000000c1',
+      delegator: '0x00000000000000000000000000000000000000a1',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [],
+      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      signature: '0x1234',
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (
+          jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1' &&
+          params?.['agent_id'] === 'portfolio-manager' &&
+          params['role'] === 'orchestrator'
+        ) {
+          return createAgentServiceIdentityResponse({
+            agentId: 'portfolio-manager',
+            role: 'orchestrator',
+            walletAddress: '0x00000000000000000000000000000000000000d1',
+          });
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'unexpected',
+          result: {},
+        };
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x00000000000000000000000000000000000000c1',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'onboarding',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 2,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: null,
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingApprovedMandateEnvelope: {
+            portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+            managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-delegation-signing-request',
+          input: {
+            outcome: 'signed',
+            signedDelegations: [signedDelegation],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'onboarding',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Portfolio manager onboarding is blocked because the registered portfolio-manager orchestrator wallet does not match this session controller wallet.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledTimes(1);
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
   });
 
   it('returns to prehire and clears wallet-local state when delegation signing is rejected', async () => {
@@ -451,6 +775,31 @@ describe('createPortfolioManagerDomain', () => {
     };
     const protocolHost = {
       handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+          if (params?.['agent_id'] === 'portfolio-manager' && params['role'] === 'orchestrator') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: '0x2222222222222222222222222222222222222222',
+            });
+          }
+
+          if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'ember-lending',
+              role: 'subagent',
+              walletAddress: '0x00000000000000000000000000000000000000e1',
+            });
+          }
+        }
+
         if (
           typeof request === 'object' &&
           request !== null &&
@@ -542,6 +891,24 @@ describe('createPortfolioManagerDomain', () => {
 
     expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
       jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'ember-lending',
+        role: 'subagent',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
+      jsonrpc: '2.0',
       id: 'shared-ember-thread-1-read-current-revision',
       method: 'subagent.readPortfolioState.v1',
       params: {
@@ -549,7 +916,7 @@ describe('createPortfolioManagerDomain', () => {
       },
     });
     expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
-      2,
+      4,
       expect.objectContaining({
         method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
         params: expect.objectContaining({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -643,6 +643,125 @@ describe('createPortfolioManagerDomain', () => {
     );
   });
 
+  it('fails fast before rooted bootstrap when the portfolio-manager orchestrator identity is missing', async () => {
+    const signedDelegation = {
+      delegate: '0x00000000000000000000000000000000000000c1',
+      delegator: '0x00000000000000000000000000000000000000a1',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [],
+      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      signature: '0x1234',
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (
+          jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1' &&
+          params?.['agent_id'] === 'portfolio-manager' &&
+          params['role'] === 'orchestrator'
+        ) {
+          return {
+            jsonrpc: '2.0',
+            id: 'rpc-agent-service-identity-read',
+            result: {
+              revision: 2,
+              agent_service_identity: null,
+            },
+          };
+        }
+
+        throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest?.['method'])}`);
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x00000000000000000000000000000000000000c1',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'onboarding',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 2,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: null,
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingApprovedMandateEnvelope: {
+            portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+            managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-delegation-signing-request',
+          input: {
+            outcome: 'signed',
+            signedDelegations: [signedDelegation],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'onboarding',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Portfolio manager onboarding is blocked until the portfolio-manager service registers its orchestrator identity in Shared Ember.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          agent_id: 'ember-lending',
+          role: 'subagent',
+        }),
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+      }),
+    );
+  });
+
   it('fails closed after rooted bootstrap when the managed ember-lending execution context still has no subagent wallet', async () => {
     const signedDelegation = {
       delegate: '0x00000000000000000000000000000000000000c1',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -643,6 +643,125 @@ describe('createPortfolioManagerDomain', () => {
     );
   });
 
+  it('fails fast before rooted bootstrap when the managed ember-lending identity echo is misaddressed', async () => {
+    const signedDelegation = {
+      delegate: '0x00000000000000000000000000000000000000c1',
+      delegator: '0x00000000000000000000000000000000000000a1',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [],
+      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      signature: '0x1234',
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+          if (params?.['agent_id'] === 'portfolio-manager' && params['role'] === 'orchestrator') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: '0x00000000000000000000000000000000000000c1',
+            });
+          }
+
+          if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: '0x00000000000000000000000000000000000000e1',
+            });
+          }
+        }
+
+        throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest?.['method'])}`);
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x00000000000000000000000000000000000000c1',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'onboarding',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 2,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: null,
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingApprovedMandateEnvelope: {
+            portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+            managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-delegation-signing-request',
+          input: {
+            outcome: 'signed',
+            signedDelegations: [signedDelegation],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'onboarding',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Portfolio manager onboarding is blocked until the ember-lending service registers its subagent identity in Shared Ember.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'ember-lending',
+        role: 'subagent',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.readPortfolioState.v1',
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+      }),
+    );
+  });
+
   it('fails fast before rooted bootstrap when the portfolio-manager orchestrator identity is missing', async () => {
     const signedDelegation = {
       delegate: '0x00000000000000000000000000000000000000c1',
@@ -674,6 +793,122 @@ describe('createPortfolioManagerDomain', () => {
               agent_service_identity: null,
             },
           };
+        }
+
+        throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest?.['method'])}`);
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 2,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x00000000000000000000000000000000000000c1',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'onboarding',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 2,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: null,
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingApprovedMandateEnvelope: {
+            portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+            managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-delegation-signing-request',
+          input: {
+            outcome: 'signed',
+            signedDelegations: [signedDelegation],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'onboarding',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Portfolio manager onboarding is blocked until the portfolio-manager service registers its orchestrator identity in Shared Ember.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      id: 'rpc-agent-service-identity-read',
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          agent_id: 'ember-lending',
+          role: 'subagent',
+        }),
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
+      }),
+    );
+  });
+
+  it('fails fast before rooted bootstrap when the portfolio-manager orchestrator identity echo is misaddressed', async () => {
+    const signedDelegation = {
+      delegate: '0x00000000000000000000000000000000000000c1',
+      delegator: '0x00000000000000000000000000000000000000a1',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [],
+      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      signature: '0x1234',
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (
+          jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1' &&
+          params?.['agent_id'] === 'portfolio-manager' &&
+          params['role'] === 'orchestrator'
+        ) {
+          return createAgentServiceIdentityResponse({
+            agentId: 'ember-lending',
+            role: 'subagent',
+            walletAddress: '0x00000000000000000000000000000000000000c1',
+          });
         }
 
         throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest?.['method'])}`);

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/startupIdentityPreflight.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/startupIdentityPreflight.int.test.ts
@@ -1,0 +1,281 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPortfolioManagerGatewayService } from './agUiServer.js';
+
+type StubRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+};
+
+type StubResponse = {
+  status?: number;
+  body?: unknown;
+};
+
+async function readRequestBody(request: IncomingMessage): Promise<Uint8Array> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function startJsonStubServer(
+  handler: (request: StubRequest) => Promise<StubResponse> | StubResponse,
+): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    void (async () => {
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+      const rawBody = await readRequestBody(request);
+      const body =
+        rawBody.length === 0 ? null : (JSON.parse(Buffer.from(rawBody).toString('utf8')) as unknown);
+      const result = await handler({
+        method: request.method ?? 'GET',
+        path: url.pathname,
+        body,
+      });
+
+      response.statusCode = result.status ?? 200;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(JSON.stringify(result.body ?? null));
+    })().catch((error: unknown) => {
+      response.statusCode = 500;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(
+        JSON.stringify({
+          message: error instanceof Error ? error.message : 'unknown error',
+        }),
+      );
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+function createInternalPostgresHooks() {
+  return {
+    ensureReady: vi.fn(async () => ({
+      databaseUrl: 'postgresql://postgres:postgres@127.0.0.1:55432/pi_runtime',
+    })),
+    loadInspectionState: vi.fn(async () => ({
+      threads: [],
+      executions: [],
+      automations: [],
+      automationRuns: [],
+      interrupts: [],
+      leases: [],
+      outboxIntents: [],
+      executionEvents: [],
+      threadActivities: [],
+    })),
+    executeStatements: vi.fn(async () => undefined),
+    persistDirectExecution: vi.fn(async () => undefined),
+  };
+}
+
+describe('portfolio-manager startup identity preflight integration', () => {
+  const cleanupFns: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanupFns.length > 0) {
+      const cleanup = cleanupFns.pop();
+      if (cleanup) {
+        await cleanup();
+      }
+    }
+  });
+
+  it('writes the orchestrator identity through the live Shared Ember and local OWS HTTP boundaries before boot succeeds', async () => {
+    const sharedEmberRequests: Array<Record<string, unknown>> = [];
+    const sharedEmber = await startJsonStubServer(async ({ path, body }) => {
+      if (path !== '/jsonrpc') {
+        return {
+          status: 404,
+          body: {
+            message: 'not found',
+          },
+        };
+      }
+
+      const request =
+        typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : {};
+      sharedEmberRequests.push(request);
+
+      if (request['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-read',
+            result: {
+              protocol_version: 'v1',
+              revision: 2,
+              agent_service_identity: null,
+            },
+          },
+        };
+      }
+
+      if (request['method'] === 'orchestrator.writeAgentServiceIdentity.v1') {
+        const params =
+          typeof request['params'] === 'object' && request['params'] !== null
+            ? (request['params'] as Record<string, unknown>)
+            : {};
+
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-write',
+            result: {
+              protocol_version: 'v1',
+              revision: 3,
+              agent_service_identity: params['agent_service_identity'] ?? null,
+            },
+          },
+        };
+      }
+
+      return {
+        status: 500,
+        body: {
+          message: `unexpected method ${String(request['method'])}`,
+        },
+      };
+    });
+    cleanupFns.push(sharedEmber.close);
+
+    const localOws = await startJsonStubServer(async ({ method, path }) => {
+      if (method === 'GET' && path === '/identity') {
+        return {
+          body: {
+            controller_wallet_address: '0x00000000000000000000000000000000000000c1',
+          },
+        };
+      }
+
+      return {
+        status: 404,
+        body: {
+          message: 'not found',
+        },
+      };
+    });
+    cleanupFns.push(localOws.close);
+
+    const service = await createPortfolioManagerGatewayService({
+      env: {
+        OPENROUTER_API_KEY: 'test-openrouter-key',
+        SHARED_EMBER_BASE_URL: sharedEmber.baseUrl,
+        PORTFOLIO_MANAGER_OWS_BASE_URL: localOws.baseUrl,
+      },
+      __internalPostgres: createInternalPostgresHooks(),
+    } as never);
+
+    await expect(service.control.inspectHealth()).resolves.toMatchObject({
+      status: 'ok',
+    });
+
+    expect(sharedEmberRequests).toHaveLength(2);
+    expect(sharedEmberRequests[0]).toMatchObject({
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
+    expect(sharedEmberRequests[1]).toMatchObject({
+      method: 'orchestrator.writeAgentServiceIdentity.v1',
+      params: {
+        expected_revision: 2,
+        agent_service_identity: {
+          agent_id: 'portfolio-manager',
+          role: 'orchestrator',
+          wallet_address: '0x00000000000000000000000000000000000000c1',
+          registration_version: 1,
+        },
+      },
+    });
+  });
+
+  it('fails closed before boot succeeds when the local OWS controller identity omits the wallet address', async () => {
+    const sharedEmberRequests: Array<Record<string, unknown>> = [];
+    const sharedEmber = await startJsonStubServer(async ({ path, body }) => {
+      if (path === '/jsonrpc' && typeof body === 'object' && body !== null) {
+        sharedEmberRequests.push(body as Record<string, unknown>);
+      }
+
+      return {
+        body: {
+          jsonrpc: '2.0',
+          id: 'unexpected',
+          result: {},
+        },
+      };
+    });
+    cleanupFns.push(sharedEmber.close);
+
+    const localOws = await startJsonStubServer(async ({ method, path }) => {
+      if (method === 'GET' && path === '/identity') {
+        return {
+          body: {
+            status: 'ok',
+          },
+        };
+      }
+
+      return {
+        status: 404,
+        body: {
+          message: 'not found',
+        },
+      };
+    });
+    cleanupFns.push(localOws.close);
+
+    await expect(
+      createPortfolioManagerGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: sharedEmber.baseUrl,
+          PORTFOLIO_MANAGER_OWS_BASE_URL: localOws.baseUrl,
+        },
+        __internalPostgres: createInternalPostgresHooks(),
+      } as never),
+    ).rejects.toThrow('Local OWS controller identity response was missing a wallet address.');
+
+    expect(sharedEmberRequests).toHaveLength(0);
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/startupIdentityPreflight.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/startupIdentityPreflight.int.test.ts
@@ -230,6 +230,96 @@ describe('portfolio-manager startup identity preflight integration', () => {
     });
   });
 
+  it('fails closed before boot succeeds when Shared Ember does not confirm the orchestrator identity write', async () => {
+    const sharedEmberRequests: Array<Record<string, unknown>> = [];
+    const sharedEmber = await startJsonStubServer(async ({ path, body }) => {
+      if (path !== '/jsonrpc') {
+        return {
+          status: 404,
+          body: {
+            message: 'not found',
+          },
+        };
+      }
+
+      const request =
+        typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : {};
+      sharedEmberRequests.push(request);
+
+      if (request['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-read',
+            result: {
+              protocol_version: 'v1',
+              revision: 2,
+              agent_service_identity: null,
+            },
+          },
+        };
+      }
+
+      if (request['method'] === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          body: {
+            jsonrpc: '2.0',
+            id: request['id'] ?? 'rpc-agent-service-identity-write',
+            result: {
+              protocol_version: 'v1',
+              revision: 3,
+              agent_service_identity: null,
+            },
+          },
+        };
+      }
+
+      return {
+        status: 500,
+        body: {
+          message: `unexpected method ${String(request['method'])}`,
+        },
+      };
+    });
+    cleanupFns.push(sharedEmber.close);
+
+    const localOws = await startJsonStubServer(async ({ method, path }) => {
+      if (method === 'GET' && path === '/identity') {
+        return {
+          body: {
+            controller_wallet_address: '0x00000000000000000000000000000000000000c1',
+          },
+        };
+      }
+
+      return {
+        status: 404,
+        body: {
+          message: 'not found',
+        },
+      };
+    });
+    cleanupFns.push(localOws.close);
+
+    await expect(
+      createPortfolioManagerGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: sharedEmber.baseUrl,
+          PORTFOLIO_MANAGER_OWS_BASE_URL: localOws.baseUrl,
+        },
+        __internalPostgres: createInternalPostgresHooks(),
+      } as never),
+    ).rejects.toThrow(
+      'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.',
+    );
+
+    expect(sharedEmberRequests).toHaveLength(2);
+    expect(sharedEmberRequests[1]).toMatchObject({
+      method: 'orchestrator.writeAgentServiceIdentity.v1',
+    });
+  });
+
   it('fails closed before boot succeeds when the local OWS controller identity omits the wallet address', async () => {
     const sharedEmberRequests: Array<Record<string, unknown>> = [];
     const sharedEmber = await startJsonStubServer(async ({ path, body }) => {

--- a/typescript/clients/web-ag-ui/docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md
@@ -1,0 +1,103 @@
+# ADR 0014: fail-closed-service-identity-preflight-for-managed-shared-ember-agents
+
+Status: Accepted
+Date: 2026-04-02
+
+## Context
+
+The first managed Shared Ember downstream pair in `web-ag-ui` depends on two
+durable role-scoped service identities:
+
+- `portfolio-manager` / `orchestrator`
+- `ember-lending` / `subagent`
+
+Issue `#563` exposed that managed onboarding could appear healthy even when
+those durable records were missing, stale, or did not match the wallet
+currently resolved from the local OWS-facing service seam.
+
+The downstream apps also need a clear readiness rule for the first managed lane
+after rooted bootstrap:
+
+- durable identity presence alone is not enough
+- the portfolio-manager must not mark onboarding complete until Shared Ember
+  exposes a non-null managed-lane `subagent_wallet_address`
+
+At the same time, the repo already has a separate follow-on issue for deeper
+OWS-internals refactoring. This ADR should ratify the current downstream
+contract without pulling that separate work into the managed-onboarding bugfix
+slice.
+
+## Decision
+
+For managed Shared Ember downstream agents in `web-ag-ui`:
+
+- each service owns its own startup identity preflight
+- each service must resolve its local wallet from the current OWS-facing HTTP
+  seam before the runtime is considered ready
+- each service must read the current durable Shared Ember service identity for
+  its own `agent_id` and role
+- if the durable identity is missing or points at a different wallet, the
+  service must rewrite it before continuing
+- each distinct identity rewrite must use a fresh identity-scoped idempotency
+  key
+- startup must fail closed unless Shared Ember echoes back the confirmed
+  identity with the expected `agent_id`, role, and wallet address
+
+Managed onboarding rules:
+
+- portfolio-manager must re-read both required durable identities before rooted
+  bootstrap
+- portfolio-manager must block onboarding if either required identity is absent
+  or unverified
+- portfolio-manager must not mark onboarding complete until a follow-up
+  `subagent.readExecutionContext.v1` read for `ember-lending` exposes a
+  non-null `subagent_wallet_address`
+
+Scope boundary:
+
+- this ADR governs the current downstream OWS-facing HTTP seam only
+- it does not decide where deeper OWS internals should eventually live
+- the separate OWS-internals follow-up remains responsible for that refactor
+
+## Rationale
+
+- preserves correct ownership: orchestrator and subagent each prove only their
+  own identity
+- prevents managed onboarding from succeeding on stale or guessed wallet state
+- makes local OWS resolution and Shared Ember durable state agree before the
+  runtime appears healthy
+- keeps the downstream managed-onboarding contract explicit while allowing a
+  separate issue to change OWS internals later
+- provides a concrete validation lane:
+  - `pnpm smoke:managed-identities`
+
+## Alternatives Considered
+
+- allow onboarding to proceed when durable identities are missing:
+  - rejected because it recreates the fail-open behavior from `#563`
+- accept any non-null durable identity without comparing it to the current OWS
+  wallet:
+  - rejected because stale durable records are not safe readiness proof
+- wait for execution-time hydration to discover the missing subagent wallet:
+  - rejected because onboarding would already appear complete by then
+- fold the deeper OWS-internals refactor into this decision:
+  - rejected because that is a separate issue with a broader architectural
+    surface
+
+## Consequences
+
+- Positive:
+  - managed Shared Ember agents now have one clear startup and onboarding
+    readiness contract
+  - the runtime fails early with operator-visible errors instead of late
+    downstream surprises
+  - the repo has a repeatable smoke command for the audited proof surface
+- Tradeoffs:
+  - downstream apps remain temporarily coupled to the current OWS-facing HTTP
+    seam until the follow-on issue lands
+  - managed onboarding now depends on an extra post-bootstrap execution-context
+    read before promotion to `active`
+- Follow-on work:
+  - keep docs and smoke output aligned with the current contract
+  - let the separate OWS-internals issue change the seam later without
+    weakening the fail-closed identity contract

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -15,3 +15,4 @@
 | [0011](./0011-blessed-agent-runtime-factory-and-runtime-owned-projection-assembly.md) | Blessed agent-runtime factory and runtime-owned projection assembly | Accepted | 2026-03-28 |
 | [0012](./0012-runtime-family-neutral-web-thread-contract.md) | Runtime-family-neutral web thread contract | Accepted | 2026-03-30 |
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
+| [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -157,11 +157,12 @@ Container responsibilities:
 - Operator control plane: scheduler health, maintenance, replay/recreate, inspection, and archival workflows that are not model-facing tools
 - Current managed-runtime example:
   - `agent-portfolio-manager` owns onboarding approval, rooted-signing collection, and managed-agent control-plane projection, but Shared Ember owns the durable reservation and owned-unit truth created during onboarding completion.
-  - `agent-portfolio-manager` startup must resolve the local OWS controller wallet, confirm or rewrite the durable `portfolio-manager` / `orchestrator` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity.
+  - `agent-portfolio-manager` startup must resolve the local OWS controller wallet, confirm or rewrite the durable `portfolio-manager` / `orchestrator` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address.
+  - `agent-portfolio-manager` does not mark managed onboarding complete until a follow-up `subagent.readExecutionContext.v1` read for `ember-lending` exposes a non-null `subagent_wallet_address`.
   - `agent-portfolio-manager` wallet-accounting reads must target the activated managed mandate lane, not the portfolio-manager lane, so reservation and policy-snapshot context comes from the same agent scope that Shared Ember activated during bootstrap.
   - The current portfolio-manager implementation writes `activation.mandateRef` on new bootstrap completions but still tolerates legacy stored bootstrap payloads that only captured `activation.agentId` until older thread state is replaced.
   - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember and consumes agent-scoped lane data plus rooted-wallet-wide wallet contents from Shared Ember execution context.
-  - `agent-ember-lending` startup must resolve the local OWS signer wallet, confirm or rewrite the durable `ember-lending` / `subagent` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity.
+  - `agent-ember-lending` startup must resolve the local OWS signer wallet, confirm or rewrite the durable `ember-lending` / `subagent` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address.
   - After healthy identity preflight plus onboarding, the first healthy `subagent.readExecutionContext.v1` read is expected to expose a non-null `subagent_wallet_address`.
 
 Important web constraint:

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -36,6 +36,7 @@ Related docs:
 - `docs/adr/0007-sibling-channel-adapters-and-canonical-thread-identity.md`
 - `docs/adr/0008-runtime-agnostic-shared-contract-extraction.md`
 - `docs/adr/0011-blessed-agent-runtime-factory-and-runtime-owned-projection-assembly.md`
+- `docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md`
 
 ## 2. Boundary rules
 
@@ -164,6 +165,7 @@ Container responsibilities:
   - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember and consumes agent-scoped lane data plus rooted-wallet-wide wallet contents from Shared Ember execution context.
   - `agent-ember-lending` startup must resolve the local OWS signer wallet, confirm or rewrite the durable `ember-lending` / `subagent` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address.
   - After healthy identity preflight plus onboarding, the first healthy `subagent.readExecutionContext.v1` read is expected to expose a non-null `subagent_wallet_address`.
+  - The repo-local validation lane for this boundary is `pnpm smoke:managed-identities`; deeper OWS-internals refactors remain out of scope for this contract.
 
 Important web constraint:
 

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -157,9 +157,12 @@ Container responsibilities:
 - Operator control plane: scheduler health, maintenance, replay/recreate, inspection, and archival workflows that are not model-facing tools
 - Current managed-runtime example:
   - `agent-portfolio-manager` owns onboarding approval, rooted-signing collection, and managed-agent control-plane projection, but Shared Ember owns the durable reservation and owned-unit truth created during onboarding completion.
+  - `agent-portfolio-manager` startup must resolve the local OWS controller wallet, confirm or rewrite the durable `portfolio-manager` / `orchestrator` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity.
   - `agent-portfolio-manager` wallet-accounting reads must target the activated managed mandate lane, not the portfolio-manager lane, so reservation and policy-snapshot context comes from the same agent scope that Shared Ember activated during bootstrap.
   - The current portfolio-manager implementation writes `activation.mandateRef` on new bootstrap completions but still tolerates legacy stored bootstrap payloads that only captured `activation.agentId` until older thread state is replaced.
   - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate runtime against Shared Ember and consumes agent-scoped lane data plus rooted-wallet-wide wallet contents from Shared Ember execution context.
+  - `agent-ember-lending` startup must resolve the local OWS signer wallet, confirm or rewrite the durable `ember-lending` / `subagent` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity.
+  - After healthy identity preflight plus onboarding, the first healthy `subagent.readExecutionContext.v1` read is expected to expose a non-null `subagent_wallet_address`.
 
 Important web constraint:
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -187,17 +187,22 @@ Current concrete managed-path specialization:
 
 - `agent-portfolio-manager`
   - owns onboarding approval, rooted-signing collection, and managed-agent activation/deactivation intent submission
+  - resolves the local OWS controller wallet during startup and confirms or rewrites the durable `portfolio-manager` / `orchestrator` identity before boot
+  - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity
   - submits the minimal rooted-bootstrap activation contract that tells Shared Ember which managed mandate should materialize the initial lane
   - consumes Shared Ember through a thin app-local adapter without owning Ember business logic
 
 - `agent-ember-lending`
   - owns the first bounded managed-subagent runtime
+  - resolves the local OWS signer wallet during startup and confirms or rewrites the durable `ember-lending` / `subagent` identity before boot
+  - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
   - keeps `request_transaction_execution` as one model-visible tool while internally composing Shared Ember execution preparation, local OWS redelegation/execution signing, and Ember-owned submission/finalization
   - treats `authority_preparation_needed` as an internal wait state and re-polls the Shared Ember execution request with a stage-scoped retry idempotency key instead of exposing a second tool or reusing the original acknowledged request key
   - reconciles dropped signed-transaction submit responses through the Shared Ember committed-event outbox before replaying an idempotent submit
   - fails closed when the local OWS identity/signing path cannot prove it matches the prepared dedicated subagent signing package
+  - expects the first healthy post-onboarding `subagent.readExecutionContext.v1` read to expose a non-null `subagent_wallet_address` without any manual reseed step
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
   - treats `owned_units` and `reservations` as lending-lane truth while treating `wallet_contents` as rooted-wallet-wide context for prompt visibility
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -207,6 +207,11 @@ Current concrete managed-path specialization:
   - projects lifecycle, wallet, mandate, reservation, planning, execution, and escalation state into the shared AG-UI thread contract
   - treats `owned_units` and `reservations` as lending-lane truth while treating `wallet_contents` as rooted-wallet-wide context for prompt visibility
 
+Validation note:
+
+- `pnpm smoke:managed-identities` is the current repo-local proof for the two non-null identity reads plus the non-null post-bootstrap `subagent_wallet_address`.
+- That smoke stays on the current downstream OWS-facing HTTP seam; deeper OWS-internals changes are intentionally handled elsewhere.
+
 ## 6. Dynamic views (sequence)
 
 ### 6.1 Detail page open (active stream)

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -188,14 +188,15 @@ Current concrete managed-path specialization:
 - `agent-portfolio-manager`
   - owns onboarding approval, rooted-signing collection, and managed-agent activation/deactivation intent submission
   - resolves the local OWS controller wallet during startup and confirms or rewrites the durable `portfolio-manager` / `orchestrator` identity before boot
-  - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity
+  - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address
+  - only marks onboarding complete after rooted bootstrap once a follow-up `subagent.readExecutionContext.v1` read for `ember-lending` exposes a non-null `subagent_wallet_address`
   - submits the minimal rooted-bootstrap activation contract that tells Shared Ember which managed mandate should materialize the initial lane
   - consumes Shared Ember through a thin app-local adapter without owning Ember business logic
 
 - `agent-ember-lending`
   - owns the first bounded managed-subagent runtime
   - resolves the local OWS signer wallet during startup and confirms or rewrites the durable `ember-lending` / `subagent` identity before boot
-  - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity
+  - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
   - keeps `request_transaction_execution` as one model-visible tool while internally composing Shared Ember execution preparation, local OWS redelegation/execution signing, and Ember-owned submission/finalization

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -95,3 +95,4 @@ sequenceDiagram
 - The managed lending mandate supplied at bootstrap should carry `managed_onboarding` so Shared Ember can derive the initial lane and delegation inputs from structured mandate data.
 - Portfolio-manager wallet accounting should resolve its onboarding-state `agent_id` from the activated managed mandate so operator-visible reservations and policy snapshots match the managed lane Ember Lending sees.
 - When Shared Ember has a durable subagent identity ready during onboarding, the first post-bootstrap execution-context read should already expose a non-null `subagent_wallet_address`, and Ember Lending should project it without any manual reseed step.
+- The current repo-local smoke for this contract is `pnpm smoke:managed-identities`; it intentionally stays on the downstream OWS-facing HTTP seam and does not absorb the separate OWS-internals follow-up.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -40,10 +40,12 @@ sequenceDiagram
 
   PM->>OWS: resolve controller wallet
   PM->>SE: read/write `portfolio-manager` / `orchestrator` service identity
-  Note over PM,SE: each distinct startup identity write uses a fresh identity-scoped idempotency key and must echo a confirmed `agent_service_identity` or startup fails closed
+  Note over PM,SE: each distinct startup identity write uses a fresh identity-scoped idempotency key and must echo a confirmed `agent_service_identity` with the expected `agent_id`, `role`, and wallet or startup fails closed
   EL->>OWS: resolve signer wallet
   EL->>SE: read/write `ember-lending` / `subagent` service identity
   PM->>SE: complete rooted bootstrap with activation.mandateRef targeting the approved lending mandate
+  PM->>SE: read `subagent.readExecutionContext.v1` for `ember-lending`
+  Note over PM,SE: onboarding stays blocked until `subagent_wallet_address` is non-null in the post-bootstrap execution-context read
   Note over SE: Wallet observation, accounting-unit ingestion, reservation creation, and policy snapshot materialization happen inside Shared Ember
   PM->>SE: read onboarding/accounting state through the activated managed mandate lane
   Note over PM,SE: Portfolio-manager accounting context follows the same managed `lending.supply` lane that bootstrap activated
@@ -89,7 +91,7 @@ sequenceDiagram
 - There is no model-visible `read_portfolio_state` tool.
 - There is no model-visible onboarding-context read or manual sync/bootstrap step.
 - `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.
-- Portfolio-manager and Ember Lending startup must both fail closed when Shared Ember does not echo back the confirmed durable service identity for the current OWS-resolved wallet.
+- Portfolio-manager and Ember Lending startup must both fail closed when Shared Ember does not echo back the confirmed durable service identity for the current OWS-resolved `agent_id`, `role`, and wallet.
 - The managed lending mandate supplied at bootstrap should carry `managed_onboarding` so Shared Ember can derive the initial lane and delegation inputs from structured mandate data.
 - Portfolio-manager wallet accounting should resolve its onboarding-state `agent_id` from the activated managed mandate so operator-visible reservations and policy snapshots match the managed lane Ember Lending sees.
 - When Shared Ember has a durable subagent identity ready during onboarding, the first post-bootstrap execution-context read should already expose a non-null `subagent_wallet_address`, and Ember Lending should project it without any manual reseed step.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -16,6 +16,7 @@ Follow-on note:
   - `request_transaction_execution`
   - `create_escalation_request`
 - Runtime-only behavior remains hidden:
+  - startup identity proof / rotation against local OWS + Shared Ember before the managed path is considered ready
   - connect-time projection hydration
   - `subagent.readExecutionContext.v1` during system-context assembly
   - revision refresh / retry handling after Shared Ember conflicts
@@ -34,8 +35,14 @@ sequenceDiagram
   participant PM as agent-portfolio-manager
   participant EL as agent-ember-lending
   participant SE as Shared Ember
+  participant OWS as local OWS identity surface
   participant Planner as ember-cli planner path
 
+  PM->>OWS: resolve controller wallet
+  PM->>SE: read/write `portfolio-manager` / `orchestrator` service identity
+  Note over PM,SE: each distinct startup identity write uses a fresh identity-scoped idempotency key and must echo a confirmed `agent_service_identity` or startup fails closed
+  EL->>OWS: resolve signer wallet
+  EL->>SE: read/write `ember-lending` / `subagent` service identity
   PM->>SE: complete rooted bootstrap with activation.mandateRef targeting the approved lending mandate
   Note over SE: Wallet observation, accounting-unit ingestion, reservation creation, and policy snapshot materialization happen inside Shared Ember
   PM->>SE: read onboarding/accounting state through the activated managed mandate lane
@@ -82,6 +89,7 @@ sequenceDiagram
 - There is no model-visible `read_portfolio_state` tool.
 - There is no model-visible onboarding-context read or manual sync/bootstrap step.
 - `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.
+- Portfolio-manager and Ember Lending startup must both fail closed when Shared Ember does not echo back the confirmed durable service identity for the current OWS-resolved wallet.
 - The managed lending mandate supplied at bootstrap should carry `managed_onboarding` so Shared Ember can derive the initial lane and delegation inputs from structured mandate data.
 - Portfolio-manager wallet accounting should resolve its onboarding-state `agent_id` from the activated managed mandate so operator-visible reservations and policy snapshots match the managed lane Ember Lending sees.
 - When Shared Ember has a durable subagent identity ready during onboarding, the first post-bootstrap execution-context read should already expose a non-null `subagent_wallet_address`, and Ember Lending should project it without any manual reseed step.

--- a/typescript/clients/web-ag-ui/package.json
+++ b/typescript/clients/web-ag-ui/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "pnpm -r --filter \"./apps/*\" run test:e2e",
     "test:watch": "pnpm -r --parallel --filter \"./apps/*\" run test:watch",
     "test:ci": "pnpm -r --filter \"./apps/*\" run test:ci",
+    "smoke:managed-identities": "pnpm --dir ./apps/agent-portfolio-manager exec tsx ../../scripts/smoke/managed-onboarding-identity-smoke.ts",
     "reset:dev-stack": "bash scripts/reset-dev-stack.sh"
   },
   "devDependencies": {

--- a/typescript/clients/web-ag-ui/scripts/smoke/README.md
+++ b/typescript/clients/web-ag-ui/scripts/smoke/README.md
@@ -19,6 +19,13 @@ These scripts are intentionally "thin" and rely on already-running local dev pro
   - If you interrupt the script, it attempts to close the Playwright browser. If you still see noisy polling
     afterward, run `pnpm reset:dev-stack` (it also kills stale Playwright headless shells).
 
+- `pnpm smoke:managed-identities`
+  - Boots the repo-local Shared Ember HTTP harness plus current downstream OWS-facing identity stubs.
+  - Confirms `portfolio-manager` / `orchestrator` and `ember-lending` / `subagent` are both non-null.
+  - Drives the portfolio-manager rooted-bootstrap path and verifies post-bootstrap
+    `subagent.readExecutionContext.v1` returns a non-null `subagent_wallet_address`.
+  - This smoke intentionally stays on the current downstream OWS HTTP seam; deeper OWS-internals changes belong to the separate follow-on issue.
+
 ## Typical Local Flow
 
 ```bash
@@ -33,4 +40,7 @@ PENDLE_POLL_INTERVAL_MS=5000 pnpm dev:delegations-bypass
 # in another terminal
 bash scripts/smoke/pendle-detail-page-health.sh
 bash scripts/smoke/pendle-cron-ui-updates.sh
+
+# managed Shared Ember identity proof
+pnpm smoke:managed-identities
 ```

--- a/typescript/clients/web-ag-ui/scripts/smoke/managed-onboarding-identity-smoke.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/managed-onboarding-identity-smoke.ts
@@ -1,0 +1,400 @@
+import { existsSync } from 'node:fs';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ensureEmberLendingServiceIdentity } from '../../apps/agent-ember-lending/src/serviceIdentityPreflight.js';
+import { createEmberLendingSharedEmberHttpHost } from '../../apps/agent-ember-lending/src/sharedEmberHttpHost.js';
+import { ensurePortfolioManagerServiceIdentity } from '../../apps/agent-portfolio-manager/src/serviceIdentityPreflight.js';
+import { createPortfolioManagerDomain } from '../../apps/agent-portfolio-manager/src/sharedEmberAdapter.js';
+import { resolveSharedEmberTarget } from '../../apps/agent-portfolio-manager/src/sharedEmberIntegrationHarness.js';
+import { createPortfolioManagerSharedEmberHttpHost } from '../../apps/agent-portfolio-manager/src/sharedEmberHttpHost.js';
+
+type StubRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+};
+
+type StubResponse = {
+  status?: number;
+  body?: unknown;
+};
+
+type JsonRpcResponse<TResult> = {
+  result?: TResult;
+  error?: {
+    message?: string;
+  };
+};
+
+const CONTROLLER_WALLET = '0x00000000000000000000000000000000000000c1' as const;
+const SUBAGENT_WALLET = '0x00000000000000000000000000000000000000b1' as const;
+const USER_WALLET = '0x00000000000000000000000000000000000000a1' as const;
+const THREAD_ID = 'smoke-thread-563';
+
+function findForgePrivateRepoRoot(): string | null {
+  let current = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+
+  while (true) {
+    const candidate = path.join(current, 'repos', 'ember-orchestration-v1-spec');
+    if (existsSync(path.join(candidate, 'package.json'))) {
+      return candidate;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+
+    current = parent;
+  }
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<Uint8Array> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function startJsonStubServer(
+  handler: (request: StubRequest) => Promise<StubResponse> | StubResponse,
+): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    void (async () => {
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+      const rawBody = await readRequestBody(request);
+      const body =
+        rawBody.length === 0 ? null : (JSON.parse(Buffer.from(rawBody).toString('utf8')) as unknown);
+      const result = await handler({
+        method: request.method ?? 'GET',
+        path: url.pathname,
+        body,
+      });
+
+      response.statusCode = result.status ?? 200;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(JSON.stringify(result.body ?? null));
+    })().catch((error: unknown) => {
+      response.statusCode = 500;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end(
+        JSON.stringify({
+          message: error instanceof Error ? error.message : 'unknown error',
+        }),
+      );
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function postJsonRpc<TResult>(input: {
+  baseUrl: string;
+  method: string;
+  params: Record<string, unknown>;
+}): Promise<TResult> {
+  const response = await fetch(`${input.baseUrl}/jsonrpc`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: `smoke-${input.method}`,
+      method: input.method,
+      params: input.params,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Shared Ember HTTP request failed with status ${response.status}.`);
+  }
+
+  const body = (await response.json()) as JsonRpcResponse<TResult>;
+  if (body.error?.message) {
+    throw new Error(`Shared Ember JSON-RPC error: ${body.error.message}`);
+  }
+  if (!body.result) {
+    throw new Error(`Shared Ember JSON-RPC response for ${input.method} was missing result.`);
+  }
+
+  return body.result;
+}
+
+function createPortfolioManagerSetupInput() {
+  return {
+    walletAddress: USER_WALLET,
+    portfolioMandate: {
+      approved: true,
+      riskLevel: 'medium' as const,
+    },
+    managedAgentMandates: [
+      {
+        agentKey: 'ember-lending-primary',
+        agentType: 'ember-lending',
+        approved: true,
+        settings: {
+          network: 'arbitrum',
+          protocol: 'aave',
+          allowedCollateralAssets: ['USDC'],
+          allowedBorrowAssets: ['USDC'],
+          maxAllocationPct: 35,
+          maxLtvBps: 7000,
+          minHealthFactor: '1.25',
+        },
+      },
+    ],
+  };
+}
+
+function createSignedDelegation() {
+  return {
+    delegate: '0x2222222222222222222222222222222222222222',
+    delegator: USER_WALLET,
+    authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    caveats: [],
+    salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    signature: '0x1234',
+  };
+}
+
+async function main() {
+  const detectedPrivateRepoRoot = findForgePrivateRepoRoot();
+  if (!process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT'] && detectedPrivateRepoRoot) {
+    process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT'] = detectedPrivateRepoRoot;
+  }
+
+  const sharedEmberTarget = await resolveSharedEmberTarget({
+    managedAgentId: 'ember-lending',
+    managedAgentWalletAddress: SUBAGENT_WALLET,
+  });
+  const controllerOws = await startJsonStubServer(async ({ method, path }) => {
+    if (method === 'GET' && path === '/identity') {
+      return {
+        body: {
+          controller_wallet_address: CONTROLLER_WALLET,
+        },
+      };
+    }
+
+    return {
+      status: 404,
+      body: {
+        message: 'not found',
+      },
+    };
+  });
+  const lendingOws = await startJsonStubServer(async ({ method, path }) => {
+    if (method === 'GET' && path === '/identity') {
+      return {
+        body: {
+          wallet_address: SUBAGENT_WALLET,
+        },
+      };
+    }
+
+    return {
+      status: 404,
+      body: {
+        message: 'not found',
+      },
+    };
+  });
+
+  const portfolioProtocolHost = createPortfolioManagerSharedEmberHttpHost({
+    baseUrl: sharedEmberTarget.baseUrl,
+  });
+  const lendingProtocolHost = createEmberLendingSharedEmberHttpHost({
+    baseUrl: sharedEmberTarget.baseUrl,
+  });
+
+  try {
+    const ensuredPortfolioIdentity = await ensurePortfolioManagerServiceIdentity({
+      protocolHost: portfolioProtocolHost,
+      readControllerWalletAddress: async () => CONTROLLER_WALLET,
+    });
+    const ensuredLendingIdentity = await ensureEmberLendingServiceIdentity({
+      protocolHost: lendingProtocolHost,
+      readSignerWalletAddress: async () => SUBAGENT_WALLET,
+    });
+
+    if (ensuredPortfolioIdentity.identity.wallet_address !== CONTROLLER_WALLET) {
+      throw new Error('Portfolio-manager startup identity preflight did not confirm the expected wallet.');
+    }
+    if (ensuredLendingIdentity.identity.wallet_address !== SUBAGENT_WALLET) {
+      throw new Error('Ember-lending startup identity preflight did not confirm the expected wallet.');
+    }
+
+    const orchestratorIdentity = await postJsonRpc<{
+      revision?: number;
+      agent_service_identity?: {
+        wallet_address?: string;
+      } | null;
+    }>({
+      baseUrl: sharedEmberTarget.baseUrl,
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'portfolio-manager',
+        role: 'orchestrator',
+      },
+    });
+    const subagentIdentity = await postJsonRpc<{
+      revision?: number;
+      agent_service_identity?: {
+        wallet_address?: string;
+      } | null;
+    }>({
+      baseUrl: sharedEmberTarget.baseUrl,
+      method: 'orchestrator.readAgentServiceIdentity.v1',
+      params: {
+        agent_id: 'ember-lending',
+        role: 'subagent',
+      },
+    });
+
+    const orchestratorWallet = orchestratorIdentity.agent_service_identity?.wallet_address ?? null;
+    const subagentWallet = subagentIdentity.agent_service_identity?.wallet_address ?? null;
+    if (orchestratorWallet !== CONTROLLER_WALLET) {
+      throw new Error(
+        `Expected portfolio-manager orchestrator wallet ${CONTROLLER_WALLET} but got ${String(orchestratorWallet)}.`,
+      );
+    }
+    if (subagentWallet !== SUBAGENT_WALLET) {
+      throw new Error(
+        `Expected ember-lending subagent wallet ${SUBAGENT_WALLET} but got ${String(subagentWallet)}.`,
+      );
+    }
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost: portfolioProtocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: CONTROLLER_WALLET,
+    });
+
+    const hireResult = await domain.handleOperation?.({
+      threadId: THREAD_ID,
+      state: {
+        phase: 'prehire',
+        lastPortfolioState: null,
+        lastSharedEmberRevision: null,
+        lastRootDelegation: null,
+        lastOnboardingBootstrap: null,
+        lastRootedWalletContextId: null,
+        activeWalletAddress: null,
+        pendingOnboardingWalletAddress: null,
+      },
+      operation: {
+        source: 'command',
+        name: 'hire',
+      },
+    });
+
+    if (!hireResult?.state || !('phase' in hireResult.state) || hireResult.state.phase !== 'onboarding') {
+      throw new Error('Portfolio-manager hire did not enter onboarding.');
+    }
+
+    const setupResult = await domain.handleOperation?.({
+      threadId: THREAD_ID,
+      state: hireResult.state,
+      operation: {
+        source: 'interrupt',
+        name: 'portfolio-manager-setup-request',
+        input: createPortfolioManagerSetupInput(),
+      },
+    });
+
+    if (
+      !setupResult?.state ||
+      !('pendingOnboardingWalletAddress' in setupResult.state) ||
+      setupResult.state.pendingOnboardingWalletAddress !== USER_WALLET
+    ) {
+      throw new Error('Portfolio-manager setup did not persist the expected onboarding wallet.');
+    }
+
+    const signingResult = await domain.handleOperation?.({
+      threadId: THREAD_ID,
+      state: setupResult.state,
+      operation: {
+        source: 'interrupt',
+        name: 'portfolio-manager-delegation-signing-request',
+        input: {
+          outcome: 'signed',
+          signedDelegations: [createSignedDelegation()],
+        },
+      },
+    });
+
+    if (!signingResult?.state || !('phase' in signingResult.state) || signingResult.state.phase !== 'active') {
+      throw new Error('Portfolio-manager rooted bootstrap did not promote the thread to active.');
+    }
+
+    const executionContext = await postJsonRpc<{
+      revision?: number;
+      execution_context?: {
+        subagent_wallet_address?: string | null;
+      };
+    }>({
+      baseUrl: sharedEmberTarget.baseUrl,
+      method: 'subagent.readExecutionContext.v1',
+      params: {
+        agent_id: 'ember-lending',
+      },
+    });
+    const hydratedSubagentWallet =
+      executionContext.execution_context?.subagent_wallet_address ?? null;
+    if (hydratedSubagentWallet !== SUBAGENT_WALLET) {
+      throw new Error(
+        `Expected post-bootstrap subagent wallet ${SUBAGENT_WALLET} but got ${String(hydratedSubagentWallet)}.`,
+      );
+    }
+
+    console.log('[smoke:managed-identities] portfolio-manager/orchestrator:', orchestratorWallet);
+    console.log('[smoke:managed-identities] ember-lending/subagent:', subagentWallet);
+    console.log('[smoke:managed-identities] post-bootstrap subagent_wallet_address:', hydratedSubagentWallet);
+    console.log('[smoke:managed-identities] OK');
+  } finally {
+    await lendingOws.close();
+    await controllerOws.close();
+    await sharedEmberTarget.close();
+  }
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error('[smoke:managed-identities] FAILED:', message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add the missing regression coverage for an absent `portfolio-manager` orchestrator identity in both the domain and AG-UI onboarding paths
- reject misaddressed Shared Ember identity echoes during onboarding re-verification so mismatched `agent_id` or `role` fail closed before bootstrap
- add `pnpm smoke:managed-identities` to prove the current downstream Shared Ember + OWS-facing seam returns two non-null identity reads plus a non-null post-bootstrap `subagent_wallet_address`
- align the READMEs, C4 docs, sequence doc, and ADR 0014 with the fail-closed contract while keeping deeper OWS integration scoped to `#564`

## Fresh proof
- `pnpm exec vitest run src/sharedEmberAdapter.unit.test.ts` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm exec vitest run --config vitest.config.int.ts src/agUiServer.int.test.ts` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm test:int` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm build` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm smoke:managed-identities` in `typescript/clients/web-ag-ui`
  - `portfolio-manager/orchestrator`: `0x00000000000000000000000000000000000000c1`
  - `ember-lending/subagent`: `0x00000000000000000000000000000000000000b1`
  - post-bootstrap `subagent_wallet_address`: `0x00000000000000000000000000000000000000b1`

## Test plan
- `pnpm test:unit` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm test:int` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm build` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm test:unit` in `typescript/clients/web-ag-ui/apps/agent-ember-lending`
- `pnpm test:int` in `typescript/clients/web-ag-ui/apps/agent-ember-lending`
- `pnpm build` in `typescript/clients/web-ag-ui/apps/agent-ember-lending`
- `pnpm exec vitest run src/sharedEmberAdapter.unit.test.ts` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm exec vitest run --config vitest.config.int.ts src/agUiServer.int.test.ts` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `pnpm smoke:managed-identities` in `typescript/clients/web-ag-ui`

## Related
- Relates #563
- Follow-on OWS integration work: #564
- Stacked on #553 / `task/i538-ember-lending-sub-agent-public-pi-runtime`

## Scope note
- This PR fixes the fail-closed onboarding re-verification gap on the current downstream seam.
- It still does not satisfy `#563`'s separate live-QA acceptance step by itself.
- It intentionally does not absorb the deeper OWS-internals refactor tracked in `#564`.
