### PR TITLE
fix(agent-ember-lending): anchor prepared execution payloads

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
@@ -25,11 +25,11 @@ OPENROUTER_API_KEY=
 
 # Optional: override the Onchain Actions API origin the live lending service
 # uses to anchor planner payload refs behind the service boundary and later
-# resolve terminal transaction requests during execution signing.
+# resolve ordered transaction steps during execution signing.
 # ONCHAIN_ACTIONS_API_URL=https://api.emberai.xyz
 
 # Optional: override the chain RPC endpoints used to prepare the exact unsigned
-# transaction bytes from an anchored Onchain Actions request just before
+# transaction bytes for the requested anchored Onchain Actions step just before
 # runtime-owned signing.
 # ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
 # BASE_CHAIN_RPC_URL=https://mainnet.base.org

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
@@ -25,8 +25,15 @@ OPENROUTER_API_KEY=
 
 # Optional: override the Onchain Actions API origin the live lending service
 # uses to anchor planner payload refs behind the service boundary and later
-# resolve prepared unsigned transactions during execution signing.
+# resolve terminal transaction requests during execution signing.
 # ONCHAIN_ACTIONS_API_URL=https://api.emberai.xyz
+
+# Optional: override the chain RPC endpoints used to prepare the exact unsigned
+# transaction bytes from an anchored Onchain Actions request just before
+# runtime-owned signing.
+# ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
+# BASE_CHAIN_RPC_URL=https://mainnet.base.org
+# ETHEREUM_RPC_URL=https://eth.merkle.io
 
 # Optional: select the direct OWS wallet the runtime should use for startup
 # identity proof, redelegation, and execution signing. Required when

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
@@ -23,6 +23,11 @@ OPENROUTER_API_KEY=
 # ready.
 # SHARED_EMBER_BASE_URL=http://127.0.0.1:4010
 
+# Optional: override the Onchain Actions API origin the live lending service
+# uses to anchor planner payload refs behind the service boundary and later
+# resolve prepared unsigned transactions during execution signing.
+# ONCHAIN_ACTIONS_API_URL=https://api.emberai.xyz
+
 # Optional: select the direct OWS wallet the runtime should use for startup
 # identity proof, redelegation, and execution signing. Required when
 # `SHARED_EMBER_BASE_URL` is set for the live managed path.

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -43,21 +43,22 @@ Current execution-context semantics:
   fail closed if the prepared signing package does not match the resolved
   dedicated subagent wallet identity
 - the live managed path now anchors planner-returned transaction payload refs
-  behind the lending service boundary via Onchain Actions, stores the terminal
-  transaction request privately, and resolves the exact unsigned transaction
-  bytes only at execution time using the managed wallet address plus chain RPC
-  state, instead of relying on a test-only harness seam
+  behind the lending service boundary via Onchain Actions, stores the full
+  ordered transaction-request sequence in runtime-owned persisted domain state,
+  and resolves the exact unsigned transaction bytes for the requested step only
+  at execution time using the managed wallet address plus chain RPC state,
+  instead of relying on a process-local map or a test-only harness seam
 
 Runtime wiring:
 
 - `SHARED_EMBER_BASE_URL` points the app at the bounded Shared Ember HTTP
   surface
 - `ONCHAIN_ACTIONS_API_URL` optionally overrides the Onchain Actions API origin
-  used for service-owned planner payload anchoring and terminal transaction
-  request resolution
+  used for service-owned planner payload anchoring and ordered transaction-step
+  resolution
 - `ARBITRUM_RPC_URL`, `BASE_CHAIN_RPC_URL`, and `ETHEREUM_RPC_URL` optionally
   override the chain RPC endpoints the lending service uses to prepare the
-  final unsigned transaction bytes just before runtime signing
+  requested unsigned transaction bytes just before runtime signing
 - `EMBER_LENDING_OWS_WALLET_NAME` selects the direct OWS wallet the runtime
   should use for startup identity proof, redelegation, and execution signing
 - `EMBER_LENDING_OWS_PASSPHRASE` optionally unlocks that wallet when the vault

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -48,6 +48,10 @@ Current execution-context semantics:
   and resolves the exact unsigned transaction bytes for the requested step only
   at execution time using the managed wallet address plus chain RPC state,
   instead of relying on a process-local map or a test-only harness seam
+- `create_transaction_plan` now fails closed unless that service-owned
+  anchoring step succeeds; missing planner payload metadata, missing managed
+  wallet context, or missing anchored-resolver wiring must stop plan creation
+  before a locally executable candidate plan is recorded
 
 Runtime wiring:
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -42,11 +42,18 @@ Current execution-context semantics:
 - direct OWS signing stays inside the private runtime service layer and must
   fail closed if the prepared signing package does not match the resolved
   dedicated subagent wallet identity
+- the live managed path now anchors planner-returned transaction payload refs
+  behind the lending service boundary via Onchain Actions and resolves the
+  prepared unsigned transaction from that private store during execution
+  signing, instead of relying on a test-only harness seam
 
 Runtime wiring:
 
 - `SHARED_EMBER_BASE_URL` points the app at the bounded Shared Ember HTTP
   surface
+- `ONCHAIN_ACTIONS_API_URL` optionally overrides the Onchain Actions API origin
+  used for service-owned planner payload anchoring and prepared unsigned
+  transaction resolution
 - `EMBER_LENDING_OWS_WALLET_NAME` selects the direct OWS wallet the runtime
   should use for startup identity proof, redelegation, and execution signing
 - `EMBER_LENDING_OWS_PASSPHRASE` optionally unlocks that wallet when the vault
@@ -85,4 +92,4 @@ Validation note:
   a repo-local HTTP sidecar seam
 - run `RUN_SHARED_EMBER_INT=1 EMBER_ORCHESTRATION_V1_SPEC_ROOT=<private-repo-root> pnpm --filter agent-ember-lending test:int -- src/sharedEmberAdapter.int.test.ts`
   to prove the real runtime-owned redelegation typed-data signing path plus the
-  concrete-service prepared unsigned-transaction resolution seam
+  service-owned Onchain Actions prepared unsigned-transaction resolution seam

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/README.md
@@ -43,17 +43,21 @@ Current execution-context semantics:
   fail closed if the prepared signing package does not match the resolved
   dedicated subagent wallet identity
 - the live managed path now anchors planner-returned transaction payload refs
-  behind the lending service boundary via Onchain Actions and resolves the
-  prepared unsigned transaction from that private store during execution
-  signing, instead of relying on a test-only harness seam
+  behind the lending service boundary via Onchain Actions, stores the terminal
+  transaction request privately, and resolves the exact unsigned transaction
+  bytes only at execution time using the managed wallet address plus chain RPC
+  state, instead of relying on a test-only harness seam
 
 Runtime wiring:
 
 - `SHARED_EMBER_BASE_URL` points the app at the bounded Shared Ember HTTP
   surface
 - `ONCHAIN_ACTIONS_API_URL` optionally overrides the Onchain Actions API origin
-  used for service-owned planner payload anchoring and prepared unsigned
-  transaction resolution
+  used for service-owned planner payload anchoring and terminal transaction
+  request resolution
+- `ARBITRUM_RPC_URL`, `BASE_CHAIN_RPC_URL`, and `ETHEREUM_RPC_URL` optionally
+  override the chain RPC endpoints the lending service uses to prepare the
+  final unsigned transaction bytes just before runtime signing
 - `EMBER_LENDING_OWS_WALLET_NAME` selects the direct OWS wallet the runtime
   should use for startup identity proof, redelegation, and execution signing
 - `EMBER_LENDING_OWS_PASSPHRASE` optionally unlocks that wallet when the vault
@@ -92,4 +96,4 @@ Validation note:
   a repo-local HTTP sidecar seam
 - run `RUN_SHARED_EMBER_INT=1 EMBER_ORCHESTRATION_V1_SPEC_ROOT=<private-repo-root> pnpm --filter agent-ember-lending test:int -- src/sharedEmberAdapter.int.test.ts`
   to prove the real runtime-owned redelegation typed-data signing path plus the
-  service-owned Onchain Actions prepared unsigned-transaction resolution seam
+  service-owned Onchain Actions anchored-payload resolution seam

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/package.json
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "agent-runtime": "workspace:^",
-    "viem": "catalog:"
+    "viem": "catalog:",
+    "zod": "catalog:"
   },
   "dependenciesMeta": {
     "agent-runtime": {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -15,6 +15,36 @@ const TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX =
 const TEST_TRANSACTION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
 
+function createAnchoredPayloadResolverStub() {
+  return {
+    anchorCandidatePlanPayload: vi.fn(async () => ({
+      anchoredPayloadRef: 'txpayload-ember-lending-001',
+      transactionRequests: [
+        {
+          type: 'EVM_TX' as const,
+          to: '0x00000000000000000000000000000000000000c1',
+          value: '0',
+          data: '0x095ea7b3',
+          chainId: '42161',
+        },
+        {
+          type: 'EVM_TX' as const,
+          to: '0x00000000000000000000000000000000000000d2',
+          value: '0',
+          data: '0x617ba037',
+          chainId: '42161',
+        },
+      ],
+      controlPath: 'lending.supply',
+      network: 'arbitrum',
+      transactionPlanId: 'txplan-ember-lending-001',
+    })),
+    resolvePreparedUnsignedTransaction: vi.fn(
+      async () => TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX,
+    ),
+  };
+}
+
 type AgUiEventEnvelope = {
   type: string;
   [key: string]: unknown;
@@ -293,7 +323,6 @@ function createReadyForExecutionSigningPreparationResult() {
       request_id: 'req-ember-lending-execution-001',
       active_delegation_id: 'del-ember-lending-001',
       canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-001',
-      unsigned_transaction_hex: TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX,
     },
   };
 }
@@ -413,6 +442,7 @@ describe('agent-ember-lending AG-UI integration', () => {
     readAddress: ReturnType<typeof vi.fn>;
     signPayload: ReturnType<typeof vi.fn>;
   };
+  let anchoredPayloadResolver: ReturnType<typeof createAnchoredPayloadResolverStub>;
   const defaultHandleJsonRpc = async (input: unknown) => {
     const request =
       typeof input === 'object' && input !== null
@@ -505,6 +535,11 @@ describe('agent-ember-lending AG-UI integration', () => {
               transaction_plan_id: 'txplan-ember-lending-001',
               handoff: {
                 handoff_id: 'handoff-thread-1',
+                payload_builder_output: {
+                  transaction_payload_ref: 'txpayload-ember-lending-001',
+                  required_control_path: 'lending.supply',
+                  network: 'arbitrum',
+                },
               },
               compact_plan_summary: {
                 control_path: 'lending.supply',
@@ -576,6 +611,7 @@ describe('agent-ember-lending AG-UI integration', () => {
   };
 
   beforeEach(async () => {
+    anchoredPayloadResolver = createAnchoredPayloadResolverStub();
     runtimeSigning = {
       readAddress: vi.fn(async () => '0x00000000000000000000000000000000000000b1'),
       signPayload: vi.fn(async () => ({
@@ -601,6 +637,7 @@ describe('agent-ember-lending AG-UI integration', () => {
         domain: createEmberLendingDomain({
           protocolHost,
           runtimeSigning,
+          anchoredPayloadResolver,
           runtimeSignerRef: 'service-wallet',
           agentId: 'ember-lending',
         }),
@@ -992,6 +1029,24 @@ describe('agent-ember-lending AG-UI integration', () => {
         }),
       }),
     );
+    expect(anchoredPayloadResolver.anchorCandidatePlanPayload).toHaveBeenCalledWith({
+      agentId: 'ember-lending',
+      threadId: 'thread-plan-1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-001',
+        required_control_path: 'lending.supply',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        amount: '10',
+        summary: 'supply reserved USDC on Aave',
+      },
+    });
     expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'subagent.createTransactionPlan.v1',
@@ -1074,6 +1129,41 @@ describe('agent-ember-lending AG-UI integration', () => {
         }),
       }),
     );
+    expect(anchoredPayloadResolver.resolvePreparedUnsignedTransaction).toHaveBeenCalledWith({
+      agentId: 'ember-lending',
+      canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
+      executionPreparationId: 'execprep-ember-lending-001',
+      network: 'arbitrum',
+      plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      requestId: 'req-ember-lending-execution-001',
+      requiredControlPath: 'lending.supply',
+      transactionPlanId: 'txplan-ember-lending-001',
+      anchoredPayloadRecords: [
+        {
+          anchoredPayloadRef: 'txpayload-ember-lending-001',
+          transactionRequests: [
+            {
+              type: 'EVM_TX',
+              to: '0x00000000000000000000000000000000000000c1',
+              value: '0',
+              data: '0x095ea7b3',
+              chainId: '42161',
+            },
+            {
+              type: 'EVM_TX',
+              to: '0x00000000000000000000000000000000000000d2',
+              value: '0',
+              data: '0x617ba037',
+              chainId: '42161',
+            },
+          ],
+          controlPath: 'lending.supply',
+          network: 'arbitrum',
+          transactionPlanId: 'txplan-ember-lending-001',
+        },
+      ],
+    });
   });
 
   it('serves blocked lending execution requests over real AG-UI HTTP endpoints without claiming execution success', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.ts
@@ -9,6 +9,7 @@ import {
 import {
   createEmberLendingAgentConfig,
   type EmberLendingAgentConfig,
+  type EmberLendingGatewayDependencies,
   type EmberLendingGatewayEnv,
   resolveEmberLendingGatewayDependencies,
 } from './emberLendingFoundation.js';
@@ -38,6 +39,9 @@ type EmberLendingGatewayServiceOptions = {
 type EmberLendingGatewayInternalOptions = EmberLendingGatewayServiceOptions & {
   __internalCreateAgentRuntimeKernel?: typeof createAgentRuntimeKernel;
   __internalEnsureServiceIdentity?: typeof ensureEmberLendingServiceIdentity;
+  __internalResolveGatewayDependencies?: (
+    env?: EmberLendingGatewayEnv,
+  ) => EmberLendingGatewayDependencies;
   __internalPostgres?: AgentRuntimeInternalPostgresHooks;
 };
 
@@ -143,6 +147,8 @@ export async function createEmberLendingGatewayService(
 ): Promise<AgentRuntimeService> {
   const createAgentRuntimeKernelImpl =
     options.__internalCreateAgentRuntimeKernel ?? createAgentRuntimeKernel;
+  const resolveGatewayDependencies =
+    options.__internalResolveGatewayDependencies ?? resolveEmberLendingGatewayDependencies;
 
   const kernel = await createAgentRuntimeKernelImpl({
     env: options.env,
@@ -163,7 +169,7 @@ export async function createEmberLendingGatewayService(
         } as never;
       }
 
-      const dependencies = resolveEmberLendingGatewayDependencies(options.env);
+      const dependencies = resolveGatewayDependencies(options.env);
       if (dependencies.protocolHost) {
         const ensuredIdentity = await (
           options.__internalEnsureServiceIdentity ?? ensureEmberLendingServiceIdentity
@@ -183,6 +189,7 @@ export async function createEmberLendingGatewayService(
 
       return {
         ...createEmberLendingAgentConfig(options.env, {
+          dependencies,
           runtimeSigning: signing,
           runtimeSignerRef: EMBER_LENDING_RUNTIME_SIGNER_REF,
         }),

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
@@ -68,6 +68,7 @@ function createManagedLifecycleState() {
     lastReservationSummary: 'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
     lastCandidatePlan: null,
     lastCandidatePlanSummary: null,
+    anchoredPayloadRecords: [],
     lastExecutionResult: null,
     lastExecutionTxHash: null,
     pendingExecutionSubmission: null,
@@ -309,13 +310,22 @@ describe('createEmberLendingGatewayService', () => {
     const anchoredPayloadResolver = {
       anchorCandidatePlanPayload: vi.fn(async () => ({
         anchoredPayloadRef: 'txpayload-ember-lending-001',
-        transactionRequest: {
-          type: 'EVM_TX',
-          to: '0x00000000000000000000000000000000000000c1',
-          value: '0',
-          data: '0x',
-          chainId: '42161',
-        },
+        transactionRequests: [
+          {
+            type: 'EVM_TX',
+            to: '0x00000000000000000000000000000000000000c1',
+            value: '0',
+            data: '0x095ea7b3',
+            chainId: '42161',
+          },
+          {
+            type: 'EVM_TX',
+            to: '0x00000000000000000000000000000000000000d2',
+            value: '0',
+            data: '0x617ba037',
+            chainId: '42161',
+          },
+        ],
         controlPath: 'lending.supply',
         network: 'arbitrum',
         transactionPlanId: 'txplan-ember-lending-001',
@@ -418,6 +428,30 @@ describe('createEmberLendingGatewayService', () => {
       requestId: 'req-ember-lending-execution-001',
       requiredControlPath: 'lending.supply',
       transactionPlanId: 'txplan-ember-lending-001',
+      anchoredPayloadRecords: [
+        {
+          anchoredPayloadRef: 'txpayload-ember-lending-001',
+          transactionRequests: [
+            {
+              type: 'EVM_TX',
+              to: '0x00000000000000000000000000000000000000c1',
+              value: '0',
+              data: '0x095ea7b3',
+              chainId: '42161',
+            },
+            {
+              type: 'EVM_TX',
+              to: '0x00000000000000000000000000000000000000d2',
+              value: '0',
+              data: '0x617ba037',
+              chainId: '42161',
+            },
+          ],
+          controlPath: 'lending.supply',
+          network: 'arbitrum',
+          transactionPlanId: 'txplan-ember-lending-001',
+        },
+      ],
     });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeService } from 'agent-runtime';
+import type { EmberLendingAgentConfig } from './emberLendingFoundation.js';
 
 import { createEmberLendingGatewayService } from './agUiServer.js';
+
+const TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX =
+  '0x02e982a4b1018405f5e100843b9aca008252089400000000000000000000000000000000000000c18080c0';
+const TEST_TRANSACTION_SIGNATURE =
+  '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
 
 function createStubService(): AgentRuntimeService {
   return {
@@ -20,6 +26,136 @@ function createStubService(): AgentRuntimeService {
       inspectMaintenance: async () => ({ recovery: {}, archival: {} }),
     },
     createAgUiHandler: () => async () => new Response(null),
+  };
+}
+
+function createManagedLifecycleState() {
+  return {
+    phase: 'active' as const,
+    mandateRef: 'mandate-ember-lending-001',
+    mandateSummary: 'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+    mandateContext: {
+      network: 'arbitrum',
+      protocol: 'aave',
+      allowedCollateralAssets: ['USDC'],
+      allowedBorrowAssets: ['USDC'],
+      maxAllocationPct: 35,
+      maxLtvBps: 7000,
+      minHealthFactor: '1.25',
+    },
+    walletAddress: '0x00000000000000000000000000000000000000b1' as const,
+    rootUserWalletAddress: '0x00000000000000000000000000000000000000a1' as const,
+    rootedWalletContextId: 'rwc-ember-lending-thread-001',
+    lastPortfolioState: {
+      agent_id: 'ember-lending',
+      owned_units: [
+        {
+          unit_id: 'unit-ember-lending-001',
+          root_asset: 'USDC',
+          quantity: '10',
+          reservation_id: 'reservation-ember-lending-001',
+        },
+      ],
+      reservations: [
+        {
+          reservation_id: 'reservation-ember-lending-001',
+          purpose: 'deploy',
+          control_path: 'lending.supply',
+        },
+      ],
+    },
+    lastSharedEmberRevision: 7,
+    lastReservationSummary: 'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
+    lastCandidatePlan: null,
+    lastCandidatePlanSummary: null,
+    lastExecutionResult: null,
+    lastExecutionTxHash: null,
+    pendingExecutionSubmission: null,
+    lastEscalationRequest: null,
+    lastEscalationSummary: null,
+  };
+}
+
+function createCandidatePlanInput() {
+  return {
+    idempotencyKey: 'idem-candidate-plan-001',
+    intent: 'deploy',
+    action_summary: 'supply reserved USDC on Aave',
+    candidate_unit_ids: ['unit-ember-lending-001'],
+    requested_quantities: [
+      {
+        unit_id: 'unit-ember-lending-001',
+        quantity: '10',
+      },
+    ],
+    decision_context: {
+      objective_summary: 'deploy reserved capital into the approved lending lane',
+      accounting_state_summary: 'one reserved USDC unit is available for the lending agent',
+      why_this_path_is_best: 'lending.supply is the admitted path for this reservation',
+      consequence_if_delayed: 'reserved capital remains idle',
+      alternatives_considered: ['leave the unit idle'],
+    },
+    payload_builder_output: {
+      transaction_payload_ref: 'tx-lending-supply-001',
+      required_control_path: 'lending.supply',
+      network: 'arbitrum',
+    },
+  };
+}
+
+function createReadyForExecutionSigningPreparationResult() {
+  return {
+    phase: 'ready_for_execution_signing',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution_preparation: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      network: 'arbitrum',
+      reservation_id: 'reservation-ember-lending-001',
+      required_control_path: 'lending.supply',
+      canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-001',
+      active_delegation_id: 'del-ember-lending-001',
+      root_delegation_id: 'root-user-ember-lending-001',
+      prepared_at: '2026-04-01T06:15:00.000Z',
+      metadata: {
+        planned_transaction_payload_ref: 'txpayload-ember-lending-001',
+      },
+    },
+    execution_signing_package: {
+      execution_preparation_id: 'execprep-ember-lending-001',
+      transaction_plan_id: 'txplan-ember-lending-001',
+      request_id: 'req-ember-lending-execution-001',
+      active_delegation_id: 'del-ember-lending-001',
+      canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-001',
+    },
+  };
+}
+
+function createTerminalExecutionResult() {
+  return {
+    phase: 'completed',
+    transaction_plan_id: 'txplan-ember-lending-001',
+    request_id: 'req-ember-lending-execution-001',
+    execution: {
+      execution_id: 'exec-ember-lending-001',
+      status: 'confirmed' as const,
+      transaction_hash:
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' as const,
+      successor_unit_ids: ['unit-ember-lending-successor-001'],
+    },
+    portfolio_state: {
+      agent_id: 'ember-lending',
+      agent_wallet: '0x00000000000000000000000000000000000000b1',
+      root_user_wallet: '0x00000000000000000000000000000000000000a1',
+      mandate_ref: 'mandate-ember-lending-001',
+      reservations: [],
+      owned_units: [],
+    },
   };
 }
 
@@ -104,5 +240,177 @@ describe('createEmberLendingGatewayService', () => {
     );
 
     expect(createAgentRuntimeKernel).toHaveBeenCalledOnce();
+  });
+
+  it('wires the live gateway dependency resolver into candidate-plan anchoring and prepared execution resolution', async () => {
+    const service = createStubService();
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-create-transaction-plan',
+          result: {
+            protocol_version: 'v1',
+            revision: 8,
+            committed_event_ids: ['evt-candidate-plan-1'],
+            candidate_plan: {
+              planning_kind: 'subagent_handoff',
+              transaction_plan_id: 'txplan-ember-lending-001',
+              handoff: {
+                handoff_id: 'handoff-thread-1',
+                payload_builder_output: {
+                  transaction_payload_ref: 'txpayload-ember-lending-001',
+                  required_control_path: 'lending.supply',
+                  network: 'arbitrum',
+                },
+              },
+              compact_plan_summary: {
+                control_path: 'lending.supply',
+                asset: 'USDC',
+                amount: '10',
+                summary: 'supply reserved USDC on Aave',
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-submit-execution-1'],
+            execution_result: createTerminalExecutionResult(),
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const anchoredPayloadResolver = {
+      anchorCandidatePlanPayload: vi.fn(async () => ({
+        anchoredPayloadRef: 'txpayload-ember-lending-001',
+        unsignedTransactionHex: TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX,
+        controlPath: 'lending.supply',
+        network: 'arbitrum',
+        transactionPlanId: 'txplan-ember-lending-001',
+      })),
+      resolvePreparedUnsignedTransaction: vi.fn(
+        async () => TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX,
+      ),
+    };
+    const resolveGatewayDependencies = vi.fn(() => ({
+      protocolHost,
+      anchoredPayloadResolver,
+    }));
+    const ensureServiceIdentity = vi.fn(async () => ({
+      revision: 2,
+      wroteIdentity: false,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000b1',
+      },
+    }));
+    let runtimeConfig: EmberLendingAgentConfig | null = null;
+    const createAgentRuntimeKernel = vi.fn(async ({ createRuntimeOptions }) => {
+      const signing = {
+        readAddress: vi.fn(async () => '0x00000000000000000000000000000000000000b1' as const),
+        signPayload: vi.fn(async () => ({
+          confirmedAddress: '0x00000000000000000000000000000000000000b1' as const,
+          signedPayload: {
+            signature: TEST_TRANSACTION_SIGNATURE,
+            recoveryId: 1,
+          },
+        })),
+      };
+      runtimeConfig = await createRuntimeOptions({
+        signing,
+      });
+
+      return {
+        service,
+        signing,
+      };
+    });
+
+    await expect(
+      createEmberLendingGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+        },
+        __internalResolveGatewayDependencies: resolveGatewayDependencies,
+        __internalEnsureServiceIdentity: ensureServiceIdentity,
+        __internalCreateAgentRuntimeKernel: createAgentRuntimeKernel,
+      } as never),
+    ).resolves.toBe(service);
+
+    expect(runtimeConfig).not.toBeNull();
+    const candidatePlanResult = await runtimeConfig!.domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    await runtimeConfig!.domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: candidatePlanResult?.state ?? createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(resolveGatewayDependencies).toHaveBeenCalled();
+    expect(ensureServiceIdentity).toHaveBeenCalledOnce();
+    expect(anchoredPayloadResolver.anchorCandidatePlanPayload).toHaveBeenCalledWith({
+      agentId: 'ember-lending',
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-001',
+        required_control_path: 'lending.supply',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        amount: '10',
+        summary: 'supply reserved USDC on Aave',
+      },
+    });
+    expect(anchoredPayloadResolver.resolvePreparedUnsignedTransaction).toHaveBeenCalledWith({
+      agentId: 'ember-lending',
+      canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
+      executionPreparationId: 'execprep-ember-lending-001',
+      network: 'arbitrum',
+      plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
+      requiredControlPath: 'lending.supply',
+      transactionPlanId: 'txplan-ember-lending-001',
+    });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.unit.test.ts
@@ -309,7 +309,13 @@ describe('createEmberLendingGatewayService', () => {
     const anchoredPayloadResolver = {
       anchorCandidatePlanPayload: vi.fn(async () => ({
         anchoredPayloadRef: 'txpayload-ember-lending-001',
-        unsignedTransactionHex: TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX,
+        transactionRequest: {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000c1',
+          value: '0',
+          data: '0x',
+          chainId: '42161',
+        },
         controlPath: 'lending.supply',
         network: 'arbitrum',
         transactionPlanId: 'txplan-ember-lending-001',
@@ -408,6 +414,7 @@ describe('createEmberLendingGatewayService', () => {
       executionPreparationId: 'execprep-ember-lending-001',
       network: 'arbitrum',
       plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
       requestId: 'req-ember-lending-execution-001',
       requiredControlPath: 'lending.supply',
       transactionPlanId: 'txplan-ember-lending-001',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
@@ -7,7 +7,6 @@ import {
   createEmberLendingDomain,
   type EmberLendingAnchoredPayloadResolver,
   type EmberLendingLifecycleState,
-  type EmberLendingPreparedUnsignedTransactionResolver,
 } from './sharedEmberAdapter.js';
 import {
   createEmberLendingOnchainActionsAnchoredPayloadResolver,
@@ -29,6 +28,9 @@ export type EmberLendingGatewayEnv = NodeJS.ProcessEnv & {
   DATABASE_URL?: string;
   SHARED_EMBER_BASE_URL?: string;
   ONCHAIN_ACTIONS_API_URL?: string;
+  ARBITRUM_RPC_URL?: string;
+  BASE_CHAIN_RPC_URL?: string;
+  ETHEREUM_RPC_URL?: string;
   EMBER_LENDING_OWS_WALLET_NAME?: string;
   EMBER_LENDING_OWS_PASSPHRASE?: string;
   EMBER_LENDING_OWS_VAULT_PATH?: string;
@@ -50,7 +52,6 @@ export type EmberLendingGatewayDependencies = {
 
 type CreateEmberLendingAgentConfigOptions = {
   runtimeSigning?: AgentRuntimeSigningService;
-  resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
   dependencies?: EmberLendingGatewayDependencies;
   runtimeSignerRef?: string;
 };
@@ -104,7 +105,6 @@ export function createEmberLendingAgentConfig(
     domain: createEmberLendingDomain({
       protocolHost,
       runtimeSigning: options.runtimeSigning,
-      resolvePreparedUnsignedTransaction: options.resolvePreparedUnsignedTransaction,
       anchoredPayloadResolver,
       runtimeSignerRef: options.runtimeSignerRef,
     }),
@@ -131,6 +131,7 @@ export function resolveEmberLendingGatewayDependencies(
       : undefined,
     anchoredPayloadResolver: createEmberLendingOnchainActionsAnchoredPayloadResolver({
       baseUrl: onchainActionsApiUrl,
+      env,
     }),
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
@@ -5,9 +5,14 @@ import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 
 import {
   createEmberLendingDomain,
+  type EmberLendingAnchoredPayloadResolver,
   type EmberLendingLifecycleState,
   type EmberLendingPreparedUnsignedTransactionResolver,
 } from './sharedEmberAdapter.js';
+import {
+  createEmberLendingOnchainActionsAnchoredPayloadResolver,
+  resolveEmberLendingOnchainActionsApiUrl,
+} from './onchainActionsPayloadResolver.js';
 import {
   createEmberLendingSharedEmberHttpHost,
   resolveEmberLendingSharedEmberBaseUrl,
@@ -23,6 +28,7 @@ export type EmberLendingGatewayEnv = NodeJS.ProcessEnv & {
   EMBER_LENDING_MODEL?: string;
   DATABASE_URL?: string;
   SHARED_EMBER_BASE_URL?: string;
+  ONCHAIN_ACTIONS_API_URL?: string;
   EMBER_LENDING_OWS_WALLET_NAME?: string;
   EMBER_LENDING_OWS_PASSPHRASE?: string;
   EMBER_LENDING_OWS_VAULT_PATH?: string;
@@ -39,11 +45,13 @@ type EmberLendingGatewayModel = EmberLendingAgentConfig['model'];
 
 export type EmberLendingGatewayDependencies = {
   protocolHost: ReturnType<typeof createEmberLendingSharedEmberHttpHost> | undefined;
+  anchoredPayloadResolver: EmberLendingAnchoredPayloadResolver;
 };
 
 type CreateEmberLendingAgentConfigOptions = {
   runtimeSigning?: AgentRuntimeSigningService;
   resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
+  dependencies?: EmberLendingGatewayDependencies;
   runtimeSignerRef?: string;
 };
 
@@ -85,7 +93,8 @@ export function createEmberLendingAgentConfig(
 ): EmberLendingAgentConfig {
   const apiKey = requireEnvValue(env.OPENROUTER_API_KEY, 'OPENROUTER_API_KEY');
   const modelId = env.EMBER_LENDING_MODEL?.trim() || DEFAULT_EMBER_LENDING_MODEL;
-  const { protocolHost } = resolveEmberLendingGatewayDependencies(env);
+  const { protocolHost, anchoredPayloadResolver } =
+    options.dependencies ?? resolveEmberLendingGatewayDependencies(env);
 
   return {
     model: createOpenRouterModel(modelId),
@@ -96,6 +105,7 @@ export function createEmberLendingAgentConfig(
       protocolHost,
       runtimeSigning: options.runtimeSigning,
       resolvePreparedUnsignedTransaction: options.resolvePreparedUnsignedTransaction,
+      anchoredPayloadResolver,
       runtimeSignerRef: options.runtimeSignerRef,
     }),
     agentOptions: {
@@ -111,6 +121,7 @@ export function resolveEmberLendingGatewayDependencies(
   env: EmberLendingGatewayEnv = process.env,
 ): EmberLendingGatewayDependencies {
   const sharedEmberBaseUrl = resolveEmberLendingSharedEmberBaseUrl(env);
+  const onchainActionsApiUrl = resolveEmberLendingOnchainActionsApiUrl(env);
 
   return {
     protocolHost: sharedEmberBaseUrl
@@ -118,5 +129,8 @@ export function resolveEmberLendingGatewayDependencies(
           baseUrl: sharedEmberBaseUrl,
         })
       : undefined,
+    anchoredPayloadResolver: createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: onchainActionsApiUrl,
+    }),
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
@@ -1,10 +1,13 @@
-import { serializeTransaction } from 'viem';
+import { createPublicClient, http, serializeTransaction } from 'viem';
+import { arbitrum, base, mainnet } from 'viem/chains';
 import { z } from 'zod';
 
 const DEFAULT_ONCHAIN_ACTIONS_API_URL = 'https://api.emberai.xyz';
-const DEFAULT_GAS_LIMIT = 210_000n;
-const DEFAULT_MAX_PRIORITY_FEE_PER_GAS = 1n;
-const DEFAULT_MAX_FEE_PER_GAS = 2n;
+const DEFAULT_ARBITRUM_RPC_URL = 'https://arb1.arbitrum.io/rpc';
+const DEFAULT_BASE_RPC_URL = 'https://mainnet.base.org';
+const DEFAULT_ETHEREUM_RPC_URL = 'https://eth.merkle.io';
+const RPC_RETRY_COUNT = 2;
+const RPC_TIMEOUT_MS = 8_000;
 
 const HexStringSchema = z.string().regex(/^0x[0-9a-fA-F]+$/u);
 const AddressSchema = z.string().regex(/^0x[0-9a-fA-F]{40}$/u);
@@ -56,6 +59,7 @@ export type EmberLendingPreparedUnsignedTransactionResolutionInput = {
   requestId: string;
   canonicalUnsignedPayloadRef: string;
   plannedTransactionPayloadRef: string | null;
+  walletAddress: `0x${string}`;
   network: string | null;
   requiredControlPath: string | null;
 };
@@ -80,7 +84,7 @@ export type EmberLendingCompactPlanSummary = {
 
 export type EmberLendingAnchoredPayloadRecord = {
   anchoredPayloadRef: string;
-  unsignedTransactionHex: `0x${string}`;
+  transactionRequest: z.infer<typeof OnchainActionsTransactionPlanSchema>;
   controlPath: string;
   network: string;
   transactionPlanId: string;
@@ -105,12 +109,51 @@ export type EmberLendingAnchoredPayloadResolver = {
 
 type OnchainActionsApiEnv = NodeJS.ProcessEnv & {
   ONCHAIN_ACTIONS_API_URL?: string;
+  ARBITRUM_RPC_URL?: string;
+  BASE_CHAIN_RPC_URL?: string;
+  ETHEREUM_RPC_URL?: string;
 };
 
 type LendingOperation = 'supply' | 'withdraw' | 'borrow' | 'repay';
+type SupportedExecutionNetwork = 'arbitrum' | 'base' | 'mainnet';
+type EmberLendingExecutionPublicClient = {
+  getTransactionCount: (input: {
+    address: `0x${string}`;
+    blockTag?: 'pending';
+  }) => Promise<number>;
+  estimateFeesPerGas: () => Promise<{
+    gasPrice?: bigint;
+    maxFeePerGas?: bigint;
+    maxPriorityFeePerGas?: bigint;
+  }>;
+  estimateGas: (input: {
+    account: `0x${string}`;
+    to: `0x${string}`;
+    value: bigint;
+    data: `0x${string}`;
+  }) => Promise<bigint>;
+};
+type ResolveExecutionPublicClient = (
+  network: SupportedExecutionNetwork,
+) => EmberLendingExecutionPublicClient;
 
 function trimTrailingSlash(value: string): string {
   return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function createRpcTransport(url: string): ReturnType<typeof http> {
+  const baseTransport = http(url);
+  const baseTransportValue: unknown = baseTransport;
+  if (typeof baseTransportValue !== 'function') {
+    return baseTransport;
+  }
+
+  return ((params: Parameters<typeof baseTransport>[0]) =>
+    baseTransport({
+      ...params,
+      retryCount: RPC_RETRY_COUNT,
+      timeout: RPC_TIMEOUT_MS,
+    })) as ReturnType<typeof http>;
 }
 
 export function resolveEmberLendingOnchainActionsApiUrl(
@@ -137,6 +180,55 @@ function resolveChainId(network: string): string {
     default:
       throw new Error(`Unsupported lending execution network "${network}".`);
   }
+}
+
+function resolveSupportedExecutionNetwork(network: string): SupportedExecutionNetwork {
+  switch (network.trim().toLowerCase()) {
+    case 'arbitrum':
+      return 'arbitrum';
+    case 'base':
+      return 'base';
+    case 'ethereum':
+    case 'mainnet':
+      return 'mainnet';
+    default:
+      throw new Error(`Unsupported lending execution network "${network}".`);
+  }
+}
+
+function resolveRpcUrl(
+  network: SupportedExecutionNetwork,
+  env: OnchainActionsApiEnv,
+): string {
+  switch (network) {
+    case 'arbitrum':
+      return env.ARBITRUM_RPC_URL?.trim() || DEFAULT_ARBITRUM_RPC_URL;
+    case 'base':
+      return env.BASE_CHAIN_RPC_URL?.trim() || DEFAULT_BASE_RPC_URL;
+    case 'mainnet':
+      return env.ETHEREUM_RPC_URL?.trim() || DEFAULT_ETHEREUM_RPC_URL;
+  }
+}
+
+function createDefaultExecutionPublicClientResolver(
+  env: OnchainActionsApiEnv,
+): ResolveExecutionPublicClient {
+  const clients = new Map<SupportedExecutionNetwork, EmberLendingExecutionPublicClient>();
+
+  return (network) => {
+    const existingClient = clients.get(network);
+    if (existingClient) {
+      return existingClient;
+    }
+
+    const client = createPublicClient({
+      chain:
+        network === 'arbitrum' ? arbitrum : network === 'base' ? base : mainnet,
+      transport: createRpcTransport(resolveRpcUrl(network, env)),
+    }) as EmberLendingExecutionPublicClient;
+    clients.set(network, client);
+    return client;
+  };
 }
 
 function resolveLendingOperation(controlPath: string): LendingOperation {
@@ -184,36 +276,49 @@ async function resolveTokenIdentifier(input: {
   asset: string;
 }): Promise<z.infer<typeof TokenIdentifierSchema>> {
   const chainId = resolveChainId(input.network);
-  const response = await fetchJson({
-    fetchImpl: input.fetchImpl,
-    url: `${input.baseUrl}/tokens?${new URLSearchParams({
-      chainIds: chainId,
-    }).toString()}`,
-    schema: TokensResponseSchema,
-  });
   const normalizedAsset = input.asset.trim().toLowerCase();
-  const match =
-    response.tokens.find(
-      (token) =>
-        token.symbol.trim().toLowerCase() === normalizedAsset && token.isVetted,
-    ) ??
-    response.tokens.find(
-      (token) => token.symbol.trim().toLowerCase() === normalizedAsset,
-    ) ??
-    response.tokens.find(
-      (token) => token.name.trim().toLowerCase() === normalizedAsset && token.isVetted,
-    ) ??
-    response.tokens.find(
-      (token) => token.name.trim().toLowerCase() === normalizedAsset,
-    );
+  let page = 1;
 
-  if (!match) {
-    throw new Error(
-      `Onchain Actions did not return a token for ${input.asset} on ${input.network}.`,
-    );
+  while (true) {
+    const response = await fetchJson({
+      fetchImpl: input.fetchImpl,
+      url: `${input.baseUrl}/tokens?${new URLSearchParams({
+        chainIds: chainId,
+        page: String(page),
+      }).toString()}`,
+      schema: TokensResponseSchema,
+    });
+    const match =
+      response.tokens.find(
+        (token) =>
+          token.symbol.trim().toLowerCase() === normalizedAsset && token.isVetted,
+      ) ??
+      response.tokens.find(
+        (token) => token.symbol.trim().toLowerCase() === normalizedAsset,
+      ) ??
+      response.tokens.find(
+        (token) => token.name.trim().toLowerCase() === normalizedAsset && token.isVetted,
+      ) ??
+      response.tokens.find(
+        (token) => token.name.trim().toLowerCase() === normalizedAsset,
+      );
+
+    if (match) {
+      return match.tokenUid;
+    }
+
+    const currentPage = response.currentPage ?? page;
+    const totalPages = response.totalPages ?? currentPage;
+    if (currentPage >= totalPages) {
+      break;
+    }
+
+    page = currentPage + 1;
   }
 
-  return match.tokenUid;
+  throw new Error(
+    `Onchain Actions did not return a token for ${input.asset} on ${input.network}.`,
+  );
 }
 
 function buildLendingRequestBody(input: {
@@ -250,25 +355,63 @@ function buildLendingRequestBody(input: {
   }
 }
 
-function serializePreparedUnsignedTransaction(
-  transaction: z.infer<typeof OnchainActionsTransactionPlanSchema>,
-): `0x${string}` {
-  const chainId = Number(transaction.chainId);
+async function resolvePreparedUnsignedTransactionHex(input: {
+  publicClient: EmberLendingExecutionPublicClient;
+  transaction: z.infer<typeof OnchainActionsTransactionPlanSchema>;
+  walletAddress: `0x${string}`;
+}): Promise<`0x${string}`> {
+  const chainId = Number(input.transaction.chainId);
   if (!Number.isFinite(chainId) || chainId <= 0) {
-    throw new Error(`Invalid transaction chain id "${transaction.chainId}".`);
+    throw new Error(`Invalid transaction chain id "${input.transaction.chainId}".`);
   }
 
-  return serializeTransaction({
-    chainId,
-    type: 'eip1559',
-    nonce: 0,
-    gas: DEFAULT_GAS_LIMIT,
-    maxPriorityFeePerGas: DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
-    maxFeePerGas: DEFAULT_MAX_FEE_PER_GAS,
-    to: transaction.to.toLowerCase() as `0x${string}`,
-    value: BigInt(transaction.value),
-    data: transaction.data.toLowerCase() as `0x${string}`,
-  });
+  const to = input.transaction.to.toLowerCase() as `0x${string}`;
+  const value = BigInt(input.transaction.value);
+  const data = input.transaction.data.toLowerCase() as `0x${string}`;
+  const [nonce, feeEstimate, gas] = await Promise.all([
+    input.publicClient.getTransactionCount({
+      address: input.walletAddress,
+      blockTag: 'pending',
+    }),
+    input.publicClient.estimateFeesPerGas(),
+    input.publicClient.estimateGas({
+      account: input.walletAddress,
+      to,
+      value,
+      data,
+    }),
+  ]);
+
+  if (
+    typeof feeEstimate.maxFeePerGas === 'bigint' &&
+    typeof feeEstimate.maxPriorityFeePerGas === 'bigint'
+  ) {
+    return serializeTransaction({
+      chainId,
+      type: 'eip1559',
+      nonce,
+      gas,
+      maxFeePerGas: feeEstimate.maxFeePerGas,
+      maxPriorityFeePerGas: feeEstimate.maxPriorityFeePerGas,
+      to,
+      value,
+      data,
+    });
+  }
+
+  if (typeof feeEstimate.gasPrice === 'bigint') {
+    return serializeTransaction({
+      chainId,
+      nonce,
+      gas,
+      gasPrice: feeEstimate.gasPrice,
+      to,
+      value,
+      data,
+    });
+  }
+
+  throw new Error('RPC fee estimation did not return a signable gas price or EIP-1559 fee pair.');
 }
 
 function resolveAnchoredPayloadRef(input: {
@@ -287,11 +430,16 @@ function resolveAnchoredPayloadRef(input: {
 export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: {
   baseUrl?: string;
   fetch?: typeof fetch;
+  env?: OnchainActionsApiEnv;
+  resolvePublicClient?: ResolveExecutionPublicClient;
 }): EmberLendingAnchoredPayloadResolver {
   const fetchImpl = input?.fetch ?? fetch;
+  const env = input?.env ?? process.env;
   const baseUrl = trimTrailingSlash(
-    input?.baseUrl ?? resolveEmberLendingOnchainActionsApiUrl(),
+    input?.baseUrl ?? resolveEmberLendingOnchainActionsApiUrl(env),
   );
+  const resolvePublicClient =
+    input?.resolvePublicClient ?? createDefaultExecutionPublicClientResolver(env);
   const anchoredPayloads = new Map<string, EmberLendingAnchoredPayloadRecord>();
 
   return {
@@ -329,7 +477,7 @@ export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: 
 
       const anchoredPayload: EmberLendingAnchoredPayloadRecord = {
         anchoredPayloadRef: request.payloadBuilderOutput.transaction_payload_ref,
-        unsignedTransactionHex: serializePreparedUnsignedTransaction(terminalTransaction),
+        transactionRequest: terminalTransaction,
         controlPath: request.payloadBuilderOutput.required_control_path,
         network: request.payloadBuilderOutput.network,
         transactionPlanId: request.transactionPlanId,
@@ -344,8 +492,18 @@ export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: 
         plannedTransactionPayloadRef: request.plannedTransactionPayloadRef,
         canonicalUnsignedPayloadRef: request.canonicalUnsignedPayloadRef,
       });
+      const anchoredPayload = anchoredPayloads.get(anchoredPayloadRef);
+      if (!anchoredPayload) {
+        return null;
+      }
 
-      return anchoredPayloads.get(anchoredPayloadRef)?.unsignedTransactionHex ?? null;
+      return resolvePreparedUnsignedTransactionHex({
+        publicClient: resolvePublicClient(
+          resolveSupportedExecutionNetwork(anchoredPayload.network),
+        ),
+        transaction: anchoredPayload.transactionRequest,
+        walletAddress: request.walletAddress,
+      });
     },
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
@@ -62,6 +62,7 @@ export type EmberLendingPreparedUnsignedTransactionResolutionInput = {
   walletAddress: `0x${string}`;
   network: string | null;
   requiredControlPath: string | null;
+  anchoredPayloadRecords?: EmberLendingAnchoredPayloadRecord[] | null;
 };
 
 export type EmberLendingPreparedUnsignedTransactionResolver = (
@@ -82,9 +83,13 @@ export type EmberLendingCompactPlanSummary = {
   protocol_summary?: string;
 };
 
+export type EmberLendingAnchoredTransactionRequest = z.infer<
+  typeof OnchainActionsTransactionPlanSchema
+>;
+
 export type EmberLendingAnchoredPayloadRecord = {
   anchoredPayloadRef: string;
-  transactionRequest: z.infer<typeof OnchainActionsTransactionPlanSchema>;
+  transactionRequests: EmberLendingAnchoredTransactionRequest[];
   controlPath: string;
   network: string;
   transactionPlanId: string;
@@ -427,6 +432,97 @@ function resolveAnchoredPayloadRef(input: {
     : input.canonicalUnsignedPayloadRef;
 }
 
+function readExplicitTransactionIndex(input: {
+  anchoredPayloadRef: string;
+  plannedTransactionPayloadRef: string | null;
+  canonicalUnsignedPayloadRef: string;
+}): number | null {
+  const candidates = [
+    input.plannedTransactionPayloadRef,
+    input.canonicalUnsignedPayloadRef.startsWith('unsigned-')
+      ? input.canonicalUnsignedPayloadRef.slice('unsigned-'.length)
+      : input.canonicalUnsignedPayloadRef,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate || candidate === input.anchoredPayloadRef) {
+      continue;
+    }
+    if (!candidate.startsWith(input.anchoredPayloadRef)) {
+      continue;
+    }
+
+    const suffix = candidate.slice(input.anchoredPayloadRef.length);
+    const stepMatch =
+      suffix.match(/^[:#/_-](\d+)$/u) ??
+      suffix.match(/^[:#/_-](?:step|tx|transaction)[-_:]?(\d+)$/iu) ??
+      suffix.match(/^(?:step|tx|transaction)[-_:]?(\d+)$/iu);
+    if (!stepMatch) {
+      continue;
+    }
+
+    const parsed = Number.parseInt(stepMatch[1] ?? '', 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function resolveAnchoredPayloadRecord(input: {
+  anchoredPayloadRecords?: EmberLendingAnchoredPayloadRecord[] | null;
+  anchoredPayloads: Map<string, EmberLendingAnchoredPayloadRecord>;
+  anchoredPayloadRef: string;
+}): EmberLendingAnchoredPayloadRecord | null {
+  const allRecords = [
+    ...(input.anchoredPayloadRecords ?? []),
+    ...input.anchoredPayloads.values(),
+  ];
+  const exactRecord =
+    allRecords.find((record) => record.anchoredPayloadRef === input.anchoredPayloadRef) ?? null;
+  if (exactRecord) {
+    return exactRecord;
+  }
+
+  let matchedRecord: EmberLendingAnchoredPayloadRecord | null = null;
+  for (const record of allRecords) {
+    if (!input.anchoredPayloadRef.startsWith(record.anchoredPayloadRef)) {
+      continue;
+    }
+    if (
+      matchedRecord === null ||
+      record.anchoredPayloadRef.length > matchedRecord.anchoredPayloadRef.length
+    ) {
+      matchedRecord = record;
+    }
+  }
+
+  return matchedRecord;
+}
+
+function resolveAnchoredTransactionRequest(input: {
+  anchoredPayload: EmberLendingAnchoredPayloadRecord;
+  plannedTransactionPayloadRef: string | null;
+  canonicalUnsignedPayloadRef: string;
+}): EmberLendingAnchoredTransactionRequest {
+  const transactionIndex =
+    readExplicitTransactionIndex({
+      anchoredPayloadRef: input.anchoredPayload.anchoredPayloadRef,
+      plannedTransactionPayloadRef: input.plannedTransactionPayloadRef,
+      canonicalUnsignedPayloadRef: input.canonicalUnsignedPayloadRef,
+    }) ?? 0;
+  const transaction = input.anchoredPayload.transactionRequests[transactionIndex];
+
+  if (!transaction) {
+    throw new Error(
+      `Anchored payload ref "${input.anchoredPayload.anchoredPayloadRef}" does not contain transaction step ${transactionIndex}.`,
+    );
+  }
+
+  return transaction;
+}
+
 export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: {
   baseUrl?: string;
   fetch?: typeof fetch;
@@ -470,14 +566,10 @@ export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: 
           ),
         },
       });
-      const terminalTransaction = response.transactions.at(-1);
-      if (!terminalTransaction) {
-        throw new Error('Onchain Actions did not return a terminal lending transaction.');
-      }
 
       const anchoredPayload: EmberLendingAnchoredPayloadRecord = {
         anchoredPayloadRef: request.payloadBuilderOutput.transaction_payload_ref,
-        transactionRequest: terminalTransaction,
+        transactionRequests: response.transactions,
         controlPath: request.payloadBuilderOutput.required_control_path,
         network: request.payloadBuilderOutput.network,
         transactionPlanId: request.transactionPlanId,
@@ -492,7 +584,11 @@ export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: 
         plannedTransactionPayloadRef: request.plannedTransactionPayloadRef,
         canonicalUnsignedPayloadRef: request.canonicalUnsignedPayloadRef,
       });
-      const anchoredPayload = anchoredPayloads.get(anchoredPayloadRef);
+      const anchoredPayload = resolveAnchoredPayloadRecord({
+        anchoredPayloadRecords: request.anchoredPayloadRecords,
+        anchoredPayloads,
+        anchoredPayloadRef,
+      });
       if (!anchoredPayload) {
         return null;
       }
@@ -501,7 +597,11 @@ export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: 
         publicClient: resolvePublicClient(
           resolveSupportedExecutionNetwork(anchoredPayload.network),
         ),
-        transaction: anchoredPayload.transactionRequest,
+        transaction: resolveAnchoredTransactionRequest({
+          anchoredPayload,
+          plannedTransactionPayloadRef: request.plannedTransactionPayloadRef,
+          canonicalUnsignedPayloadRef: request.canonicalUnsignedPayloadRef,
+        }),
         walletAddress: request.walletAddress,
       });
     },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
@@ -1,0 +1,351 @@
+import { serializeTransaction } from 'viem';
+import { z } from 'zod';
+
+const DEFAULT_ONCHAIN_ACTIONS_API_URL = 'https://api.emberai.xyz';
+const DEFAULT_GAS_LIMIT = 210_000n;
+const DEFAULT_MAX_PRIORITY_FEE_PER_GAS = 1n;
+const DEFAULT_MAX_FEE_PER_GAS = 2n;
+
+const HexStringSchema = z.string().regex(/^0x[0-9a-fA-F]+$/u);
+const AddressSchema = z.string().regex(/^0x[0-9a-fA-F]{40}$/u);
+const TokenIdentifierSchema = z
+  .object({
+    chainId: z.string().min(1),
+    address: AddressSchema,
+  })
+  .strict();
+const TokenSchema = z
+  .object({
+    tokenUid: TokenIdentifierSchema,
+    name: z.string().min(1),
+    symbol: z.string().min(1),
+    isNative: z.boolean(),
+    decimals: z.number().int().nonnegative(),
+    iconUri: z.string().nullable().optional(),
+    isVetted: z.boolean(),
+  })
+  .strict();
+const TokensResponseSchema = z
+  .object({
+    tokens: z.array(TokenSchema),
+    cursor: z.string().nullable().optional(),
+    currentPage: z.number().int().optional(),
+    totalPages: z.number().int().optional(),
+    totalItems: z.number().int().optional(),
+  })
+  .strict();
+const OnchainActionsTransactionPlanSchema = z
+  .object({
+    type: z.literal('EVM_TX'),
+    to: AddressSchema,
+    value: z.string().optional().default('0'),
+    data: HexStringSchema,
+    chainId: z.string().min(1),
+  })
+  .strict();
+const OnchainActionsPlanResponseSchema = z
+  .object({
+    transactions: z.array(OnchainActionsTransactionPlanSchema).min(1),
+  })
+  .strict();
+
+export type EmberLendingPreparedUnsignedTransactionResolutionInput = {
+  agentId: string;
+  executionPreparationId: string;
+  transactionPlanId: string;
+  requestId: string;
+  canonicalUnsignedPayloadRef: string;
+  plannedTransactionPayloadRef: string | null;
+  network: string | null;
+  requiredControlPath: string | null;
+};
+
+export type EmberLendingPreparedUnsignedTransactionResolver = (
+  input: EmberLendingPreparedUnsignedTransactionResolutionInput,
+) => Promise<`0x${string}` | null>;
+
+export type EmberLendingPayloadBuilderOutput = {
+  transaction_payload_ref: string;
+  required_control_path: string;
+  network: string;
+};
+
+export type EmberLendingCompactPlanSummary = {
+  control_path: string;
+  asset: string;
+  amount: string;
+  summary: string;
+  protocol_summary?: string;
+};
+
+export type EmberLendingAnchoredPayloadRecord = {
+  anchoredPayloadRef: string;
+  unsignedTransactionHex: `0x${string}`;
+  controlPath: string;
+  network: string;
+  transactionPlanId: string;
+};
+
+export type EmberLendingCandidatePlanPayloadAnchorInput = {
+  agentId: string;
+  threadId: string;
+  transactionPlanId: string;
+  walletAddress: `0x${string}`;
+  rootUserWalletAddress: `0x${string}`;
+  payloadBuilderOutput: EmberLendingPayloadBuilderOutput;
+  compactPlanSummary: EmberLendingCompactPlanSummary;
+};
+
+export type EmberLendingAnchoredPayloadResolver = {
+  anchorCandidatePlanPayload: (
+    input: EmberLendingCandidatePlanPayloadAnchorInput,
+  ) => Promise<EmberLendingAnchoredPayloadRecord | null>;
+  resolvePreparedUnsignedTransaction: EmberLendingPreparedUnsignedTransactionResolver;
+};
+
+type OnchainActionsApiEnv = NodeJS.ProcessEnv & {
+  ONCHAIN_ACTIONS_API_URL?: string;
+};
+
+type LendingOperation = 'supply' | 'withdraw' | 'borrow' | 'repay';
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export function resolveEmberLendingOnchainActionsApiUrl(
+  env: OnchainActionsApiEnv = process.env,
+): string {
+  const endpoint = trimTrailingSlash(
+    env.ONCHAIN_ACTIONS_API_URL?.trim() || DEFAULT_ONCHAIN_ACTIONS_API_URL,
+  );
+
+  return endpoint.endsWith('/openapi.json')
+    ? endpoint.slice(0, -'/openapi.json'.length)
+    : endpoint;
+}
+
+function resolveChainId(network: string): string {
+  switch (network.trim().toLowerCase()) {
+    case 'arbitrum':
+      return '42161';
+    case 'base':
+      return '8453';
+    case 'ethereum':
+    case 'mainnet':
+      return '1';
+    default:
+      throw new Error(`Unsupported lending execution network "${network}".`);
+  }
+}
+
+function resolveLendingOperation(controlPath: string): LendingOperation {
+  switch (controlPath.trim().toLowerCase()) {
+    case 'lending.supply':
+    case 'vault.deposit':
+      return 'supply';
+    case 'lending.withdraw':
+    case 'vault.withdraw':
+      return 'withdraw';
+    case 'lending.borrow':
+    case 'vault.borrow':
+      return 'borrow';
+    case 'lending.repay':
+    case 'vault.repay':
+      return 'repay';
+    default:
+      throw new Error(`Unsupported lending control path "${controlPath}".`);
+  }
+}
+
+async function fetchJson<T>(input: {
+  fetchImpl: typeof fetch;
+  url: string;
+  schema: z.ZodType<T>;
+  init?: RequestInit;
+}): Promise<T> {
+  const response = await input.fetchImpl(input.url, input.init);
+  const rawBody = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `Onchain Actions request failed with status ${response.status}: ${rawBody || 'no body'}`,
+    );
+  }
+
+  const parsedBody = rawBody.length === 0 ? null : (JSON.parse(rawBody) as unknown);
+  return input.schema.parse(parsedBody);
+}
+
+async function resolveTokenIdentifier(input: {
+  fetchImpl: typeof fetch;
+  baseUrl: string;
+  network: string;
+  asset: string;
+}): Promise<z.infer<typeof TokenIdentifierSchema>> {
+  const chainId = resolveChainId(input.network);
+  const response = await fetchJson({
+    fetchImpl: input.fetchImpl,
+    url: `${input.baseUrl}/tokens?${new URLSearchParams({
+      chainIds: chainId,
+    }).toString()}`,
+    schema: TokensResponseSchema,
+  });
+  const normalizedAsset = input.asset.trim().toLowerCase();
+  const match =
+    response.tokens.find(
+      (token) =>
+        token.symbol.trim().toLowerCase() === normalizedAsset && token.isVetted,
+    ) ??
+    response.tokens.find(
+      (token) => token.symbol.trim().toLowerCase() === normalizedAsset,
+    ) ??
+    response.tokens.find(
+      (token) => token.name.trim().toLowerCase() === normalizedAsset && token.isVetted,
+    ) ??
+    response.tokens.find(
+      (token) => token.name.trim().toLowerCase() === normalizedAsset,
+    );
+
+  if (!match) {
+    throw new Error(
+      `Onchain Actions did not return a token for ${input.asset} on ${input.network}.`,
+    );
+  }
+
+  return match.tokenUid;
+}
+
+function buildLendingRequestBody(input: {
+  operation: LendingOperation;
+  walletAddress: `0x${string}`;
+  tokenUid: z.infer<typeof TokenIdentifierSchema>;
+  amount: string;
+}): Record<string, unknown> {
+  switch (input.operation) {
+    case 'supply':
+      return {
+        walletAddress: input.walletAddress,
+        supplyTokenUid: input.tokenUid,
+        amount: input.amount,
+      };
+    case 'withdraw':
+      return {
+        walletAddress: input.walletAddress,
+        tokenUidToWidthraw: input.tokenUid,
+        amount: input.amount,
+      };
+    case 'borrow':
+      return {
+        walletAddress: input.walletAddress,
+        borrowTokenUid: input.tokenUid,
+        amount: input.amount,
+      };
+    case 'repay':
+      return {
+        walletAddress: input.walletAddress,
+        repayTokenUid: input.tokenUid,
+        amount: input.amount,
+      };
+  }
+}
+
+function serializePreparedUnsignedTransaction(
+  transaction: z.infer<typeof OnchainActionsTransactionPlanSchema>,
+): `0x${string}` {
+  const chainId = Number(transaction.chainId);
+  if (!Number.isFinite(chainId) || chainId <= 0) {
+    throw new Error(`Invalid transaction chain id "${transaction.chainId}".`);
+  }
+
+  return serializeTransaction({
+    chainId,
+    type: 'eip1559',
+    nonce: 0,
+    gas: DEFAULT_GAS_LIMIT,
+    maxPriorityFeePerGas: DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
+    maxFeePerGas: DEFAULT_MAX_FEE_PER_GAS,
+    to: transaction.to.toLowerCase() as `0x${string}`,
+    value: BigInt(transaction.value),
+    data: transaction.data.toLowerCase() as `0x${string}`,
+  });
+}
+
+function resolveAnchoredPayloadRef(input: {
+  plannedTransactionPayloadRef: string | null;
+  canonicalUnsignedPayloadRef: string;
+}): string {
+  if (input.plannedTransactionPayloadRef) {
+    return input.plannedTransactionPayloadRef;
+  }
+
+  return input.canonicalUnsignedPayloadRef.startsWith('unsigned-')
+    ? input.canonicalUnsignedPayloadRef.slice('unsigned-'.length)
+    : input.canonicalUnsignedPayloadRef;
+}
+
+export function createEmberLendingOnchainActionsAnchoredPayloadResolver(input?: {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}): EmberLendingAnchoredPayloadResolver {
+  const fetchImpl = input?.fetch ?? fetch;
+  const baseUrl = trimTrailingSlash(
+    input?.baseUrl ?? resolveEmberLendingOnchainActionsApiUrl(),
+  );
+  const anchoredPayloads = new Map<string, EmberLendingAnchoredPayloadRecord>();
+
+  return {
+    async anchorCandidatePlanPayload(request) {
+      const operation = resolveLendingOperation(request.payloadBuilderOutput.required_control_path);
+      const tokenUid = await resolveTokenIdentifier({
+        fetchImpl,
+        baseUrl,
+        network: request.payloadBuilderOutput.network,
+        asset: request.compactPlanSummary.asset,
+      });
+      const response = await fetchJson({
+        fetchImpl,
+        url: `${baseUrl}/lending/${operation}`,
+        schema: OnchainActionsPlanResponseSchema,
+        init: {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(
+            buildLendingRequestBody({
+              operation,
+              walletAddress: request.walletAddress,
+              tokenUid,
+              amount: request.compactPlanSummary.amount,
+            }),
+          ),
+        },
+      });
+      const terminalTransaction = response.transactions.at(-1);
+      if (!terminalTransaction) {
+        throw new Error('Onchain Actions did not return a terminal lending transaction.');
+      }
+
+      const anchoredPayload: EmberLendingAnchoredPayloadRecord = {
+        anchoredPayloadRef: request.payloadBuilderOutput.transaction_payload_ref,
+        unsignedTransactionHex: serializePreparedUnsignedTransaction(terminalTransaction),
+        controlPath: request.payloadBuilderOutput.required_control_path,
+        network: request.payloadBuilderOutput.network,
+        transactionPlanId: request.transactionPlanId,
+      };
+
+      anchoredPayloads.set(anchoredPayload.anchoredPayloadRef, anchoredPayload);
+      return anchoredPayload;
+    },
+
+    async resolvePreparedUnsignedTransaction(request) {
+      const anchoredPayloadRef = resolveAnchoredPayloadRef({
+        plannedTransactionPayloadRef: request.plannedTransactionPayloadRef,
+        canonicalUnsignedPayloadRef: request.canonicalUnsignedPayloadRef,
+      });
+
+      return anchoredPayloads.get(anchoredPayloadRef)?.unsignedTransactionHex ?? null;
+    },
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { serializeTransaction } from 'viem';
 
 import {
   createEmberLendingOnchainActionsAnchoredPayloadResolver,
@@ -16,6 +17,277 @@ describe('resolveEmberLendingOnchainActionsApiUrl', () => {
 });
 
 describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
+  it('resolves exact unsigned transaction bytes from the anchored request using wallet-aware chain state', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c1',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d2',
+                value: '0',
+                data: '0x617ba037',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const rpcClient = {
+      getTransactionCount: vi.fn(async () => 7),
+      estimateFeesPerGas: vi.fn(async () => ({
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 3n,
+      })),
+      estimateGas: vi.fn(async () => 55_000n),
+    };
+    const resolvePublicClient = vi.fn(() => rpcClient);
+    const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+      resolvePublicClient,
+    });
+
+    await resolver.anchorCandidatePlanPayload({
+      agentId: 'ember-lending',
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-ember-lending-003',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-003',
+        required_control_path: 'lending.supply',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        amount: '10',
+        summary: 'supply reserved USDC on Aave',
+      },
+    });
+
+    await expect(
+      resolver.resolvePreparedUnsignedTransaction({
+        agentId: 'ember-lending',
+        executionPreparationId: 'execprep-ember-lending-003',
+        transactionPlanId: 'txplan-ember-lending-003',
+        requestId: 'req-ember-lending-execution-003',
+        canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-003',
+        plannedTransactionPayloadRef: 'txpayload-ember-lending-003',
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        network: 'arbitrum',
+        requiredControlPath: 'lending.supply',
+      }),
+    ).resolves.toBe(
+      serializeTransaction({
+        chainId: 42161,
+        type: 'eip1559',
+        nonce: 7,
+        gas: 55_000n,
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 3n,
+        to: '0x00000000000000000000000000000000000000d2',
+        value: 0n,
+        data: '0x617ba037',
+      }),
+    );
+
+    expect(resolvePublicClient).toHaveBeenCalledWith('arbitrum');
+    expect(rpcClient.getTransactionCount).toHaveBeenCalledWith({
+      address: '0x00000000000000000000000000000000000000b1',
+      blockTag: 'pending',
+    });
+    expect(rpcClient.estimateFeesPerGas).toHaveBeenCalledWith();
+    expect(rpcClient.estimateGas).toHaveBeenCalledWith({
+      account: '0x00000000000000000000000000000000000000b1',
+      to: '0x00000000000000000000000000000000000000d2',
+      value: 0n,
+      data: '0x617ba037',
+    });
+  });
+
+  it('walks paginated token responses until it finds the requested asset', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000a1',
+                },
+                name: 'Wrapped Ether',
+                symbol: 'WETH',
+                isNative: false,
+                decimals: 18,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: 'page-2',
+            currentPage: 1,
+            totalPages: 2,
+            totalItems: 2,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c1',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: null,
+            currentPage: 2,
+            totalPages: 2,
+            totalItems: 2,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d2',
+                value: '0',
+                data: '0x617ba037',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+    });
+
+    await expect(
+      resolver.anchorCandidatePlanPayload({
+        agentId: 'ember-lending',
+        threadId: 'thread-1',
+        transactionPlanId: 'txplan-ember-lending-002',
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+        payloadBuilderOutput: {
+          transaction_payload_ref: 'txpayload-ember-lending-002',
+          required_control_path: 'lending.supply',
+          network: 'arbitrum',
+        },
+        compactPlanSummary: {
+          control_path: 'lending.supply',
+          asset: 'USDC',
+          amount: '10',
+          summary: 'supply reserved USDC on Aave',
+        },
+      }),
+    ).resolves.toMatchObject({
+      anchoredPayloadRef: 'txpayload-ember-lending-002',
+      transactionPlanId: 'txplan-ember-lending-002',
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://api.emberai.xyz/tokens?chainIds=42161&page=1',
+      undefined,
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.emberai.xyz/tokens?chainIds=42161&page=2',
+      undefined,
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      'https://api.emberai.xyz/lending/supply',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          walletAddress: '0x00000000000000000000000000000000000000b1',
+          supplyTokenUid: {
+            chainId: '42161',
+            address: '0x00000000000000000000000000000000000000c1',
+          },
+          amount: '10',
+        }),
+      },
+    );
+  });
+
   it('anchors a planned lending payload and resolves the prepared unsigned transaction by either payload ref', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
@@ -73,9 +345,18 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
           },
         ),
       );
+    const rpcClient = {
+      getTransactionCount: vi.fn(async () => 9),
+      estimateFeesPerGas: vi.fn(async () => ({
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 3n,
+      })),
+      estimateGas: vi.fn(async () => 55_000n),
+    };
     const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
       baseUrl: 'https://api.emberai.xyz',
       fetch: fetchImpl,
+      resolvePublicClient: vi.fn(() => rpcClient),
     });
 
     const anchoredPayload = await resolver.anchorCandidatePlanPayload({
@@ -99,7 +380,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
 
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      'https://api.emberai.xyz/tokens?chainIds=42161',
+      'https://api.emberai.xyz/tokens?chainIds=42161&page=1',
       undefined,
     );
     expect(fetchImpl).toHaveBeenNthCalledWith(
@@ -125,8 +406,25 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
       controlPath: 'lending.supply',
       network: 'arbitrum',
       transactionPlanId: 'txplan-ember-lending-001',
+      transactionRequest: {
+        type: 'EVM_TX',
+        to: '0x00000000000000000000000000000000000000d2',
+        value: '0',
+        data: '0x617ba037',
+        chainId: '42161',
+      },
     });
-    expect(anchoredPayload?.unsignedTransactionHex).toMatch(/^0x[0-9a-f]+$/u);
+    const expectedUnsignedTransactionHex = serializeTransaction({
+      chainId: 42161,
+      type: 'eip1559',
+      nonce: 9,
+      gas: 55_000n,
+      maxFeePerGas: 200n,
+      maxPriorityFeePerGas: 3n,
+      to: '0x00000000000000000000000000000000000000d2',
+      value: 0n,
+      data: '0x617ba037',
+    });
 
     await expect(
       resolver.resolvePreparedUnsignedTransaction({
@@ -136,10 +434,11 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         requestId: 'req-ember-lending-execution-001',
         canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
         plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+        walletAddress: '0x00000000000000000000000000000000000000b1',
         network: 'arbitrum',
         requiredControlPath: 'lending.supply',
       }),
-    ).resolves.toBe(anchoredPayload?.unsignedTransactionHex);
+    ).resolves.toBe(expectedUnsignedTransactionHex);
 
     await expect(
       resolver.resolvePreparedUnsignedTransaction({
@@ -149,9 +448,10 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         requestId: 'req-ember-lending-execution-001',
         canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
         plannedTransactionPayloadRef: null,
+        walletAddress: '0x00000000000000000000000000000000000000b1',
         network: 'arbitrum',
         requiredControlPath: 'lending.supply',
       }),
-    ).resolves.toBe(anchoredPayload?.unsignedTransactionHex);
+    ).resolves.toBe(expectedUnsignedTransactionHex);
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
@@ -406,15 +406,35 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
       controlPath: 'lending.supply',
       network: 'arbitrum',
       transactionPlanId: 'txplan-ember-lending-001',
-      transactionRequest: {
-        type: 'EVM_TX',
-        to: '0x00000000000000000000000000000000000000d2',
-        value: '0',
-        data: '0x617ba037',
-        chainId: '42161',
-      },
+      transactionRequests: [
+        {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000d1',
+          value: '0',
+          data: '0x095ea7b3',
+          chainId: '42161',
+        },
+        {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000d2',
+          value: '0',
+          data: '0x617ba037',
+          chainId: '42161',
+        },
+      ],
     });
-    const expectedUnsignedTransactionHex = serializeTransaction({
+    const expectedApprovalUnsignedTransactionHex = serializeTransaction({
+      chainId: 42161,
+      type: 'eip1559',
+      nonce: 9,
+      gas: 55_000n,
+      maxFeePerGas: 200n,
+      maxPriorityFeePerGas: 3n,
+      to: '0x00000000000000000000000000000000000000d1',
+      value: 0n,
+      data: '0x095ea7b3',
+    });
+    const expectedTerminalUnsignedTransactionHex = serializeTransaction({
       chainId: 42161,
       type: 'eip1559',
       nonce: 9,
@@ -438,7 +458,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         network: 'arbitrum',
         requiredControlPath: 'lending.supply',
       }),
-    ).resolves.toBe(expectedUnsignedTransactionHex);
+    ).resolves.toBe(expectedApprovalUnsignedTransactionHex);
 
     await expect(
       resolver.resolvePreparedUnsignedTransaction({
@@ -446,12 +466,140 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         executionPreparationId: 'execprep-ember-lending-001',
         transactionPlanId: 'txplan-ember-lending-001',
         requestId: 'req-ember-lending-execution-001',
-        canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
+        canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001:1',
         plannedTransactionPayloadRef: null,
         walletAddress: '0x00000000000000000000000000000000000000b1',
         network: 'arbitrum',
         requiredControlPath: 'lending.supply',
       }),
-    ).resolves.toBe(expectedUnsignedTransactionHex);
+    ).resolves.toBe(expectedTerminalUnsignedTransactionHex);
+  });
+
+  it('resolves anchored payloads from persisted records after a fresh resolver instance starts', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c1',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d1',
+                value: '0',
+                data: '0x095ea7b3',
+                chainId: '42161',
+              },
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d2',
+                value: '0',
+                data: '0x617ba037',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const rpcClient = {
+      getTransactionCount: vi.fn(async () => 11),
+      estimateFeesPerGas: vi.fn(async () => ({
+        maxFeePerGas: 300n,
+        maxPriorityFeePerGas: 5n,
+      })),
+      estimateGas: vi.fn(async () => 65_000n),
+    };
+    const resolvePublicClient = vi.fn(() => rpcClient);
+    const firstResolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+      resolvePublicClient,
+    });
+
+    const anchoredPayload = await firstResolver.anchorCandidatePlanPayload({
+      agentId: 'ember-lending',
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-ember-lending-004',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-004',
+        required_control_path: 'lending.supply',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        amount: '10',
+        summary: 'supply reserved USDC on Aave',
+      },
+    });
+    const freshResolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: vi.fn<typeof fetch>(),
+      resolvePublicClient,
+    });
+
+    await expect(
+      freshResolver.resolvePreparedUnsignedTransaction({
+        agentId: 'ember-lending',
+        executionPreparationId: 'execprep-ember-lending-004',
+        transactionPlanId: 'txplan-ember-lending-004',
+        requestId: 'req-ember-lending-execution-004',
+        canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-004:1',
+        plannedTransactionPayloadRef: null,
+        walletAddress: '0x00000000000000000000000000000000000000b1',
+        network: 'arbitrum',
+        requiredControlPath: 'lending.supply',
+        anchoredPayloadRecords: [anchoredPayload!],
+      }),
+    ).resolves.toBe(
+      serializeTransaction({
+        chainId: 42161,
+        type: 'eip1559',
+        nonce: 11,
+        gas: 65_000n,
+        maxFeePerGas: 300n,
+        maxPriorityFeePerGas: 5n,
+        to: '0x00000000000000000000000000000000000000d2',
+        value: 0n,
+        data: '0x617ba037',
+      }),
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createEmberLendingOnchainActionsAnchoredPayloadResolver,
+  resolveEmberLendingOnchainActionsApiUrl,
+} from './onchainActionsPayloadResolver.js';
+
+describe('resolveEmberLendingOnchainActionsApiUrl', () => {
+  it('normalizes an explicit OpenAPI document URL down to the API origin', () => {
+    expect(
+      resolveEmberLendingOnchainActionsApiUrl({
+        ONCHAIN_ACTIONS_API_URL: 'https://api.emberai.xyz/openapi.json/',
+      }),
+    ).toBe('https://api.emberai.xyz');
+  });
+});
+
+describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
+  it('anchors a planned lending payload and resolves the prepared unsigned transaction by either payload ref', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c1',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d1',
+                value: '0',
+                data: '0x095ea7b3',
+                chainId: '42161',
+              },
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d2',
+                value: '0',
+                data: '0x617ba037',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+    });
+
+    const anchoredPayload = await resolver.anchorCandidatePlanPayload({
+      agentId: 'ember-lending',
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-001',
+        required_control_path: 'lending.supply',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        amount: '10',
+        summary: 'supply reserved USDC on Aave',
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://api.emberai.xyz/tokens?chainIds=42161',
+      undefined,
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.emberai.xyz/lending/supply',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          walletAddress: '0x00000000000000000000000000000000000000b1',
+          supplyTokenUid: {
+            chainId: '42161',
+            address: '0x00000000000000000000000000000000000000c1',
+          },
+          amount: '10',
+        }),
+      },
+    );
+    expect(anchoredPayload).toMatchObject({
+      anchoredPayloadRef: 'txpayload-ember-lending-001',
+      controlPath: 'lending.supply',
+      network: 'arbitrum',
+      transactionPlanId: 'txplan-ember-lending-001',
+    });
+    expect(anchoredPayload?.unsignedTransactionHex).toMatch(/^0x[0-9a-f]+$/u);
+
+    await expect(
+      resolver.resolvePreparedUnsignedTransaction({
+        agentId: 'ember-lending',
+        executionPreparationId: 'execprep-ember-lending-001',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
+        plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+        network: 'arbitrum',
+        requiredControlPath: 'lending.supply',
+      }),
+    ).resolves.toBe(anchoredPayload?.unsignedTransactionHex);
+
+    await expect(
+      resolver.resolvePreparedUnsignedTransaction({
+        agentId: 'ember-lending',
+        executionPreparationId: 'execprep-ember-lending-001',
+        transactionPlanId: 'txplan-ember-lending-001',
+        requestId: 'req-ember-lending-execution-001',
+        canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
+        plannedTransactionPayloadRef: null,
+        network: 'arbitrum',
+        requiredControlPath: 'lending.supply',
+      }),
+    ).resolves.toBe(anchoredPayload?.unsignedTransactionHex);
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.int.test.ts
@@ -16,7 +16,7 @@ import {
   TEST_EMBER_LENDING_AGENT_WALLET,
   TEST_EMBER_LENDING_USER_WALLET,
   type StartedSharedEmberTarget,
-} from './sharedEmberIntegrationHarness.js';
+} from '../test-support/sharedEmberIntegrationHarness.js';
 import { createEmberLendingSharedEmberHttpHost } from './sharedEmberHttpHost.js';
 
 const runSharedEmberIntegration = process.env['RUN_SHARED_EMBER_INT']?.trim() === '1';
@@ -71,14 +71,14 @@ const TEST_REDELEGATION_SIGNATURE =
 const REAL_RUNTIME_PRIVATE_KEY =
   '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-function requirePreparedUnsignedTransactionResolver(target: StartedSharedEmberTarget) {
-  if (!target.resolvePreparedUnsignedTransaction) {
+function requireAnchoredPayloadResolver(target: StartedSharedEmberTarget) {
+  if (!target.anchoredPayloadResolver) {
     throw new Error(
-      'Shared Ember execution integration tests require a prepared unsigned transaction resolver.',
+      'Shared Ember execution integration tests require an anchored payload resolver.',
     );
   }
 
-  return target.resolvePreparedUnsignedTransaction;
+  return target.anchoredPayloadResolver;
 }
 
 function createManagedLifecycleState() {
@@ -551,7 +551,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
     const domain = createEmberLendingDomain({
       protocolHost,
       runtimeSigning,
-      resolvePreparedUnsignedTransaction: requirePreparedUnsignedTransactionResolver(target),
+      anchoredPayloadResolver: requireAnchoredPayloadResolver(target),
       runtimeSignerRef: 'service-wallet',
       agentId: TEST_EMBER_LENDING_AGENT_ID,
     });
@@ -664,7 +664,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
     const domain = createEmberLendingDomain({
       protocolHost,
       runtimeSigning: signingFixture.runtimeSigning,
-      resolvePreparedUnsignedTransaction: requirePreparedUnsignedTransactionResolver(target),
+      anchoredPayloadResolver: requireAnchoredPayloadResolver(target),
       runtimeSignerRef: 'service-wallet',
       agentId: TEST_EMBER_LENDING_AGENT_ID,
     });
@@ -750,7 +750,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
     const domain = createEmberLendingDomain({
       protocolHost,
       runtimeSigning,
-      resolvePreparedUnsignedTransaction: requirePreparedUnsignedTransactionResolver(target),
+      anchoredPayloadResolver: requireAnchoredPayloadResolver(target),
       runtimeSignerRef: 'service-wallet',
       agentId: TEST_EMBER_LENDING_AGENT_ID,
     });
@@ -828,7 +828,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
       const domain = createEmberLendingDomain({
         protocolHost,
         runtimeSigning,
-        resolvePreparedUnsignedTransaction: requirePreparedUnsignedTransactionResolver(target),
+        anchoredPayloadResolver: requireAnchoredPayloadResolver(target),
         runtimeSignerRef: 'service-wallet',
         agentId: TEST_EMBER_LENDING_AGENT_ID,
       });
@@ -898,7 +898,7 @@ describeSharedEmberIntegration('ember-lending Shared Ember execution integration
       const domain = createEmberLendingDomain({
         protocolHost,
         runtimeSigning,
-        resolvePreparedUnsignedTransaction: requirePreparedUnsignedTransactionResolver(target),
+        anchoredPayloadResolver: requireAnchoredPayloadResolver(target),
         runtimeSignerRef: 'service-wallet',
         agentId: TEST_EMBER_LENDING_AGENT_ID,
       });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -6,12 +6,14 @@ import {
 import { keccak256, parseSignature, parseTransaction, serializeTransaction, toHex } from 'viem';
 import type {
   EmberLendingAnchoredPayloadResolver,
+  EmberLendingAnchoredPayloadRecord,
   EmberLendingCompactPlanSummary,
   EmberLendingPayloadBuilderOutput,
 } from './onchainActionsPayloadResolver.js';
 
 export type {
   EmberLendingAnchoredPayloadResolver,
+  EmberLendingAnchoredPayloadRecord,
   EmberLendingCompactPlanSummary,
   EmberLendingPayloadBuilderOutput,
 } from './onchainActionsPayloadResolver.js';
@@ -38,6 +40,7 @@ export type EmberLendingLifecycleState = {
   lastReservationSummary: string | null;
   lastCandidatePlan: unknown;
   lastCandidatePlanSummary: string | null;
+  anchoredPayloadRecords: EmberLendingAnchoredPayloadRecord[];
   lastExecutionResult: unknown;
   lastExecutionTxHash: `0x${string}` | null;
   pendingExecutionSubmission?: PendingExecutionSubmission | null;
@@ -177,6 +180,7 @@ function buildDefaultLifecycleState(): EmberLendingLifecycleState {
     lastReservationSummary: null,
     lastCandidatePlan: null,
     lastCandidatePlanSummary: null,
+    anchoredPayloadRecords: [],
     lastExecutionResult: null,
     lastExecutionTxHash: null,
     pendingExecutionSubmission: null,
@@ -817,6 +821,20 @@ function readExecutionTxHash(executionResult: unknown): `0x${string}` | null {
   }
 
   return readHexAddress(executionResult['execution']['transaction_hash']);
+}
+
+function upsertAnchoredPayloadRecord(
+  records: EmberLendingAnchoredPayloadRecord[],
+  nextRecord: EmberLendingAnchoredPayloadRecord | null,
+): EmberLendingAnchoredPayloadRecord[] {
+  if (!nextRecord) {
+    return records;
+  }
+
+  const remainingRecords = records.filter(
+    (record) => record.anchoredPayloadRef !== nextRecord.anchoredPayloadRef,
+  );
+  return [...remainingRecords, nextRecord];
 }
 
 function readExecutionPortfolioState(executionResult: unknown): unknown {
@@ -1797,6 +1815,7 @@ async function runPreparedExecutionFlow(input: {
           walletAddress: input.currentState.walletAddress,
           network,
           requiredControlPath,
+          anchoredPayloadRecords: input.currentState.anchoredPayloadRecords,
         }))
       : null);
   if (!unsignedTransactionHex) {
@@ -2171,30 +2190,35 @@ export function createEmberLendingDomain(
           const candidatePlanTransactionPlanId = readCandidatePlanTransactionPlanId(candidatePlan);
           const payloadBuilderOutput = readCandidatePlanPayloadBuilderOutput(candidatePlan);
           const compactPlanSummary = readCandidatePlanCompactPlanSummary(candidatePlan);
-          if (
+          const anchoredPayloadRecord =
+            (
             options.anchoredPayloadResolver &&
             currentState.walletAddress &&
             currentState.rootUserWalletAddress &&
             candidatePlanTransactionPlanId &&
             payloadBuilderOutput &&
             compactPlanSummary
-          ) {
-            await options.anchoredPayloadResolver.anchorCandidatePlanPayload({
-              agentId,
-              threadId,
-              transactionPlanId: candidatePlanTransactionPlanId,
-              walletAddress: currentState.walletAddress,
-              rootUserWalletAddress: currentState.rootUserWalletAddress,
-              payloadBuilderOutput,
-              compactPlanSummary,
-            });
-          }
+            )
+              ? await options.anchoredPayloadResolver.anchorCandidatePlanPayload({
+                  agentId,
+                  threadId,
+                  transactionPlanId: candidatePlanTransactionPlanId,
+                  walletAddress: currentState.walletAddress,
+                  rootUserWalletAddress: currentState.rootUserWalletAddress,
+                  payloadBuilderOutput,
+                  compactPlanSummary,
+                })
+              : null;
           const nextState: EmberLendingLifecycleState = {
             ...currentState,
             phase: 'active',
             lastSharedEmberRevision: response.result?.revision ?? null,
             lastCandidatePlan: candidatePlan,
             lastCandidatePlanSummary: readCandidatePlanSummary(candidatePlan),
+            anchoredPayloadRecords: upsertAnchoredPayloadRecord(
+              currentState.anchoredPayloadRecords,
+              anchoredPayloadRecord,
+            ),
           };
 
           return {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -8,14 +8,12 @@ import type {
   EmberLendingAnchoredPayloadResolver,
   EmberLendingCompactPlanSummary,
   EmberLendingPayloadBuilderOutput,
-  EmberLendingPreparedUnsignedTransactionResolver,
 } from './onchainActionsPayloadResolver.js';
 
 export type {
   EmberLendingAnchoredPayloadResolver,
   EmberLendingCompactPlanSummary,
   EmberLendingPayloadBuilderOutput,
-  EmberLendingPreparedUnsignedTransactionResolver,
 } from './onchainActionsPayloadResolver.js';
 
 export type EmberLendingSharedEmberProtocolHost = {
@@ -50,7 +48,6 @@ export type EmberLendingLifecycleState = {
 type CreateEmberLendingDomainOptions = {
   protocolHost?: EmberLendingSharedEmberProtocolHost;
   runtimeSigning?: AgentRuntimeSigningService;
-  resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
   anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
   runtimeSignerRef?: string;
   agentId?: string;
@@ -1588,7 +1585,6 @@ async function signPayloadWithRuntimeService(input: {
 async function runPreparedExecutionFlow(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
   runtimeSigning?: AgentRuntimeSigningService;
-  resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
   anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
   runtimeSignerRef?: string;
   threadId: string;
@@ -1791,23 +1787,14 @@ async function runPreparedExecutionFlow(input: {
   const unsignedTransactionHex =
     readExecutionUnsignedTransactionHex(executionResult) ??
     (executionPreparationId && canonicalUnsignedPayloadRef
-      ? (await input.resolvePreparedUnsignedTransaction?.({
+      ? (await input.anchoredPayloadResolver?.resolvePreparedUnsignedTransaction({
           agentId: input.agentId,
           executionPreparationId,
           transactionPlanId: input.transactionPlanId,
           requestId: requestId!,
           canonicalUnsignedPayloadRef,
           plannedTransactionPayloadRef,
-          network,
-          requiredControlPath,
-        })) ??
-        (await input.anchoredPayloadResolver?.resolvePreparedUnsignedTransaction({
-          agentId: input.agentId,
-          executionPreparationId,
-          transactionPlanId: input.transactionPlanId,
-          requestId: requestId!,
-          canonicalUnsignedPayloadRef,
-          plannedTransactionPayloadRef,
+          walletAddress: input.currentState.walletAddress,
           network,
           requiredControlPath,
         }))
@@ -2274,8 +2261,6 @@ export function createEmberLendingDomain(
                 : await runPreparedExecutionFlow({
                     protocolHost: options.protocolHost,
                     runtimeSigning: options.runtimeSigning,
-                    resolvePreparedUnsignedTransaction:
-                      options.resolvePreparedUnsignedTransaction,
                     anchoredPayloadResolver: options.anchoredPayloadResolver,
                     runtimeSignerRef: options.runtimeSignerRef,
                     threadId,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -806,6 +806,34 @@ function readCandidatePlanCompactPlanSummary(
   };
 }
 
+function resolveCandidatePlanAnchoringFailureMessage(input: {
+  candidatePlan: unknown;
+  anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
+  walletAddress: `0x${string}` | null;
+  rootUserWalletAddress: `0x${string}` | null;
+  transactionPlanId: string | null;
+  payloadBuilderOutput: EmberLendingPayloadBuilderOutput | null;
+  compactPlanSummary: EmberLendingCompactPlanSummary | null;
+}): string | null {
+  if (!input.candidatePlan) {
+    return null;
+  }
+
+  if (!input.transactionPlanId || !input.payloadBuilderOutput || !input.compactPlanSummary) {
+    return 'Candidate lending plan could not be anchored behind the lending service boundary because Shared Ember omitted the planner payload metadata required for anchoring.';
+  }
+
+  if (!input.walletAddress || !input.rootUserWalletAddress) {
+    return 'Candidate lending plan could not be anchored behind the lending service boundary because the managed wallet context is incomplete.';
+  }
+
+  if (!input.anchoredPayloadResolver) {
+    return 'Candidate lending plan could not be anchored behind the lending service boundary because the anchored payload resolver is unavailable.';
+  }
+
+  return null;
+}
+
 function readExecutionTxHash(executionResult: unknown): `0x${string}` | null {
   if (!isRecord(executionResult)) {
     return null;
@@ -2190,25 +2218,57 @@ export function createEmberLendingDomain(
           const candidatePlanTransactionPlanId = readCandidatePlanTransactionPlanId(candidatePlan);
           const payloadBuilderOutput = readCandidatePlanPayloadBuilderOutput(candidatePlan);
           const compactPlanSummary = readCandidatePlanCompactPlanSummary(candidatePlan);
-          const anchoredPayloadRecord =
-            (
-            options.anchoredPayloadResolver &&
-            currentState.walletAddress &&
-            currentState.rootUserWalletAddress &&
-            candidatePlanTransactionPlanId &&
-            payloadBuilderOutput &&
-            compactPlanSummary
-            )
-              ? await options.anchoredPayloadResolver.anchorCandidatePlanPayload({
-                  agentId,
-                  threadId,
-                  transactionPlanId: candidatePlanTransactionPlanId,
-                  walletAddress: currentState.walletAddress,
-                  rootUserWalletAddress: currentState.rootUserWalletAddress,
-                  payloadBuilderOutput,
-                  compactPlanSummary,
-                })
-              : null;
+          const anchoringFailureMessage = resolveCandidatePlanAnchoringFailureMessage({
+            candidatePlan,
+            anchoredPayloadResolver: options.anchoredPayloadResolver,
+            walletAddress: currentState.walletAddress,
+            rootUserWalletAddress: currentState.rootUserWalletAddress,
+            transactionPlanId: candidatePlanTransactionPlanId,
+            payloadBuilderOutput,
+            compactPlanSummary,
+          });
+          if (anchoringFailureMessage) {
+            return {
+              state: {
+                ...currentState,
+                phase: 'active',
+                lastSharedEmberRevision: response.result?.revision ?? null,
+              },
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage: anchoringFailureMessage,
+                },
+              },
+            };
+          }
+
+          const anchoredPayloadRecord = await options.anchoredPayloadResolver!.anchorCandidatePlanPayload({
+            agentId,
+            threadId,
+            transactionPlanId: candidatePlanTransactionPlanId!,
+            walletAddress: currentState.walletAddress!,
+            rootUserWalletAddress: currentState.rootUserWalletAddress!,
+            payloadBuilderOutput: payloadBuilderOutput!,
+            compactPlanSummary: compactPlanSummary!,
+          });
+          if (!anchoredPayloadRecord) {
+            return {
+              state: {
+                ...currentState,
+                phase: 'active',
+                lastSharedEmberRevision: response.result?.revision ?? null,
+              },
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Candidate lending plan could not be anchored behind the lending service boundary because the anchored payload resolver did not persist the payload.',
+                },
+              },
+            };
+          }
+
           const nextState: EmberLendingLifecycleState = {
             ...currentState,
             phase: 'active',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -4,23 +4,25 @@ import {
   type AgentRuntimeSigningService,
 } from 'agent-runtime/internal';
 import { keccak256, parseSignature, parseTransaction, serializeTransaction, toHex } from 'viem';
+import type {
+  EmberLendingAnchoredPayloadResolver,
+  EmberLendingCompactPlanSummary,
+  EmberLendingPayloadBuilderOutput,
+  EmberLendingPreparedUnsignedTransactionResolver,
+} from './onchainActionsPayloadResolver.js';
+
+export type {
+  EmberLendingAnchoredPayloadResolver,
+  EmberLendingCompactPlanSummary,
+  EmberLendingPayloadBuilderOutput,
+  EmberLendingPreparedUnsignedTransactionResolver,
+} from './onchainActionsPayloadResolver.js';
 
 export type EmberLendingSharedEmberProtocolHost = {
   handleJsonRpc: (input: unknown) => Promise<unknown>;
   readCommittedEventOutbox: (input: unknown) => Promise<unknown>;
   acknowledgeCommittedEventOutbox: (input: unknown) => Promise<unknown>;
 };
-
-export type EmberLendingPreparedUnsignedTransactionResolver = (input: {
-  agentId: string;
-  executionPreparationId: string;
-  transactionPlanId: string;
-  requestId: string;
-  canonicalUnsignedPayloadRef: string;
-  plannedTransactionPayloadRef: string | null;
-  network: string | null;
-  requiredControlPath: string | null;
-}) => Promise<`0x${string}` | null>;
 
 export const EMBER_LENDING_INTERNAL_HYDRATE_COMMAND = 'hydrate_runtime_projection';
 export const EMBER_LENDING_SHARED_EMBER_AGENT_ID = 'ember-lending';
@@ -49,6 +51,7 @@ type CreateEmberLendingDomainOptions = {
   protocolHost?: EmberLendingSharedEmberProtocolHost;
   runtimeSigning?: AgentRuntimeSigningService;
   resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
+  anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
   runtimeSignerRef?: string;
   agentId?: string;
 };
@@ -748,6 +751,58 @@ function readCandidatePlanSummary(candidatePlan: unknown): string | null {
       : null;
 
   return readString(compactPlanSummary?.['summary']) ?? readString(candidatePlan['transaction_plan_id']);
+}
+
+function readCandidatePlanTransactionPlanId(candidatePlan: unknown): string | null {
+  return readStringKey(candidatePlan, 'transaction_plan_id');
+}
+
+function readCandidatePlanPayloadBuilderOutput(
+  candidatePlan: unknown,
+): EmberLendingPayloadBuilderOutput | null {
+  const payloadBuilderOutput = readRecordKey(
+    readRecordKey(candidatePlan, 'handoff'),
+    'payload_builder_output',
+  );
+  const transactionPayloadRef = readString(payloadBuilderOutput?.['transaction_payload_ref']);
+  const requiredControlPath = readString(payloadBuilderOutput?.['required_control_path']);
+  const network = readString(payloadBuilderOutput?.['network']);
+
+  if (!transactionPayloadRef || !requiredControlPath || !network) {
+    return null;
+  }
+
+  return {
+    transaction_payload_ref: transactionPayloadRef,
+    required_control_path: requiredControlPath,
+    network,
+  };
+}
+
+function readCandidatePlanCompactPlanSummary(
+  candidatePlan: unknown,
+): EmberLendingCompactPlanSummary | null {
+  const compactPlanSummary = readRecordKey(candidatePlan, 'compact_plan_summary');
+  const controlPath = readString(compactPlanSummary?.['control_path']);
+  const asset = readString(compactPlanSummary?.['asset']);
+  const amount = readString(compactPlanSummary?.['amount']);
+  const summary = readString(compactPlanSummary?.['summary']);
+
+  if (!controlPath || !asset || !amount || !summary) {
+    return null;
+  }
+
+  return {
+    control_path: controlPath,
+    asset,
+    amount,
+    summary,
+    ...(readString(compactPlanSummary?.['protocol_summary'])
+      ? {
+          protocol_summary: readString(compactPlanSummary?.['protocol_summary'])!,
+        }
+      : {}),
+  };
 }
 
 function readExecutionTxHash(executionResult: unknown): `0x${string}` | null {
@@ -1534,6 +1589,7 @@ async function runPreparedExecutionFlow(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
   runtimeSigning?: AgentRuntimeSigningService;
   resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
+  anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
   runtimeSignerRef?: string;
   threadId: string;
   agentId: string;
@@ -1727,21 +1783,34 @@ async function runPreparedExecutionFlow(input: {
   const executionPreparationId = readPreparedExecutionId(executionResult);
   const canonicalUnsignedPayloadRef =
     readExecutionSigningPackageCanonicalUnsignedPayloadRef(executionResult);
+  const plannedTransactionPayloadRef = readPreparedExecutionPlannedTransactionPayloadRef(
+    executionResult,
+  );
+  const network = readPreparedExecutionNetwork(executionResult);
+  const requiredControlPath = readPreparedExecutionRequiredControlPath(executionResult);
   const unsignedTransactionHex =
     readExecutionUnsignedTransactionHex(executionResult) ??
     (executionPreparationId && canonicalUnsignedPayloadRef
-      ? await input.resolvePreparedUnsignedTransaction?.({
+      ? (await input.resolvePreparedUnsignedTransaction?.({
           agentId: input.agentId,
           executionPreparationId,
           transactionPlanId: input.transactionPlanId,
           requestId: requestId!,
           canonicalUnsignedPayloadRef,
-          plannedTransactionPayloadRef: readPreparedExecutionPlannedTransactionPayloadRef(
-            executionResult,
-          ),
-          network: readPreparedExecutionNetwork(executionResult),
-          requiredControlPath: readPreparedExecutionRequiredControlPath(executionResult),
-        })
+          plannedTransactionPayloadRef,
+          network,
+          requiredControlPath,
+        })) ??
+        (await input.anchoredPayloadResolver?.resolvePreparedUnsignedTransaction({
+          agentId: input.agentId,
+          executionPreparationId,
+          transactionPlanId: input.transactionPlanId,
+          requestId: requestId!,
+          canonicalUnsignedPayloadRef,
+          plannedTransactionPayloadRef,
+          network,
+          requiredControlPath,
+        }))
       : null);
   if (!unsignedTransactionHex) {
     throw new LocalExecutionFailureError(
@@ -2112,6 +2181,27 @@ export function createEmberLendingDomain(
           });
 
           const candidatePlan = response.result?.candidate_plan ?? null;
+          const candidatePlanTransactionPlanId = readCandidatePlanTransactionPlanId(candidatePlan);
+          const payloadBuilderOutput = readCandidatePlanPayloadBuilderOutput(candidatePlan);
+          const compactPlanSummary = readCandidatePlanCompactPlanSummary(candidatePlan);
+          if (
+            options.anchoredPayloadResolver &&
+            currentState.walletAddress &&
+            currentState.rootUserWalletAddress &&
+            candidatePlanTransactionPlanId &&
+            payloadBuilderOutput &&
+            compactPlanSummary
+          ) {
+            await options.anchoredPayloadResolver.anchorCandidatePlanPayload({
+              agentId,
+              threadId,
+              transactionPlanId: candidatePlanTransactionPlanId,
+              walletAddress: currentState.walletAddress,
+              rootUserWalletAddress: currentState.rootUserWalletAddress,
+              payloadBuilderOutput,
+              compactPlanSummary,
+            });
+          }
           const nextState: EmberLendingLifecycleState = {
             ...currentState,
             phase: 'active',
@@ -2186,6 +2276,7 @@ export function createEmberLendingDomain(
                     runtimeSigning: options.runtimeSigning,
                     resolvePreparedUnsignedTransaction:
                       options.resolvePreparedUnsignedTransaction,
+                    anchoredPayloadResolver: options.anchoredPayloadResolver,
                     runtimeSignerRef: options.runtimeSignerRef,
                     threadId,
                     agentId,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -14,12 +14,6 @@ function createRuntimeSigningStub(
   };
 }
 
-function createPreparedUnsignedTransactionResolverStub(
-  implementation?: ReturnType<typeof vi.fn>,
-) {
-  return implementation ?? vi.fn(async () => TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX);
-}
-
 function createAnchoredPayloadResolverStub() {
   return {
     anchorCandidatePlanPayload: vi.fn(async () => ({
@@ -1515,11 +1509,11 @@ describe('createEmberLendingDomain', () => {
         },
       })),
     );
-    const resolvePreparedUnsignedTransaction = createPreparedUnsignedTransactionResolverStub();
+    const anchoredPayloadResolver = createAnchoredPayloadResolverStub();
     const domain = createEmberLendingDomain({
       protocolHost,
       runtimeSigning,
-      resolvePreparedUnsignedTransaction,
+      anchoredPayloadResolver,
       runtimeSignerRef: 'service-wallet',
       agentId: 'ember-lending',
     });
@@ -1548,12 +1542,13 @@ describe('createEmberLendingDomain', () => {
         unsignedTransactionHex: TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX,
       },
     });
-    expect(resolvePreparedUnsignedTransaction).toHaveBeenCalledWith({
+    expect(anchoredPayloadResolver.resolvePreparedUnsignedTransaction).toHaveBeenCalledWith({
       agentId: 'ember-lending',
       canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
       executionPreparationId: 'execprep-ember-lending-001',
       network: 'arbitrum',
       plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
       requestId: 'req-ember-lending-execution-001',
       requiredControlPath: 'lending.supply',
       transactionPlanId: 'txplan-ember-lending-001',
@@ -1695,6 +1690,7 @@ describe('createEmberLendingDomain', () => {
       executionPreparationId: 'execprep-ember-lending-001',
       network: 'arbitrum',
       plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
       requestId: 'req-ember-lending-execution-001',
       requiredControlPath: 'lending.supply',
       transactionPlanId: 'txplan-ember-lending-001',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -20,6 +20,15 @@ function createPreparedUnsignedTransactionResolverStub(
   return implementation ?? vi.fn(async () => TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX);
 }
 
+function createAnchoredPayloadResolverStub() {
+  return {
+    anchorCandidatePlanPayload: vi.fn(async () => ({
+      anchoredPayloadRef: 'txpayload-ember-lending-001',
+    })),
+    resolvePreparedUnsignedTransaction: vi.fn(async () => TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX),
+  };
+}
+
 function decodeDelegationArtifactRef(
   artifactRef: string,
 ): Record<string, unknown> {
@@ -1227,6 +1236,84 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
+  it('anchors the planner-returned payload ref behind the lending service boundary during candidate-plan creation', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-materialize-candidate-plan',
+        result: {
+          protocol_version: 'v1',
+          revision: 8,
+          committed_event_ids: ['evt-candidate-plan-1'],
+          candidate_plan: {
+            planning_kind: 'subagent_handoff',
+            transaction_plan_id: 'txplan-ember-lending-001',
+            handoff: {
+              handoff_id: 'handoff-thread-1',
+              payload_builder_output: {
+                transaction_payload_ref: 'txpayload-ember-lending-001',
+                required_control_path: 'lending.supply',
+                network: 'arbitrum',
+              },
+            },
+            compact_plan_summary: {
+              control_path: 'lending.supply',
+              asset: 'USDC',
+              amount: '10',
+              summary: 'supply reserved USDC on Aave',
+            },
+          },
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 8,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 8,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const anchoredPayloadResolver = createAnchoredPayloadResolverStub();
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+      anchoredPayloadResolver,
+    });
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    expect(anchoredPayloadResolver.anchorCandidatePlanPayload).toHaveBeenCalledWith({
+      agentId: 'ember-lending',
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      walletAddress: '0x00000000000000000000000000000000000000b1',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000a1',
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-001',
+        required_control_path: 'lending.supply',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        amount: '10',
+        summary: 'supply reserved USDC on Aave',
+      },
+    });
+  });
+
   it('fails execution when Shared Ember prepares signing but no direct OWS signer is configured', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => ({
@@ -1517,6 +1604,100 @@ describe('createEmberLendingDomain', () => {
           statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
         },
       },
+    });
+  });
+
+  it('resolves prepared unsigned transactions from the anchored lending-service payload store when no harness resolver is injected', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-transaction-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult({
+              inlineUnsignedTransactionHex: null,
+            }),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-submit-execution-1'],
+            execution_result: createTerminalExecutionResult({
+              status: 'confirmed',
+              transactionHash:
+                '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            }),
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000b1',
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const anchoredPayloadResolver = createAnchoredPayloadResolverStub();
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      runtimeSigning,
+      anchoredPayloadResolver,
+      runtimeSignerRef: 'service-wallet',
+      agentId: 'ember-lending',
+    });
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+          handoff: {
+            payload_builder_output: {
+              transaction_payload_ref: 'txpayload-ember-lending-001',
+              required_control_path: 'lending.supply',
+              network: 'arbitrum',
+            },
+          },
+        },
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_transaction_execution',
+      },
+    });
+
+    expect(anchoredPayloadResolver.resolvePreparedUnsignedTransaction).toHaveBeenCalledWith({
+      agentId: 'ember-lending',
+      canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-001',
+      executionPreparationId: 'execprep-ember-lending-001',
+      network: 'arbitrum',
+      plannedTransactionPayloadRef: 'txpayload-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
+      requiredControlPath: 'lending.supply',
+      transactionPlanId: 'txplan-ember-lending-001',
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -1163,7 +1163,7 @@ describe('createEmberLendingDomain', () => {
     );
   });
 
-  it('materializes candidate plans through the bounded subagent surface using managed state context', async () => {
+  it('fails candidate-plan creation when Shared Ember omits planner metadata required for service-owned anchoring', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async () => ({
         jsonrpc: '2.0',
@@ -1218,25 +1218,15 @@ describe('createEmberLendingDomain', () => {
       state: {
         phase: 'active',
         lastSharedEmberRevision: 8,
+        lastCandidatePlan: null,
         anchoredPayloadRecords: [],
-        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
       },
       outputs: {
         status: {
-          executionStatus: 'completed',
-          statusMessage: 'Candidate lending plan created through the Shared Ember planner.',
+          executionStatus: 'failed',
+          statusMessage:
+            'Candidate lending plan could not be anchored behind the lending service boundary because Shared Ember omitted the planner payload metadata required for anchoring.',
         },
-        artifacts: [
-          {
-            data: {
-              type: 'shared-ember-candidate-plan',
-              revision: 8,
-              candidatePlan: {
-                transaction_plan_id: 'txplan-ember-lending-001',
-              },
-            },
-          },
-        ],
       },
     });
 
@@ -1350,6 +1340,79 @@ describe('createEmberLendingDomain', () => {
         asset: 'USDC',
         amount: '10',
         summary: 'supply reserved USDC on Aave',
+      },
+    });
+  });
+
+  it('fails candidate-plan creation when the anchored payload resolver is unavailable', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-materialize-candidate-plan',
+        result: {
+          protocol_version: 'v1',
+          revision: 8,
+          committed_event_ids: ['evt-candidate-plan-1'],
+          candidate_plan: {
+            planning_kind: 'subagent_handoff',
+            transaction_plan_id: 'txplan-ember-lending-001',
+            handoff: {
+              handoff_id: 'handoff-thread-1',
+              payload_builder_output: {
+                transaction_payload_ref: 'txpayload-ember-lending-001',
+                required_control_path: 'lending.supply',
+                network: 'arbitrum',
+              },
+            },
+            compact_plan_summary: {
+              control_path: 'lending.supply',
+              asset: 'USDC',
+              amount: '10',
+              summary: 'supply reserved USDC on Aave',
+            },
+          },
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 8,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 8,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction_plan',
+        input: createCandidatePlanInput(),
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 8,
+        lastCandidatePlan: null,
+        anchoredPayloadRecords: [],
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Candidate lending plan could not be anchored behind the lending service boundary because the anchored payload resolver is unavailable.',
+        },
       },
     });
   });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -18,6 +18,25 @@ function createAnchoredPayloadResolverStub() {
   return {
     anchorCandidatePlanPayload: vi.fn(async () => ({
       anchoredPayloadRef: 'txpayload-ember-lending-001',
+      transactionRequests: [
+        {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000d1',
+          value: '0',
+          data: '0x095ea7b3',
+          chainId: '42161',
+        },
+        {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000d2',
+          value: '0',
+          data: '0x617ba037',
+          chainId: '42161',
+        },
+      ],
+      controlPath: 'lending.supply',
+      network: 'arbitrum',
+      transactionPlanId: 'txplan-ember-lending-001',
     })),
     resolvePreparedUnsignedTransaction: vi.fn(async () => TEST_UNSIGNED_EXECUTION_TRANSACTION_HEX),
   };
@@ -44,6 +63,31 @@ const TEST_TRANSACTION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
 const TEST_REDELEGATION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
+
+function createAnchoredPayloadRecord() {
+  return {
+    anchoredPayloadRef: 'txpayload-ember-lending-001',
+    transactionRequests: [
+      {
+        type: 'EVM_TX' as const,
+        to: '0x00000000000000000000000000000000000000d1',
+        value: '0',
+        data: '0x095ea7b3',
+        chainId: '42161',
+      },
+      {
+        type: 'EVM_TX' as const,
+        to: '0x00000000000000000000000000000000000000d2',
+        value: '0',
+        data: '0x617ba037',
+        chainId: '42161',
+      },
+    ],
+    controlPath: 'lending.supply',
+    network: 'arbitrum',
+    transactionPlanId: 'txplan-ember-lending-001',
+  };
+}
 
 function createManagedLifecycleState() {
   return {
@@ -84,6 +128,7 @@ function createManagedLifecycleState() {
     lastReservationSummary: 'Reservation reservation-ember-lending-001 deploys 10 USDC via lending.supply.',
     lastCandidatePlan: null,
     lastCandidatePlanSummary: null,
+    anchoredPayloadRecords: [],
     lastExecutionResult: null,
     lastExecutionTxHash: null,
     lastEscalationRequest: null,
@@ -1173,6 +1218,7 @@ describe('createEmberLendingDomain', () => {
       state: {
         phase: 'active',
         lastSharedEmberRevision: 8,
+        anchoredPayloadRecords: [],
         lastCandidatePlanSummary: 'supply reserved USDC on Aave',
       },
       outputs: {
@@ -1343,6 +1389,7 @@ describe('createEmberLendingDomain', () => {
       threadId: 'thread-1',
       state: {
         ...createManagedLifecycleState(),
+        anchoredPayloadRecords: [createAnchoredPayloadRecord()],
         lastCandidatePlan: {
           transaction_plan_id: 'txplan-ember-lending-001',
         },
@@ -1428,6 +1475,7 @@ describe('createEmberLendingDomain', () => {
       threadId: 'thread-1',
       state: {
         ...createManagedLifecycleState(),
+        anchoredPayloadRecords: [createAnchoredPayloadRecord()],
         lastCandidatePlan: {
           transaction_plan_id: 'txplan-ember-lending-001',
         },
@@ -1522,6 +1570,7 @@ describe('createEmberLendingDomain', () => {
       threadId: 'thread-1',
       state: {
         ...createManagedLifecycleState(),
+        anchoredPayloadRecords: [createAnchoredPayloadRecord()],
         lastCandidatePlan: {
           transaction_plan_id: 'txplan-ember-lending-001',
         },
@@ -1552,6 +1601,7 @@ describe('createEmberLendingDomain', () => {
       requestId: 'req-ember-lending-execution-001',
       requiredControlPath: 'lending.supply',
       transactionPlanId: 'txplan-ember-lending-001',
+      anchoredPayloadRecords: [createAnchoredPayloadRecord()],
     });
 
     expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
@@ -1666,6 +1716,7 @@ describe('createEmberLendingDomain', () => {
       threadId: 'thread-1',
       state: {
         ...createManagedLifecycleState(),
+        anchoredPayloadRecords: [createAnchoredPayloadRecord()],
         lastCandidatePlan: {
           transaction_plan_id: 'txplan-ember-lending-001',
           handoff: {
@@ -1694,6 +1745,7 @@ describe('createEmberLendingDomain', () => {
       requestId: 'req-ember-lending-execution-001',
       requiredControlPath: 'lending.supply',
       transactionPlanId: 'txplan-ember-lending-001',
+      anchoredPayloadRecords: [createAnchoredPayloadRecord()],
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/test-support/sharedEmberIntegrationHarness.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/test-support/sharedEmberIntegrationHarness.ts
@@ -191,7 +191,7 @@ function createAnchoredPayloadResolver(input: {
 
       return {
         anchoredPayloadRef: request.payloadBuilderOutput.transaction_payload_ref,
-        transactionRequest,
+        transactionRequests: [transactionRequest],
         controlPath: request.payloadBuilderOutput.required_control_path,
         network: request.payloadBuilderOutput.network,
         transactionPlanId: request.transactionPlanId,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/test-support/sharedEmberIntegrationHarness.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/test-support/sharedEmberIntegrationHarness.ts
@@ -4,12 +4,12 @@ import { pathToFileURL } from 'node:url';
 
 import { encodeFunctionData, parseAbiItem, serializeTransaction, type AbiFunction } from 'viem';
 
-import type { EmberLendingPreparedUnsignedTransactionResolver } from './sharedEmberAdapter.js';
+import type { EmberLendingAnchoredPayloadResolver } from '../src/sharedEmberAdapter.js';
 
 export type StartedSharedEmberTarget = {
   baseUrl: string;
   close: () => Promise<void>;
-  resolvePreparedUnsignedTransaction?: EmberLendingPreparedUnsignedTransactionResolver;
+  anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
 };
 
 export const TEST_EMBER_LENDING_AGENT_ID = 'ember-lending';
@@ -139,33 +139,89 @@ function buildPreparedUnsignedTransactionHex(
   });
 }
 
-function createPreparedUnsignedTransactionResolver(input: {
+function buildAnchoredTransactionRequest(
+  payload: HarnessExecutionPayloadArtifact,
+): {
+  type: 'EVM_TX';
+  to: `0x${string}`;
+  value: string;
+  data: `0x${string}`;
+  chainId: string;
+} | null {
+  const target = readString(payload.target);
+  if (!target?.startsWith('0x')) {
+    return null;
+  }
+
+  return {
+    type: 'EVM_TX',
+    to: target as `0x${string}`,
+    value: payload.value ?? '0',
+    data: buildExecutionCallData(payload),
+    chainId: String(resolveExecutionChainId(payload.network)),
+  };
+}
+
+function createAnchoredPayloadResolver(input: {
   bootstrap: SharedEmberIntegrationBootstrap;
   defaultAgentId: string;
-}): EmberLendingPreparedUnsignedTransactionResolver {
-  return async (request) => {
-    const runtime =
-      input.bootstrap.subagentRuntimes?.[request.agentId] ??
-      (request.agentId === input.defaultAgentId ? createSubagentRuntime() : undefined);
-    if (!runtime) {
-      return null;
-    }
+}): EmberLendingAnchoredPayloadResolver {
+  return {
+    async anchorCandidatePlanPayload(request) {
+      const runtime =
+        input.bootstrap.subagentRuntimes?.[request.agentId] ??
+        (request.agentId === input.defaultAgentId ? createSubagentRuntime() : undefined);
+      if (!runtime) {
+        return null;
+      }
 
-    const plannedTransactionPayloadRef =
-      request.plannedTransactionPayloadRef ??
-      (request.canonicalUnsignedPayloadRef.startsWith('unsigned-')
-        ? request.canonicalUnsignedPayloadRef.slice('unsigned-'.length)
-        : null);
-    if (!plannedTransactionPayloadRef) {
-      return null;
-    }
+      const payload = await runtime.payloadStore.getExecutionPayload(
+        request.payloadBuilderOutput.transaction_payload_ref,
+      );
+      if (!payload) {
+        return null;
+      }
 
-    const payload = await runtime.payloadStore.getExecutionPayload(plannedTransactionPayloadRef);
-    if (!payload) {
-      return null;
-    }
+      const transactionRequest = buildAnchoredTransactionRequest(
+        payload as HarnessExecutionPayloadArtifact,
+      );
+      if (!transactionRequest) {
+        return null;
+      }
 
-    return buildPreparedUnsignedTransactionHex(payload as HarnessExecutionPayloadArtifact);
+      return {
+        anchoredPayloadRef: request.payloadBuilderOutput.transaction_payload_ref,
+        transactionRequest,
+        controlPath: request.payloadBuilderOutput.required_control_path,
+        network: request.payloadBuilderOutput.network,
+        transactionPlanId: request.transactionPlanId,
+      };
+    },
+
+    async resolvePreparedUnsignedTransaction(request) {
+      const runtime =
+        input.bootstrap.subagentRuntimes?.[request.agentId] ??
+        (request.agentId === input.defaultAgentId ? createSubagentRuntime() : undefined);
+      if (!runtime) {
+        return null;
+      }
+
+      const plannedTransactionPayloadRef =
+        request.plannedTransactionPayloadRef ??
+        (request.canonicalUnsignedPayloadRef.startsWith('unsigned-')
+          ? request.canonicalUnsignedPayloadRef.slice('unsigned-'.length)
+          : null);
+      if (!plannedTransactionPayloadRef) {
+        return null;
+      }
+
+      const payload = await runtime.payloadStore.getExecutionPayload(plannedTransactionPayloadRef);
+      if (!payload) {
+        return null;
+      }
+
+      return buildPreparedUnsignedTransactionHex(payload as HarnessExecutionPayloadArtifact);
+    },
   };
 }
 
@@ -486,7 +542,7 @@ export async function resolveSharedEmberTarget(input?: {
 
   return {
     ...startedTarget,
-    resolvePreparedUnsignedTransaction: createPreparedUnsignedTransactionResolver({
+    anchoredPayloadResolver: createAnchoredPayloadResolver({
       bootstrap,
       defaultAgentId: TEST_EMBER_LENDING_AGENT_ID,
     }),

--- a/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
@@ -1,9 +1,9 @@
 # ADR 0015: service-owned-onchain-actions-transaction-resolution-for-managed-lending
 
-Status: Proposed
+Status: Accepted
 Date: 2026-04-03
 
-Approval trace: Pending explicit ADR approval on issue `#567` / PR `#568`
+Approval trace: Approved on 2026-04-03 in issue `#567` comment https://github.com/EmberAGI/arbitrum-vibekit/issues/567#issuecomment-4182405423
 
 ## Context
 
@@ -11,9 +11,8 @@ Issue `#567` established that the managed lending runtime should own the
 concrete Onchain Actions adapter and keep raw transaction artifacts private
 behind the lending service boundary.
 
-This document captures the intended architecture for that slice, but the branch
-does not yet show the visible approval trace required to treat the decision as
-accepted.
+This document captures the approved architecture for that slice after the
+explicit issue-level approval trace was recorded on 2026-04-03.
 
 The first implementation slice improved the live path but left several
 important gaps:

--- a/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
@@ -1,13 +1,19 @@
 # ADR 0015: service-owned-onchain-actions-transaction-resolution-for-managed-lending
 
-Status: Accepted
+Status: Proposed
 Date: 2026-04-03
+
+Approval trace: Pending explicit ADR approval on issue `#567` / PR `#568`
 
 ## Context
 
 Issue `#567` established that the managed lending runtime should own the
 concrete Onchain Actions adapter and keep raw transaction artifacts private
 behind the lending service boundary.
+
+This document captures the intended architecture for that slice, but the branch
+does not yet show the visible approval trace required to treat the decision as
+accepted.
 
 The first implementation slice improved the live path but left several
 important gaps:
@@ -36,6 +42,9 @@ For `agent-ember-lending`:
 - the lending service owns the concrete Onchain Actions adapter
 - `create_transaction_plan` may anchor only opaque refs and stable metadata back
   into the model-visible contract
+- `create_transaction_plan` must fail closed unless the lending service can
+  complete that private anchoring step with planner metadata, managed wallet
+  context, and the anchored payload resolver in place
 - the lending service privately stores the full ordered Onchain Actions
   transaction-request sequence (`to`, `data`, `value`, `chainId`) keyed by the
   anchored payload ref

--- a/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
@@ -1,7 +1,7 @@
 # ADR 0015: service-owned-onchain-actions-transaction-resolution-for-managed-lending
 
 Status: Accepted
-Date: 2026-04-02
+Date: 2026-04-03
 
 ## Context
 
@@ -9,14 +9,19 @@ Issue `#567` established that the managed lending runtime should own the
 concrete Onchain Actions adapter and keep raw transaction artifacts private
 behind the lending service boundary.
 
-The first implementation slice improved the live path but left three important
-gaps:
+The first implementation slice improved the live path but left several
+important gaps:
 
 - token lookup only read the first paginated `/tokens` page, which broke common
   live assets such as Arbitrum USDC
 - the lending service serialized a placeholder EIP-1559 envelope with hard-coded
   nonce, gas, and fee fields instead of resolving the final signable transaction
   bytes from live execution context
+- approval-required lending plans were still truncated to the terminal
+  transaction even though the live Onchain Actions supply and repay endpoints
+  returned ordered two-transaction plans on 2026-04-03
+- anchored payload refs still lived only in a resolver-local in-memory `Map`,
+  so service restart or cross-instance execution would lose payload resolution
 - integration-only payload helpers still lived under production `src/` paths and
   a deprecated optional resolver seam still appeared in production-facing config
 
@@ -31,10 +36,14 @@ For `agent-ember-lending`:
 - the lending service owns the concrete Onchain Actions adapter
 - `create_transaction_plan` may anchor only opaque refs and stable metadata back
   into the model-visible contract
-- the lending service privately stores the terminal Onchain Actions transaction
-  request (`to`, `data`, `value`, `chainId`) keyed by the anchored payload ref
-- `request_transaction_execution` resolves that anchored transaction request back
-  inside the lending service
+- the lending service privately stores the full ordered Onchain Actions
+  transaction-request sequence (`to`, `data`, `value`, `chainId`) keyed by the
+  anchored payload ref
+- that anchored payload record lives in runtime-owned persisted domain state so
+  the lookup survives service restart and cross-instance execution on the same
+  thread
+- `request_transaction_execution` resolves the requested transaction step back
+  inside the lending service from that persisted anchored record
 - the lending service prepares the exact unsigned transaction bytes only at
   execution time, using:
   - the managed subagent wallet address
@@ -49,6 +58,8 @@ For `agent-ember-lending`:
 
 - prevents invalid signing by removing fabricated nonce and fee defaults from
   the live path
+- preserves approval-before-terminal execution order for multi-transaction
+  Onchain Actions lending plans instead of dropping the first step
 - keeps Onchain Actions integration private to the lending service instead of
   leaking transaction-construction details through Shared Ember or model-visible
   tool payloads
@@ -64,6 +75,12 @@ For `agent-ember-lending`:
 - keep serializing placeholder EIP-1559 envelopes at plan time:
   - rejected because the resulting bytes are not chain-aware and can be invalid
     once the signer has real nonce and fee context
+- store only the terminal Onchain Actions transaction request:
+  - rejected because approval-required supply and repay flows can require more
+    than one ordered transaction
+- keep anchored payload refs only in a process-local in-memory map:
+  - rejected because a service restart or second instance would lose ref
+    resolution for already-created candidate plans
 - move nonce / gas / fee preparation into Shared Ember:
   - rejected because the issue scope keeps concrete Onchain Actions payload
     ownership inside the lending service, not in the control-plane boundary
@@ -78,6 +95,10 @@ For `agent-ember-lending`:
 
 - Positive:
   - live token lookup now follows paginated token catalogs
+  - approval-required lending plans now preserve the full ordered Onchain
+    Actions transaction sequence instead of truncating to the terminal call
+  - anchored payload refs now resolve from runtime-owned persisted domain state
+    instead of only from a process-local map
   - managed lending execution signs chain-aware unsigned bytes derived from live
     wallet and RPC context
   - production config no longer advertises the deprecated optional prepared

--- a/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md
@@ -1,0 +1,94 @@
+# ADR 0015: service-owned-onchain-actions-transaction-resolution-for-managed-lending
+
+Status: Accepted
+Date: 2026-04-02
+
+## Context
+
+Issue `#567` established that the managed lending runtime should own the
+concrete Onchain Actions adapter and keep raw transaction artifacts private
+behind the lending service boundary.
+
+The first implementation slice improved the live path but left three important
+gaps:
+
+- token lookup only read the first paginated `/tokens` page, which broke common
+  live assets such as Arbitrum USDC
+- the lending service serialized a placeholder EIP-1559 envelope with hard-coded
+  nonce, gas, and fee fields instead of resolving the final signable transaction
+  bytes from live execution context
+- integration-only payload helpers still lived under production `src/` paths and
+  a deprecated optional resolver seam still appeared in production-facing config
+
+ADR 0011 already ratifies that runtime-owned assembly and private integration
+seams should not leak into downstream public boundaries. This ADR narrows that
+rule for the managed lending execution path.
+
+## Decision
+
+For `agent-ember-lending`:
+
+- the lending service owns the concrete Onchain Actions adapter
+- `create_transaction_plan` may anchor only opaque refs and stable metadata back
+  into the model-visible contract
+- the lending service privately stores the terminal Onchain Actions transaction
+  request (`to`, `data`, `value`, `chainId`) keyed by the anchored payload ref
+- `request_transaction_execution` resolves that anchored transaction request back
+  inside the lending service
+- the lending service prepares the exact unsigned transaction bytes only at
+  execution time, using:
+  - the managed subagent wallet address
+  - live chain RPC state for nonce, gas, and fee resolution
+- `agent-runtime` remains the signing boundary and still receives only the final
+  unsigned transaction bytes for signing
+- test-only Shared Ember harness helpers must live outside production `src/`
+  paths and must exercise the same `anchoredPayloadResolver` boundary rather
+  than a separate production-facing optional resolver seam
+
+## Rationale
+
+- prevents invalid signing by removing fabricated nonce and fee defaults from
+  the live path
+- keeps Onchain Actions integration private to the lending service instead of
+  leaking transaction-construction details through Shared Ember or model-visible
+  tool payloads
+- preserves the intended boundary:
+  - Shared Ember owns preparation records and opaque refs
+  - the lending service owns private payload resolution
+  - `agent-runtime` owns signing
+- makes test support match the production architectural seam so integration
+  coverage no longer depends on a misleading production helper path
+
+## Alternatives Considered
+
+- keep serializing placeholder EIP-1559 envelopes at plan time:
+  - rejected because the resulting bytes are not chain-aware and can be invalid
+    once the signer has real nonce and fee context
+- move nonce / gas / fee preparation into Shared Ember:
+  - rejected because the issue scope keeps concrete Onchain Actions payload
+    ownership inside the lending service, not in the control-plane boundary
+- extend the model-visible tool contract to carry unsigned transaction bytes:
+  - rejected because the payload should remain private behind the lending
+    service boundary
+- leave the integration harness in production `src/` as tolerated scaffolding:
+  - rejected because it teaches the wrong boundary and keeps a test-only seam in
+    production architectural paths
+
+## Consequences
+
+- Positive:
+  - live token lookup now follows paginated token catalogs
+  - managed lending execution signs chain-aware unsigned bytes derived from live
+    wallet and RPC context
+  - production config no longer advertises the deprecated optional prepared
+    unsigned-transaction resolver seam
+  - test-only Shared Ember harness code now sits under explicit test support
+- Tradeoffs:
+  - the lending runtime now depends on chain RPC access for final transaction
+    preparation in addition to the Onchain Actions API
+  - the service must own a little more transaction-preparation logic before
+    delegating to `agent-runtime` for signing
+- Follow-on work:
+  - keep the app README and C4 docs aligned with the anchored-request boundary
+  - keep integration fixtures exercising the `anchoredPayloadResolver` seam
+    instead of reintroducing alternate production-shaped helpers

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -16,3 +16,4 @@
 | [0012](./0012-runtime-family-neutral-web-thread-contract.md) | Runtime-family-neutral web thread contract | Accepted | 2026-03-30 |
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
 | [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |
+| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-02 |

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -16,4 +16,4 @@
 | [0012](./0012-runtime-family-neutral-web-thread-contract.md) | Runtime-family-neutral web thread contract | Accepted | 2026-03-30 |
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
 | [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |
-| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Proposed | 2026-04-03 |
+| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-03 |

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -16,4 +16,4 @@
 | [0012](./0012-runtime-family-neutral-web-thread-contract.md) | Runtime-family-neutral web thread contract | Accepted | 2026-03-30 |
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
 | [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |
-| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-02 |
+| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-03 |

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -16,4 +16,4 @@
 | [0012](./0012-runtime-family-neutral-web-thread-contract.md) | Runtime-family-neutral web thread contract | Accepted | 2026-03-30 |
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
 | [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |
-| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-03 |
+| [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Proposed | 2026-04-03 |

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -37,6 +37,7 @@ Related docs:
 - `docs/adr/0008-runtime-agnostic-shared-contract-extraction.md`
 - `docs/adr/0011-blessed-agent-runtime-factory-and-runtime-owned-projection-assembly.md`
 - `docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md`
+- `docs/adr/0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md`
 
 ## 2. Boundary rules
 
@@ -169,9 +170,10 @@ Container responsibilities:
   - After healthy identity preflight plus onboarding, the first healthy `subagent.readExecutionContext.v1` read is expected to expose a non-null `subagent_wallet_address`.
   - `agent-ember-lending` keeps `request_transaction_execution` as one
     model-visible tool while internally composing runtime-owned redelegation
-    typed-data signing, concrete-service prepared unsigned-transaction
-    resolution, runtime-owned execution signing, and Shared Ember
-    submission/finalization.
+    typed-data signing, service-owned anchored Onchain Actions terminal
+    transaction-request resolution, chain-aware unsigned-transaction
+    preparation with the managed wallet plus RPC state, runtime-owned execution
+    signing, and Shared Ember submission/finalization.
   - The repo-local validation lane for the managed-identity boundary is
     `pnpm smoke:managed-identities`, and the repo-backed validation lane for
     the real redelegation signing seam is

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -175,6 +175,11 @@ Container responsibilities:
     state, chain-aware unsigned-transaction preparation with the managed wallet
     plus RPC state, runtime-owned execution signing, and Shared Ember
     submission/finalization.
+  - `agent-ember-lending` also fails `create_transaction_plan` closed unless it
+    can persist the planner-returned payload behind that service-owned anchoring
+    boundary; missing planner metadata, missing managed wallet context, or
+    missing resolver wiring must stop plan creation before local state records a
+    candidate plan as executable.
   - The repo-local validation lane for the managed-identity boundary is
     `pnpm smoke:managed-identities`, and the repo-backed validation lane for
     the real redelegation signing seam is

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -170,10 +170,11 @@ Container responsibilities:
   - After healthy identity preflight plus onboarding, the first healthy `subagent.readExecutionContext.v1` read is expected to expose a non-null `subagent_wallet_address`.
   - `agent-ember-lending` keeps `request_transaction_execution` as one
     model-visible tool while internally composing runtime-owned redelegation
-    typed-data signing, service-owned anchored Onchain Actions terminal
-    transaction-request resolution, chain-aware unsigned-transaction
-    preparation with the managed wallet plus RPC state, runtime-owned execution
-    signing, and Shared Ember submission/finalization.
+    typed-data signing, service-owned anchored Onchain Actions ordered
+    transaction-request persistence and step resolution in runtime-owned domain
+    state, chain-aware unsigned-transaction preparation with the managed wallet
+    plus RPC state, runtime-owned execution signing, and Shared Ember
+    submission/finalization.
   - The repo-local validation lane for the managed-identity boundary is
     `pnpm smoke:managed-identities`, and the repo-backed validation lane for
     the real redelegation signing seam is

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -199,6 +199,7 @@ Current concrete managed-path specialization:
   - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address
   - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
+  - treats candidate-plan creation as complete only after the lending service has privately anchored that planner-returned payload; missing planner metadata, missing managed wallet context, or missing anchored-resolver wiring must fail closed instead of leaving an apparently executable local plan
   - keeps `request_transaction_execution` as one model-visible tool while
     internally composing Shared Ember execution preparation, runtime-owned OWS
     redelegation typed-data signing, service-owned anchored Onchain Actions

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -201,9 +201,10 @@ Current concrete managed-path specialization:
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
   - keeps `request_transaction_execution` as one model-visible tool while
     internally composing Shared Ember execution preparation, runtime-owned OWS
-    redelegation typed-data signing, concrete-service prepared unsigned-transaction
-    resolution, runtime-owned execution signing, and Ember-owned
-    submission/finalization
+    redelegation typed-data signing, service-owned anchored Onchain Actions
+    terminal transaction-request resolution, chain-aware unsigned-transaction
+    preparation with the managed wallet plus RPC state, runtime-owned
+    execution signing, and Ember-owned submission/finalization
   - treats `authority_preparation_needed` as an internal wait state and re-polls the Shared Ember execution request with a stage-scoped retry idempotency key instead of exposing a second tool or reusing the original acknowledged request key
   - reconciles dropped signed-transaction submit responses through the Shared Ember committed-event outbox before replaying an idempotent submit
   - fails closed when the direct OWS identity/signing path cannot prove it matches the prepared dedicated subagent signing package

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -202,9 +202,10 @@ Current concrete managed-path specialization:
   - keeps `request_transaction_execution` as one model-visible tool while
     internally composing Shared Ember execution preparation, runtime-owned OWS
     redelegation typed-data signing, service-owned anchored Onchain Actions
-    terminal transaction-request resolution, chain-aware unsigned-transaction
-    preparation with the managed wallet plus RPC state, runtime-owned
-    execution signing, and Ember-owned submission/finalization
+    ordered transaction-request persistence and step resolution in runtime-owned
+    domain state, chain-aware unsigned-transaction preparation with the managed
+    wallet plus RPC state, runtime-owned execution signing, and Ember-owned
+    submission/finalization
   - treats `authority_preparation_needed` as an internal wait state and re-polls the Shared Ember execution request with a stage-scoped retry idempotency key instead of exposing a second tool or reusing the original acknowledged request key
   - reconciles dropped signed-transaction submit responses through the Shared Ember committed-event outbox before replaying an idempotent submit
   - fails closed when the direct OWS identity/signing path cannot prove it matches the prepared dedicated subagent signing package

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -51,7 +51,12 @@ sequenceDiagram
   EL->>SE: subagent.createTransactionPlan.v1
   Note over SE: Resolve planner-owned payload_builder_output through the Shared Ember planner path before materializing the candidate plan
   SE-->>EL: candidate_plan + revision
-  EL-->>Runtime: candidate plan artifact + summary
+  Note over EL: Fail closed unless the lending service can privately anchor the returned payload ref and ordered transaction request sequence.
+  alt anchoring succeeds
+    EL-->>Runtime: candidate plan artifact + summary
+  else metadata or resolver is missing
+    EL-->>Runtime: failed status; do not record a locally executable candidate plan
+  end
 
   User->>Web: request_transaction_execution
   Web->>Runtime: run(request_transaction_execution)

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -14,6 +14,7 @@ runtime-owned OWS-core signing, and Shared Ember submission behind
   - `create_escalation_request`
 - `request_transaction_execution` remains a model-visible tool on the lending agent. It is not a separate web command-lane concept.
 - Runtime-only behavior remains hidden:
+  - fail-closed candidate-plan anchoring behind the lending-service payload boundary
   - execution preparation
   - authority-preparation retry loops
   - stage-scoped idempotency for authority-preparation re-polls
@@ -125,6 +126,10 @@ sequenceDiagram
   Actions transaction step over time; the lending service must preserve the full
   ordered transaction-request sequence instead of truncating to the terminal
   call.
+- `create_transaction_plan` should succeed only after the lending service has
+  privately anchored the planner-returned payload; missing planner metadata,
+  missing managed wallet context, or missing anchored-resolver wiring must fail
+  the plan-creation attempt before local state treats the plan as executable.
 - Authority-preparation re-polls must not reuse the original request idempotency key once Shared Ember has already acknowledged the waiting state; a stage-scoped retry key lets the real upstream contract advance after the missing authority is repaired.
 - After a local transport interruption during `subagent.submitSignedTransaction.v1`, Ember Lending should first reconcile through the committed-event outbox before deciding whether an idempotent resubmit is still needed.
 - When the committed-event outbox already contains the execution event, recovery should preserve `transaction_hash` from that event payload while converging on the terminal status.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -35,7 +35,8 @@ runtime-owned OWS-core signing, and Shared Ember submission behind
 - Ember Lending owns:
   - runtime-owned OWS-core-backed wallet identity resolution
   - runtime-owned OWS redelegation typed-data signing
-  - concrete-service prepared unsigned-transaction resolution
+  - concrete-service prepared unsigned-transaction resolution from persisted
+    anchored transaction-request sequences
   - runtime-owned OWS execution signing
   - translation of upstream execution outcomes into the minimal runtime-facing result
 - Fail-closed signing rule:
@@ -91,7 +92,7 @@ sequenceDiagram
     OWS-->>EL: signed redelegation
     EL->>SE: orchestrator.registerSignedRedelegation.v1(signed_redelegation + ids)
     SE-->>EL: execution_result.phase=ready_for_execution_signing
-    Note over EL,SE: Resolve the canonical unsigned payload ref through the concrete service integration layer when Shared Ember omits inline unsigned transaction hex.
+    Note over EL,SE: Resolve the canonical unsigned payload ref through the concrete service integration layer from the persisted anchored transaction-request sequence when Shared Ember omits inline unsigned transaction hex.
     EL->>OWS: sign execution package
     OWS-->>EL: signer_address + raw_transaction
     EL->>SE: subagent.submitSignedTransaction.v1(signed_transaction + ids)
@@ -99,7 +100,7 @@ sequenceDiagram
     EL-->>Runtime: minimal status + tx hash when available
   else ready for execution signing
     SE-->>EL: execution_result.phase=ready_for_execution_signing + execution_signing_package + ids
-    Note over EL,SE: Resolve the canonical unsigned payload ref through the concrete service integration layer when Shared Ember omits inline unsigned transaction hex.
+    Note over EL,SE: Resolve the canonical unsigned payload ref through the concrete service integration layer from the persisted anchored transaction-request sequence when Shared Ember omits inline unsigned transaction hex.
     EL->>OWS: sign execution package
     OWS-->>EL: signer_address + raw_transaction
     EL->>SE: subagent.submitSignedTransaction.v1(signed_transaction + ids)
@@ -120,6 +121,10 @@ sequenceDiagram
 - Only Shared Ember capital/control-plane blockers should flow into `create_escalation_request`.
 - Direct OWS identity, signing, or transport failures should remain local execution failures rather than escalations.
 - Multi-call retries must be idempotent and must not create a second signing or submission side effect when the runtime retries after a conflict or transport interruption.
+- Approval-required lending plans may resolve more than one anchored Onchain
+  Actions transaction step over time; the lending service must preserve the full
+  ordered transaction-request sequence instead of truncating to the terminal
+  call.
 - Authority-preparation re-polls must not reuse the original request idempotency key once Shared Ember has already acknowledged the waiting state; a stage-scoped retry key lets the real upstream contract advance after the missing authority is repaired.
 - After a local transport interruption during `subagent.submitSignedTransaction.v1`, Ember Lending should first reconcile through the committed-event outbox before deciding whether an idempotent resubmit is still needed.
 - When the committed-event outbox already contains the execution event, recovery should preserve `transaction_hash` from that event payload while converging on the terminal status.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -64,7 +64,12 @@ sequenceDiagram
   SE->>Planner: plan from mandate + execution context
   Planner-->>SE: candidate plan
   SE-->>EL: candidate_plan + revision
-  EL-->>Runtime: candidate plan artifact
+  Note over EL: Privately anchor the planner-returned payload behind the lending-service Onchain Actions boundary before recording a locally executable candidate plan.
+  alt anchoring succeeds
+    EL-->>Runtime: candidate plan artifact
+  else anchoring prerequisites or resolver are missing
+    EL-->>Runtime: failed status; candidate plan is not recorded as locally executable
+  end
 
   User->>Web: request_transaction_execution
   Web->>Runtime: run(request_transaction_execution)

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -701,10 +701,13 @@ importers:
     dependencies:
       agent-runtime:
         specifier: workspace:^
-        version: file:agent-runtime(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
+        version: file:agent-runtime(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
       viem:
         specifier: 'catalog:'
-        version: 2.38.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.38.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.12
     dependenciesMeta:
       agent-runtime:
         injected: false
@@ -979,7 +982,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-runtime-langgraph:
     dependencies:
@@ -19110,6 +19113,12 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
+  '@anthropic-ai/sdk@0.73.0(zod@4.1.12)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.1.12
+
   '@anthropic-ai/sdk@0.73.0(zod@4.3.5)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -23299,6 +23308,18 @@ snapshots:
       - ws
       - zod
 
+  '@mariozechner/pi-agent-core@0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-ai@0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
@@ -23362,6 +23383,30 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.22.0
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.1.12)
+      '@aws-sdk/client-bedrock-runtime': 3.1013.0
+      '@google/genai': 1.46.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@mistralai/mistralai': 1.14.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@sinclair/typebox': 0.34.48
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.22.0
+      zod-to-json-schema: 3.25.1(zod@4.1.12)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -32849,6 +32894,27 @@ snapshots:
       - ws
       - zod
 
+  agent-runtime-pi@file:agent-runtime/lib/pi(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12):
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(express@5.1.0)
+      '@ag-ui/client': 0.0.47
+      '@ag-ui/core': 0.0.47
+      '@mariozechner/pi-agent-core': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      agent-runtime-postgres: file:agent-runtime/lib/postgres
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@grpc/grpc-js'
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - express
+      - pg-native
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   agent-runtime-pi@file:agent-runtime/lib/pi(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5):
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(express@5.1.0)
@@ -32905,6 +32971,27 @@ snapshots:
       '@mariozechner/pi-ai': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@open-wallet-standard/core': 1.2.0
       agent-runtime-pi: file:agent-runtime/lib/pi(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@grpc/grpc-js'
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - express
+      - pg-native
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  agent-runtime@file:agent-runtime(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12):
+    dependencies:
+      '@ag-ui/client': 0.0.47
+      '@ag-ui/core': 0.0.47
+      '@mariozechner/pi-agent-core': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      '@open-wallet-standard/core': 1.2.0
+      agent-runtime-pi: file:agent-runtime/lib/pi(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
       - '@grpc/grpc-js'
@@ -39902,7 +39989,6 @@ snapshots:
     optionalDependencies:
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 4.1.12
-    optional: true
 
   openai@6.26.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- anchor planner-returned lending payload refs behind a service-owned Onchain Actions adapter
- resolve prepared unsigned transactions from the live gateway path instead of relying only on the harness seam
- add resolver, domain, and gateway regression coverage plus env and README updates

## Testing
- `pnpm test:unit`
- `pnpm build`

Closes #567
Related to #538
