### PR TITLE
fix(agent-gmx-allora): swap selected funding token into usdc

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
@@ -39,7 +39,10 @@ import {
 import { runCycleCommandNode } from './workflow/nodes/runCycleCommand.js';
 import { summarizeNode } from './workflow/nodes/summarize.js';
 import { syncStateNode } from './workflow/nodes/syncState.js';
-import { resolveNextOnboardingNode } from './workflow/onboardingRouting.js';
+import {
+  resolveNextOnboardingNode,
+  resolvePostFundingTokenNode,
+} from './workflow/onboardingRouting.js';
 
 await setupAgentLocalE2EMocksIfNeeded();
 await configureLangGraphApiCheckpointer();
@@ -98,8 +101,10 @@ function resolvePostRunCycle(
   return target;
 }
 
-function resolvePostFundingTokenInput(state: ClmmState): 'collectSetupInput' | 'collectDelegations' {
-  const target = state.thread.operatorInput ? 'collectDelegations' : 'collectSetupInput';
+function resolvePostFundingTokenInput(
+  state: ClmmState,
+): 'collectSetupInput' | 'collectFundingTokenInput' | 'collectDelegations' | 'prepareOperator' {
+  const target = resolvePostFundingTokenNode(state);
   logRouteDecision('collectFundingTokenInput', target, {
     hasOperatorInput: Boolean(state.thread.operatorInput),
     hasFundingTokenInput: Boolean(state.thread.fundingTokenInput),

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/domain/types.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/domain/types.ts
@@ -64,6 +64,7 @@ export const FundingTokenInputSchema = z.object({
 type FundingTokenInputBase = z.infer<typeof FundingTokenInputSchema>;
 export interface FundingTokenInput extends FundingTokenInputBase {
   fundingTokenAddress: `0x${string}`;
+  collateralTokenAddress: `0x${string}`;
 }
 
 export type ResolvedGmxConfig = {
@@ -75,6 +76,7 @@ export type ResolvedGmxConfig = {
   delegateeWalletAddress: `0x${string}`;
   baseContributionUsd: number;
   fundingTokenAddress: `0x${string}`;
+  collateralTokenAddress: `0x${string}`;
   targetMarket: GmxMarket;
   maxLeverage: number;
 };

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/domain/types.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/domain/types.ts
@@ -65,6 +65,10 @@ type FundingTokenInputBase = z.infer<typeof FundingTokenInputSchema>;
 export interface FundingTokenInput extends FundingTokenInputBase {
   fundingTokenAddress: `0x${string}`;
   collateralTokenAddress: `0x${string}`;
+  fundingTokenDecimals?: number;
+  fundingTokenBalanceBaseUnits?: string;
+  fundingTokenUsdPrice?: number;
+  collateralTokenDecimals?: number;
 }
 
 export type ResolvedGmxConfig = {
@@ -77,6 +81,10 @@ export type ResolvedGmxConfig = {
   baseContributionUsd: number;
   fundingTokenAddress: `0x${string}`;
   collateralTokenAddress: `0x${string}`;
+  fundingTokenDecimals?: number;
+  fundingTokenBalanceBaseUnits?: string;
+  fundingTokenUsdPrice?: number;
+  collateralTokenDecimals?: number;
   targetMarket: GmxMarket;
   maxLeverage: number;
 };

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/context.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/context.unit.test.ts
@@ -106,6 +106,7 @@ describe('GMX thread lifecycle invariants', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         selectedPool: {
           address: '0x3333333333333333333333333333333333333333',

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.ts
@@ -1,8 +1,9 @@
+import { formatUnits, parseUnits } from 'viem';
+
 import type { OnchainClients } from '../clients/clients.js';
 import {
   OnchainActionsRequestError,
   type OnchainActionsClient,
-  type PerpetualLongRequest,
   type TransactionPlan,
 } from '../clients/onchainActions.js';
 import { redeemDelegationsAndExecuteTransactions } from '../core/delegatedExecution.js';
@@ -269,7 +270,16 @@ function summarizeOnchainActionsError(error: unknown): Record<string, unknown> {
   };
 }
 
-type PerpetualOpenRequest = PerpetualLongRequest | PerpetualShortRequest;
+type PerpetualOpenRequest = Extract<ExecutionPlan, { action: 'long' | 'short' }>['request'];
+export type CollateralSwapFundingEstimate = {
+  fromTokenDecimals?: number;
+  fromTokenBalanceBaseUnits?: string;
+  fromTokenUsdPrice?: number;
+  toTokenDecimals?: number;
+  toTokenUsdPrice?: number;
+};
+
+const COLLATERAL_SWAP_SLIPPAGE_MULTIPLIER = 1.05;
 
 function requiresCollateralSwap(request: PerpetualOpenRequest): boolean {
   return request.payTokenAddress.toLowerCase() !== request.collateralTokenAddress.toLowerCase();
@@ -285,37 +295,134 @@ function normalizeOpenRequestForExecution(request: PerpetualOpenRequest): Perpet
   };
 }
 
+function estimateCollateralSwapExactInAmount(params: {
+  amountOutBaseUnits: string;
+  estimate?: CollateralSwapFundingEstimate;
+}): string {
+  const estimate = params.estimate;
+  if (
+    estimate?.fromTokenDecimals === undefined ||
+    estimate.toTokenDecimals === undefined ||
+    estimate.fromTokenUsdPrice === undefined ||
+    estimate.fromTokenUsdPrice <= 0
+  ) {
+    throw new Error(
+      'Unable to estimate exact-in swap amount for the selected funding token. Retry onboarding and reselect a funding token with priced balance data.',
+    );
+  }
+
+  let amountOutBaseUnits: bigint;
+  try {
+    amountOutBaseUnits = BigInt(params.amountOutBaseUnits);
+  } catch {
+    throw new Error(`Unable to parse collateral amount "${params.amountOutBaseUnits}" for swap planning.`);
+  }
+  if (amountOutBaseUnits <= 0n) {
+    throw new Error('Collateral amount must be positive to plan a funding-token swap.');
+  }
+
+  const toTokenUsdPrice = estimate.toTokenUsdPrice ?? 1;
+  if (!Number.isFinite(toTokenUsdPrice) || toTokenUsdPrice <= 0) {
+    throw new Error('Unable to estimate exact-in swap amount because the collateral token price is unavailable.');
+  }
+
+  const amountOut = Number(formatUnits(amountOutBaseUnits, estimate.toTokenDecimals));
+  if (!Number.isFinite(amountOut) || amountOut <= 0) {
+    throw new Error('Unable to estimate exact-in swap amount because the collateral output amount is invalid.');
+  }
+
+  const usdOut = amountOut * toTokenUsdPrice;
+  const fromAmount = (usdOut * COLLATERAL_SWAP_SLIPPAGE_MULTIPLIER) / estimate.fromTokenUsdPrice;
+  if (!Number.isFinite(fromAmount) || fromAmount <= 0) {
+    throw new Error('Unable to estimate exact-in swap amount because the funding token price is invalid.');
+  }
+
+  let amountInBaseUnits = parseUnits(fromAmount.toFixed(estimate.fromTokenDecimals), estimate.fromTokenDecimals);
+  if (amountInBaseUnits <= 0n) {
+    amountInBaseUnits = 1n;
+  }
+
+  if (estimate.fromTokenBalanceBaseUnits) {
+    let maxAmountInBaseUnits: bigint;
+    try {
+      maxAmountInBaseUnits = BigInt(estimate.fromTokenBalanceBaseUnits);
+    } catch {
+      throw new Error('Unable to estimate exact-in swap amount because the funding token balance is invalid.');
+    }
+    if (amountInBaseUnits > maxAmountInBaseUnits) {
+      throw new Error(
+        'Selected funding token balance no longer covers the USDC collateral swap. Retry onboarding and reselect a token.',
+      );
+    }
+  }
+
+  return amountInBaseUnits.toString();
+}
+
 async function createOpenPlan(params: {
   client: Pick<OnchainActionsClient, 'createSwap' | 'createPerpetualLong' | 'createPerpetualShort'>;
   action: 'long' | 'short';
   request: PerpetualOpenRequest;
+  swapFundingEstimate?: CollateralSwapFundingEstimate;
 }): Promise<TransactionPlan[]> {
   const transactions: TransactionPlan[] = [];
 
   if (requiresCollateralSwap(params.request)) {
-    const swapResponse = await params.client.createSwap({
-      walletAddress: params.request.walletAddress,
-      amount: params.request.amount,
-      amountType: 'exactOut',
-      fromTokenUid: {
-        chainId: params.request.chainId,
-        address: params.request.payTokenAddress,
-      },
-      toTokenUid: {
-        chainId: params.request.chainId,
-        address: params.request.collateralTokenAddress,
-      },
-    });
-    transactions.push(...swapResponse.transactions);
+    transactions.push(
+      ...(await createCollateralSwapTransactions({
+        client: params.client,
+        request: params.request,
+        swapFundingEstimate: params.swapFundingEstimate,
+      })),
+    );
   }
 
+  transactions.push(
+    ...(await createPerpetualOpenTransactions({
+      client: params.client,
+      action: params.action,
+      request: params.request,
+    })),
+  );
+  return transactions;
+}
+
+async function createCollateralSwapTransactions(params: {
+  client: Pick<OnchainActionsClient, 'createSwap'>;
+  request: PerpetualOpenRequest;
+  swapFundingEstimate?: CollateralSwapFundingEstimate;
+}): Promise<TransactionPlan[]> {
+  const swapAmount = estimateCollateralSwapExactInAmount({
+    amountOutBaseUnits: params.request.amount,
+    estimate: params.swapFundingEstimate,
+  });
+  const swapResponse = await params.client.createSwap({
+    walletAddress: params.request.walletAddress,
+    amount: swapAmount,
+    amountType: 'exactIn',
+    fromTokenUid: {
+      chainId: params.request.chainId,
+      address: params.request.payTokenAddress,
+    },
+    toTokenUid: {
+      chainId: params.request.chainId,
+      address: params.request.collateralTokenAddress,
+    },
+  });
+  return swapResponse.transactions;
+}
+
+async function createPerpetualOpenTransactions(params: {
+  client: Pick<OnchainActionsClient, 'createPerpetualLong' | 'createPerpetualShort'>;
+  action: 'long' | 'short';
+  request: PerpetualOpenRequest;
+}): Promise<TransactionPlan[]> {
   const normalizedRequest = normalizeOpenRequestForExecution(params.request);
   const openResponse =
     params.action === 'long'
       ? await params.client.createPerpetualLong(normalizedRequest)
       : await params.client.createPerpetualShort(normalizedRequest);
-  transactions.push(...openResponse.transactions);
-  return transactions;
+  return openResponse.transactions;
 }
 
 export async function executePerpetualPlan(params: {
@@ -334,6 +441,7 @@ export async function executePerpetualPlan(params: {
   delegationBundle?: DelegationBundle;
   delegatorWalletAddress?: `0x${string}`;
   delegateeWalletAddress?: `0x${string}`;
+  swapFundingEstimate?: CollateralSwapFundingEstimate;
 }): Promise<ExecutionResult> {
   const { plan } = params;
 
@@ -360,10 +468,53 @@ export async function executePerpetualPlan(params: {
 
   try {
     if (plan.action === 'long') {
+      if (params.txExecutionMode === 'execute' && requiresCollateralSwap(plan.request)) {
+        const swapTransactions = await createCollateralSwapTransactions({
+          client: params.client,
+          request: plan.request,
+          swapFundingEstimate: params.swapFundingEstimate,
+        });
+        logInfo('executePerpetualPlan: collateral swap plan received', {
+          action: plan.action,
+          phase: 'swap',
+          ...summarizePlannedTransactions(swapTransactions),
+        });
+        const swapExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: swapTransactions,
+          delegationBundle: delegation,
+        });
+
+        const openTransactions = await createPerpetualOpenTransactions({
+          client: params.client,
+          action: 'long',
+          request: plan.request,
+        });
+        logInfo('executePerpetualPlan: onchain-actions plan received', {
+          action: plan.action,
+          phase: 'open',
+          ...summarizePlannedTransactions(openTransactions),
+        });
+        const openExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: openTransactions,
+          delegationBundle: delegation,
+        });
+        return {
+          action: plan.action,
+          ok: true,
+          transactions: [...swapTransactions, ...openTransactions],
+          txHashes: [...swapExecution.txHashes, ...openExecution.txHashes],
+          lastTxHash: openExecution.lastTxHash ?? swapExecution.lastTxHash,
+        };
+      }
       const transactions = await createOpenPlan({
         client: params.client,
         action: 'long',
         request: plan.request,
+        swapFundingEstimate: params.swapFundingEstimate,
       });
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
@@ -384,10 +535,53 @@ export async function executePerpetualPlan(params: {
       };
     }
     if (plan.action === 'short') {
+      if (params.txExecutionMode === 'execute' && requiresCollateralSwap(plan.request)) {
+        const swapTransactions = await createCollateralSwapTransactions({
+          client: params.client,
+          request: plan.request,
+          swapFundingEstimate: params.swapFundingEstimate,
+        });
+        logInfo('executePerpetualPlan: collateral swap plan received', {
+          action: plan.action,
+          phase: 'swap',
+          ...summarizePlannedTransactions(swapTransactions),
+        });
+        const swapExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: swapTransactions,
+          delegationBundle: delegation,
+        });
+
+        const openTransactions = await createPerpetualOpenTransactions({
+          client: params.client,
+          action: 'short',
+          request: plan.request,
+        });
+        logInfo('executePerpetualPlan: onchain-actions plan received', {
+          action: plan.action,
+          phase: 'open',
+          ...summarizePlannedTransactions(openTransactions),
+        });
+        const openExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: openTransactions,
+          delegationBundle: delegation,
+        });
+        return {
+          action: plan.action,
+          ok: true,
+          transactions: [...swapTransactions, ...openTransactions],
+          txHashes: [...swapExecution.txHashes, ...openExecution.txHashes],
+          lastTxHash: openExecution.lastTxHash ?? swapExecution.lastTxHash,
+        };
+      }
       const transactions = await createOpenPlan({
         client: params.client,
         action: 'short',
         request: plan.request,
+        swapFundingEstimate: params.swapFundingEstimate,
       });
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
@@ -434,10 +628,65 @@ export async function executePerpetualPlan(params: {
         ...summarizePlannedTransactions(closeResponse.transactions),
       });
       const nextPositionSide = resolveFlipSide(plan.closeRequest.positionSide);
+      if (params.txExecutionMode === 'execute' && requiresCollateralSwap(plan.openRequest)) {
+        const closeExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: closeResponse.transactions,
+          delegationBundle: delegation,
+        });
+        const swapTransactions = await createCollateralSwapTransactions({
+          client: params.client,
+          request: plan.openRequest,
+          swapFundingEstimate: params.swapFundingEstimate,
+        });
+        logInfo('executePerpetualPlan: collateral swap plan received', {
+          action: plan.action,
+          phase: 'swap',
+          nextPositionSide,
+          ...summarizePlannedTransactions(swapTransactions),
+        });
+        const swapExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: swapTransactions,
+          delegationBundle: delegation,
+        });
+        const openTransactions = await createPerpetualOpenTransactions({
+          client: params.client,
+          action: nextPositionSide,
+          request: plan.openRequest,
+        });
+        logInfo('executePerpetualPlan: onchain-actions reopen plan received', {
+          action: plan.action,
+          nextPositionSide,
+          phase: 'open',
+          ...summarizePlannedTransactions(openTransactions),
+        });
+        const openExecution = await planOrExecuteTransactions({
+          txExecutionMode: params.txExecutionMode,
+          clients: params.clients,
+          transactions: openTransactions,
+          delegationBundle: delegation,
+        });
+        return {
+          action: plan.action,
+          ok: true,
+          transactions: [...closeResponse.transactions, ...swapTransactions, ...openTransactions],
+          txHashes: [
+            ...closeExecution.txHashes,
+            ...swapExecution.txHashes,
+            ...openExecution.txHashes,
+          ],
+          lastTxHash:
+            openExecution.lastTxHash ?? swapExecution.lastTxHash ?? closeExecution.lastTxHash,
+        };
+      }
       const openTransactions = await createOpenPlan({
         client: params.client,
         action: nextPositionSide,
         request: plan.openRequest,
+        swapFundingEstimate: params.swapFundingEstimate,
       });
       logInfo('executePerpetualPlan: onchain-actions reopen plan received', {
         action: plan.action,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.ts
@@ -2,7 +2,7 @@ import type { OnchainClients } from '../clients/clients.js';
 import {
   OnchainActionsRequestError,
   type OnchainActionsClient,
-  type PerpetualShortRequest,
+  type PerpetualLongRequest,
   type TransactionPlan,
 } from '../clients/onchainActions.js';
 import { redeemDelegationsAndExecuteTransactions } from '../core/delegatedExecution.js';
@@ -269,10 +269,63 @@ function summarizeOnchainActionsError(error: unknown): Record<string, unknown> {
   };
 }
 
+type PerpetualOpenRequest = PerpetualLongRequest | PerpetualShortRequest;
+
+function requiresCollateralSwap(request: PerpetualOpenRequest): boolean {
+  return request.payTokenAddress.toLowerCase() !== request.collateralTokenAddress.toLowerCase();
+}
+
+function normalizeOpenRequestForExecution(request: PerpetualOpenRequest): PerpetualOpenRequest {
+  if (!requiresCollateralSwap(request)) {
+    return request;
+  }
+  return {
+    ...request,
+    payTokenAddress: request.collateralTokenAddress,
+  };
+}
+
+async function createOpenPlan(params: {
+  client: Pick<OnchainActionsClient, 'createSwap' | 'createPerpetualLong' | 'createPerpetualShort'>;
+  action: 'long' | 'short';
+  request: PerpetualOpenRequest;
+}): Promise<TransactionPlan[]> {
+  const transactions: TransactionPlan[] = [];
+
+  if (requiresCollateralSwap(params.request)) {
+    const swapResponse = await params.client.createSwap({
+      walletAddress: params.request.walletAddress,
+      amount: params.request.amount,
+      amountType: 'exactOut',
+      fromTokenUid: {
+        chainId: params.request.chainId,
+        address: params.request.payTokenAddress,
+      },
+      toTokenUid: {
+        chainId: params.request.chainId,
+        address: params.request.collateralTokenAddress,
+      },
+    });
+    transactions.push(...swapResponse.transactions);
+  }
+
+  const normalizedRequest = normalizeOpenRequestForExecution(params.request);
+  const openResponse =
+    params.action === 'long'
+      ? await params.client.createPerpetualLong(normalizedRequest)
+      : await params.client.createPerpetualShort(normalizedRequest);
+  transactions.push(...openResponse.transactions);
+  return transactions;
+}
+
 export async function executePerpetualPlan(params: {
   client: Pick<
     OnchainActionsClient,
-    'createPerpetualLong' | 'createPerpetualShort' | 'createPerpetualClose' | 'createPerpetualReduce'
+    | 'createSwap'
+    | 'createPerpetualLong'
+    | 'createPerpetualShort'
+    | 'createPerpetualClose'
+    | 'createPerpetualReduce'
   >;
   plan: ExecutionPlan;
   txExecutionMode: 'plan' | 'execute';
@@ -307,41 +360,49 @@ export async function executePerpetualPlan(params: {
 
   try {
     if (plan.action === 'long') {
-      const response = await params.client.createPerpetualLong(plan.request);
+      const transactions = await createOpenPlan({
+        client: params.client,
+        action: 'long',
+        request: plan.request,
+      });
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
-        ...summarizePlannedTransactions(response.transactions),
+        ...summarizePlannedTransactions(transactions),
       });
       const execution = await planOrExecuteTransactions({
         txExecutionMode: params.txExecutionMode,
         clients: params.clients,
-        transactions: response.transactions,
+        transactions,
         delegationBundle: delegation,
       });
       return {
         action: plan.action,
         ok: true,
-        transactions: response.transactions,
+        transactions,
         txHashes: execution.txHashes,
         lastTxHash: execution.lastTxHash,
       };
     }
     if (plan.action === 'short') {
-      const response = await params.client.createPerpetualShort(plan.request);
+      const transactions = await createOpenPlan({
+        client: params.client,
+        action: 'short',
+        request: plan.request,
+      });
       logInfo('executePerpetualPlan: onchain-actions plan received', {
         action: plan.action,
-        ...summarizePlannedTransactions(response.transactions),
+        ...summarizePlannedTransactions(transactions),
       });
       const execution = await planOrExecuteTransactions({
         txExecutionMode: params.txExecutionMode,
         clients: params.clients,
-        transactions: response.transactions,
+        transactions,
         delegationBundle: delegation,
       });
       return {
         action: plan.action,
         ok: true,
-        transactions: response.transactions,
+        transactions,
         txHashes: execution.txHashes,
         lastTxHash: execution.lastTxHash,
       };
@@ -373,17 +434,17 @@ export async function executePerpetualPlan(params: {
         ...summarizePlannedTransactions(closeResponse.transactions),
       });
       const nextPositionSide = resolveFlipSide(plan.closeRequest.positionSide);
-      const shortOpenRequest: PerpetualShortRequest = plan.openRequest;
-      const openResponse =
-        nextPositionSide === 'long'
-          ? await params.client.createPerpetualLong(plan.openRequest)
-          : await params.client.createPerpetualShort(shortOpenRequest);
+      const openTransactions = await createOpenPlan({
+        client: params.client,
+        action: nextPositionSide,
+        request: plan.openRequest,
+      });
       logInfo('executePerpetualPlan: onchain-actions reopen plan received', {
         action: plan.action,
         nextPositionSide,
-        ...summarizePlannedTransactions(openResponse.transactions),
+        ...summarizePlannedTransactions(openTransactions),
       });
-      const transactions = [...closeResponse.transactions, ...openResponse.transactions];
+      const transactions = [...closeResponse.transactions, ...openTransactions];
       const execution = await planOrExecuteTransactions({
         txExecutionMode: params.txExecutionMode,
         clients: params.clients,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.unit.test.ts
@@ -7,10 +7,12 @@ import type { DelegationBundle } from './context.js';
 import { executePerpetualPlan } from './execution.js';
 
 const {
+  createSwapMock,
   executeTransactionMock,
   redeemDelegationsAndExecuteTransactionsMock,
 } =
   vi.hoisted(() => ({
+    createSwapMock: vi.fn(),
     executeTransactionMock: vi.fn(),
     redeemDelegationsAndExecuteTransactionsMock: vi.fn(),
   }));
@@ -41,6 +43,7 @@ const createPerpetualClose = vi.fn(() => Promise.resolve({ transactions: [] }));
 const createPerpetualReduce = vi.fn(() => Promise.resolve({ transactions: [] }));
 
 const client = {
+  createSwap: createSwapMock,
   createPerpetualLong,
   createPerpetualShort,
   createPerpetualClose,
@@ -49,6 +52,11 @@ const client = {
 
 describe('executePerpetualPlan', () => {
   beforeEach(() => {
+    createPerpetualLong.mockClear();
+    createPerpetualShort.mockClear();
+    createPerpetualClose.mockClear();
+    createPerpetualReduce.mockClear();
+    createSwapMock.mockReset();
     executeTransactionMock.mockReset();
     redeemDelegationsAndExecuteTransactionsMock.mockReset();
   });
@@ -94,6 +102,70 @@ describe('executePerpetualPlan', () => {
     expect(result.transactions).toHaveLength(1);
     expect(result.transactions?.[0]?.to).toBe('0xrouter');
     expect(executeTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it('prepends a swap into collateral before opening when pay and collateral tokens differ', async () => {
+    createSwapMock.mockResolvedValueOnce({
+      exactFromAmount: '123',
+      exactToAmount: '100',
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xswap',
+          data: '0xswap01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    const plan: ExecutionPlan = {
+      action: 'long',
+      request: {
+        amount: '100',
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        chainId: '42161',
+        marketAddress: '0xmarket',
+        payTokenAddress: '0xweth',
+        collateralTokenAddress: '0xusdc',
+        leverage: '2',
+      },
+    };
+
+    const result = await executePerpetualPlan({
+      client,
+      plan,
+      txExecutionMode: 'plan',
+      delegationsBypassActive: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createSwapMock).toHaveBeenCalledWith({
+      walletAddress: '0x0000000000000000000000000000000000000001',
+      amount: '100',
+      amountType: 'exactOut',
+      fromTokenUid: { chainId: '42161', address: '0xweth' },
+      toTokenUid: { chainId: '42161', address: '0xusdc' },
+    });
+    expect(createPerpetualLong).toHaveBeenCalledWith({
+      ...plan.request,
+      payTokenAddress: '0xusdc',
+    });
+    expect(result.transactions).toEqual([
+      {
+        type: 'evm',
+        to: '0xswap',
+        data: '0xswap01',
+        chainId: '42161',
+        value: '0',
+      },
+      {
+        type: 'evm',
+        to: '0xrouter',
+        data: '0xdeadbeef',
+        chainId: '42161',
+        value: '0',
+      },
+    ]);
   });
 
   it('executes reduce plans', async () => {
@@ -199,6 +271,100 @@ describe('executePerpetualPlan', () => {
         type: 'evm',
         to: '0xclose',
         data: '0xclose01',
+        chainId: '42161',
+        value: '0',
+      },
+      {
+        type: 'evm',
+        to: '0xopen',
+        data: '0xopen01',
+        chainId: '42161',
+        value: '0',
+      },
+    ]);
+  });
+
+  it('inserts a swap between close and reopen transactions for flip plans with non-USDC funding', async () => {
+    createPerpetualClose.mockResolvedValueOnce({
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xclose',
+          data: '0xclose01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    createSwapMock.mockResolvedValueOnce({
+      exactFromAmount: '150',
+      exactToAmount: '100',
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xswap',
+          data: '0xswap02',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    createPerpetualShort.mockResolvedValueOnce({
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xopen',
+          data: '0xopen01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    const plan: ExecutionPlan = {
+      action: 'flip',
+      closeRequest: {
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        marketAddress: '0xmarket',
+        positionSide: 'long',
+        isLimit: false,
+      },
+      openRequest: {
+        amount: '100',
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        chainId: '42161',
+        marketAddress: '0xmarket',
+        payTokenAddress: '0xweth',
+        collateralTokenAddress: '0xusdc',
+        leverage: '2',
+      },
+    };
+
+    const result = await executePerpetualPlan({
+      client,
+      plan,
+      txExecutionMode: 'plan',
+      delegationsBypassActive: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createPerpetualClose).toHaveBeenCalledBefore(createSwapMock);
+    expect(createSwapMock).toHaveBeenCalledBefore(createPerpetualShort);
+    expect(createPerpetualShort).toHaveBeenCalledWith({
+      ...plan.openRequest,
+      payTokenAddress: '0xusdc',
+    });
+    expect(result.transactions).toEqual([
+      {
+        type: 'evm',
+        to: '0xclose',
+        data: '0xclose01',
+        chainId: '42161',
+        value: '0',
+      },
+      {
+        type: 'evm',
+        to: '0xswap',
+        data: '0xswap02',
         chainId: '42161',
         value: '0',
       },

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/execution.unit.test.ts
@@ -50,6 +50,14 @@ const client = {
   createPerpetualReduce,
 };
 
+const swapFundingEstimate = {
+  fromTokenDecimals: 18,
+  fromTokenBalanceBaseUnits: '1000000000000000000',
+  fromTokenUsdPrice: 1600,
+  toTokenDecimals: 6,
+  toTokenUsdPrice: 1,
+};
+
 describe('executePerpetualPlan', () => {
   beforeEach(() => {
     createPerpetualLong.mockClear();
@@ -106,8 +114,8 @@ describe('executePerpetualPlan', () => {
 
   it('prepends a swap into collateral before opening when pay and collateral tokens differ', async () => {
     createSwapMock.mockResolvedValueOnce({
-      exactFromAmount: '123',
-      exactToAmount: '100',
+      exactFromAmount: '5250000000000000',
+      exactToAmount: '8000000',
       transactions: [
         {
           type: 'evm',
@@ -121,7 +129,7 @@ describe('executePerpetualPlan', () => {
     const plan: ExecutionPlan = {
       action: 'long',
       request: {
-        amount: '100',
+        amount: '8000000',
         walletAddress: '0x0000000000000000000000000000000000000001',
         chainId: '42161',
         marketAddress: '0xmarket',
@@ -136,13 +144,14 @@ describe('executePerpetualPlan', () => {
       plan,
       txExecutionMode: 'plan',
       delegationsBypassActive: true,
+      swapFundingEstimate,
     });
 
     expect(result.ok).toBe(true);
     expect(createSwapMock).toHaveBeenCalledWith({
       walletAddress: '0x0000000000000000000000000000000000000001',
-      amount: '100',
-      amountType: 'exactOut',
+      amount: '5250000000000000',
+      amountType: 'exactIn',
       fromTokenUid: { chainId: '42161', address: '0xweth' },
       toTokenUid: { chainId: '42161', address: '0xusdc' },
     });
@@ -166,6 +175,33 @@ describe('executePerpetualPlan', () => {
         value: '0',
       },
     ]);
+  });
+
+  it('fails safely when a collateral swap is required but no exact-in estimate is available', async () => {
+    const plan: ExecutionPlan = {
+      action: 'long',
+      request: {
+        amount: '8000000',
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        chainId: '42161',
+        marketAddress: '0xmarket',
+        payTokenAddress: '0xweth',
+        collateralTokenAddress: '0xusdc',
+        leverage: '2',
+      },
+    };
+
+    const result = await executePerpetualPlan({
+      client,
+      plan,
+      txExecutionMode: 'plan',
+      delegationsBypassActive: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Unable to estimate exact-in swap amount');
+    expect(createSwapMock).not.toHaveBeenCalled();
+    expect(createPerpetualLong).not.toHaveBeenCalled();
   });
 
   it('executes reduce plans', async () => {
@@ -297,8 +333,8 @@ describe('executePerpetualPlan', () => {
       ],
     });
     createSwapMock.mockResolvedValueOnce({
-      exactFromAmount: '150',
-      exactToAmount: '100',
+      exactFromAmount: '5250000000000000',
+      exactToAmount: '8000000',
       transactions: [
         {
           type: 'evm',
@@ -329,7 +365,7 @@ describe('executePerpetualPlan', () => {
         isLimit: false,
       },
       openRequest: {
-        amount: '100',
+        amount: '8000000',
         walletAddress: '0x0000000000000000000000000000000000000001',
         chainId: '42161',
         marketAddress: '0xmarket',
@@ -344,11 +380,19 @@ describe('executePerpetualPlan', () => {
       plan,
       txExecutionMode: 'plan',
       delegationsBypassActive: true,
+      swapFundingEstimate,
     });
 
     expect(result.ok).toBe(true);
     expect(createPerpetualClose).toHaveBeenCalledBefore(createSwapMock);
     expect(createSwapMock).toHaveBeenCalledBefore(createPerpetualShort);
+    expect(createSwapMock).toHaveBeenCalledWith({
+      walletAddress: '0x0000000000000000000000000000000000000001',
+      amount: '5250000000000000',
+      amountType: 'exactIn',
+      fromTokenUid: { chainId: '42161', address: '0xweth' },
+      toTokenUid: { chainId: '42161', address: '0xusdc' },
+    });
     expect(createPerpetualShort).toHaveBeenCalledWith({
       ...plan.openRequest,
       payTokenAddress: '0xusdc',
@@ -479,5 +523,122 @@ describe('executePerpetualPlan', () => {
     });
     expect(result.txHashes).toEqual(['0xhash2']);
     expect(result.lastTxHash).toBe('0xhash2');
+  });
+
+  it('settles the collateral swap before creating the delegated GMX open plan', async () => {
+    createSwapMock.mockResolvedValueOnce({
+      exactFromAmount: '5250000000000000',
+      exactToAmount: '8000000',
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xswap',
+          data: '0xswap01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    createPerpetualLong.mockResolvedValueOnce({
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xrouter',
+          data: '0xopen01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    redeemDelegationsAndExecuteTransactionsMock
+      .mockResolvedValueOnce({
+        txHashes: ['0xswap-hash'],
+        lastTxHash: '0xswap-hash',
+      })
+      .mockResolvedValueOnce({
+        txHashes: ['0xopen-hash'],
+        lastTxHash: '0xopen-hash',
+      });
+    const clients = {} as OnchainClients;
+
+    const delegationBundle: DelegationBundle = {
+      chainId: 42161,
+      delegationManager: '0x00000000000000000000000000000000000000aa',
+      delegatorAddress: '0x00000000000000000000000000000000000000bb',
+      delegateeAddress: '0x00000000000000000000000000000000000000cc',
+      delegations: [
+        {
+          delegate: '0x00000000000000000000000000000000000000cc',
+          delegator: '0x00000000000000000000000000000000000000bb',
+          authority: `0x${'0'.repeat(64)}`,
+          caveats: [],
+          salt: `0x${'1'.repeat(64)}`,
+          signature: `0x${'2'.repeat(130)}`,
+        },
+      ],
+      intents: [],
+      descriptions: [],
+      warnings: [],
+    };
+
+    const plan: ExecutionPlan = {
+      action: 'long',
+      request: {
+        amount: '8000000',
+        walletAddress: delegationBundle.delegatorAddress,
+        chainId: '42161',
+        marketAddress: '0xmarket',
+        payTokenAddress: '0xweth',
+        collateralTokenAddress: '0xusdc',
+        leverage: '2',
+      },
+    };
+
+    const result = await executePerpetualPlan({
+      client,
+      clients,
+      plan,
+      txExecutionMode: 'execute',
+      delegationsBypassActive: false,
+      delegationBundle,
+      delegatorWalletAddress: delegationBundle.delegatorAddress,
+      delegateeWalletAddress: delegationBundle.delegateeAddress,
+      swapFundingEstimate,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(redeemDelegationsAndExecuteTransactionsMock).toHaveBeenCalledTimes(2);
+    expect(redeemDelegationsAndExecuteTransactionsMock).toHaveBeenNthCalledWith(1, {
+      clients,
+      delegationBundle,
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xswap',
+          data: '0xswap01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    expect(redeemDelegationsAndExecuteTransactionsMock).toHaveBeenNthCalledWith(2, {
+      clients,
+      delegationBundle,
+      transactions: [
+        {
+          type: 'evm',
+          to: '0xrouter',
+          data: '0xopen01',
+          chainId: '42161',
+          value: '0',
+        },
+      ],
+    });
+    expect(createSwapMock).toHaveBeenCalledBefore(createPerpetualLong);
+    expect(
+      redeemDelegationsAndExecuteTransactionsMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(createPerpetualLong.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY);
+    expect(result.txHashes).toEqual(['0xswap-hash', '0xopen-hash']);
+    expect(result.lastTxHash).toBe('0xopen-hash');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.ts
@@ -1,9 +1,13 @@
 import { copilotkitEmitState } from '@copilotkit/sdk-js/langgraph';
+import { interrupt } from '@langchain/langgraph';
+import { requestInterruptPayload } from 'agent-workflow-core';
+import { parseUnits } from 'viem';
+import { z } from 'zod';
 
 import type { PerpetualMarket } from '../../clients/onchainActions.js';
 import { ARBITRUM_CHAIN_ID, ONCHAIN_ACTIONS_API_URL } from '../../config/constants.js';
 import { selectGmxPerpetualMarket } from '../../core/marketSelection.js';
-import { type FundingTokenInput } from '../../domain/types.js';
+import { FundingTokenInputSchema, type FundingTokenInput } from '../../domain/types.js';
 import { getOnchainActionsClient } from '../clientFactory.js';
 import {
   applyThreadPatch,
@@ -49,6 +53,107 @@ function resolveUsdcTokenAddressFromMarket(market: PerpetualMarket): `0x${string
   return normalizeHexAddress(usdcToken.tokenUid.address, 'funding token address');
 }
 
+function resolveUsdcDecimalsFromMarket(market: PerpetualMarket): number {
+  const longToken = market.longToken;
+  const shortToken = market.shortToken;
+  if (!longToken || !shortToken) {
+    throw new Error('Selected GMX market is missing long/short token metadata.');
+  }
+
+  const candidates = [shortToken, longToken];
+  const usdcToken = candidates.find((token) => token.symbol.toUpperCase() === 'USDC');
+  if (!usdcToken) {
+    throw new Error('Selected GMX market does not provide USDC collateral.');
+  }
+
+  return usdcToken.decimals;
+}
+
+function hasSufficientUsdcBalance(params: {
+  walletBalances:
+    | Array<{
+        tokenUid: { address: string };
+        amount: string;
+      }>
+    | undefined;
+  usdcTokenAddress: `0x${string}`;
+  requiredCollateralUsd: number;
+  usdcDecimals: number;
+}): boolean {
+  const usdcBalance = params.walletBalances?.find(
+    (balance) => balance.tokenUid.address.toLowerCase() === params.usdcTokenAddress.toLowerCase(),
+  );
+  if (!usdcBalance) {
+    return false;
+  }
+
+  let availableAmount: bigint;
+  try {
+    availableAmount = BigInt(usdcBalance.amount);
+  } catch {
+    return false;
+  }
+
+  let requiredAmount: bigint;
+  try {
+    requiredAmount = parseUnits(params.requiredCollateralUsd.toFixed(params.usdcDecimals), params.usdcDecimals);
+  } catch {
+    return false;
+  }
+
+  return availableAmount >= requiredAmount;
+}
+
+function buildSwapSourceOptions(params: {
+  walletBalances:
+    | Array<{
+        tokenUid: { chainId: string; address: string };
+        amount: string;
+        symbol?: string;
+        decimals?: number;
+        valueUsd?: number;
+      }>
+    | undefined;
+  collateralTokenAddress: `0x${string}`;
+}): Array<{
+  address: `0x${string}`;
+  symbol: string;
+  decimals: number;
+  balance: string;
+}> {
+  return (params.walletBalances ?? [])
+    .filter((balance) => balance.tokenUid.chainId === ARBITRUM_CHAIN_ID.toString())
+    .filter((balance) => balance.tokenUid.address.toLowerCase() !== params.collateralTokenAddress.toLowerCase())
+    .filter((balance) => typeof balance.symbol === 'string' && balance.symbol.trim().length > 0)
+    .filter((balance) => typeof balance.decimals === 'number')
+    .filter((balance) => balance.symbol?.toUpperCase() !== 'ETH')
+    .filter((balance) => {
+      try {
+        return BigInt(balance.amount) > 0n;
+      } catch {
+        return false;
+      }
+    })
+    .sort((left, right) => {
+      const leftValue = left.valueUsd ?? 0;
+      const rightValue = right.valueUsd ?? 0;
+      if (rightValue !== leftValue) {
+        return rightValue - leftValue;
+      }
+      const symbolCompare = (left.symbol ?? '').localeCompare(right.symbol ?? '');
+      if (symbolCompare !== 0) {
+        return symbolCompare;
+      }
+      return left.tokenUid.address.localeCompare(right.tokenUid.address);
+    })
+    .map((balance) => ({
+      address: normalizeHexAddress(balance.tokenUid.address, 'funding token option address'),
+      symbol: balance.symbol?.trim() ?? 'UNKNOWN',
+      decimals: balance.decimals ?? 0,
+      balance: balance.amount,
+    }));
+}
+
 export const collectFundingTokenInputNode = async (
   state: ClmmState,
   config: CopilotKitConfig,
@@ -92,21 +197,16 @@ export const collectFundingTokenInputNode = async (
     };
   }
 
-  const awaitingInput = buildTaskStatus(
-    state.thread.task,
-    'working',
-    'Using USDC as collateral for GMX perps.',
-  );
-  const pendingView = applyThreadPatch(state, {
-    onboarding: { step: 2, key: FUNDING_STEP_KEY },
-    task: awaitingInput.task,
-    activity: { events: [awaitingInput.statusEvent], telemetry: state.thread.activity.telemetry },
-  });
-  await copilotkitEmitState(config, {
-    thread: pendingView,
-  });
-
   let normalizedFundingToken: `0x${string}`;
+  let walletBalances:
+    | Array<{
+        tokenUid: { chainId: string; address: string };
+        amount: string;
+        symbol?: string;
+        decimals?: number;
+        valueUsd?: number;
+      }>
+    | undefined;
   try {
     const onchainActionsClient = getOnchainActionsClient();
     const markets = await onchainActionsClient.listPerpetualMarkets({
@@ -122,10 +222,41 @@ export const collectFundingTokenInputNode = async (
     }
 
     normalizedFundingToken = resolveUsdcTokenAddressFromMarket(selectedMarket);
+    const usdcDecimals = resolveUsdcDecimalsFromMarket(selectedMarket);
+    walletBalances =
+      'listWalletBalances' in onchainActionsClient &&
+      typeof onchainActionsClient.listWalletBalances === 'function'
+        ? await onchainActionsClient.listWalletBalances({
+            walletAddress: normalizeHexAddress(operatorInput.walletAddress, 'wallet address'),
+          })
+        : undefined;
+    if (
+      hasSufficientUsdcBalance({
+        walletBalances,
+        usdcTokenAddress: normalizedFundingToken,
+        requiredCollateralUsd: operatorInput.usdcAllocation,
+        usdcDecimals,
+      })
+    ) {
+      const input: FundingTokenInput = {
+        fundingTokenAddress: normalizedFundingToken,
+        collateralTokenAddress: normalizedFundingToken,
+      };
+      const completedView = applyThreadPatch(state, {
+        fundingTokenInput: input,
+        onboarding:
+          state.thread.delegationsBypassActive === true
+            ? { step: 2, key: FUNDING_STEP_KEY }
+            : { step: 3, key: DELEGATION_STEP_KEY },
+      });
+      return {
+        thread: completedView,
+      };
+    }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     const failureMessage = `ERROR: Failed to resolve USDC funding token from ${ONCHAIN_ACTIONS_API_URL}: ${message}`;
-    const { task, statusEvent } = buildTaskStatus(awaitingInput.task, 'failed', failureMessage);
+    const { task, statusEvent } = buildTaskStatus(state.thread.task, 'failed', failureMessage);
     const failedView = applyThreadPatch(state, {
       task,
       activity: { events: [statusEvent], telemetry: state.thread.activity.telemetry },
@@ -143,6 +274,120 @@ export const collectFundingTokenInputNode = async (
     };
   }
 
+  const swapSourceOptions = buildSwapSourceOptions({
+    walletBalances,
+    collateralTokenAddress: normalizedFundingToken,
+  });
+  if (swapSourceOptions.length > 0) {
+    const awaitingInput = buildTaskStatus(
+      state.thread.task,
+      'input-required',
+      'Select a wallet token to swap into USDC collateral before opening the GMX position.',
+    );
+    const pendingView = applyThreadPatch(state, {
+      onboarding: { step: 2, key: FUNDING_STEP_KEY },
+      task: awaitingInput.task,
+      activity: { events: [awaitingInput.statusEvent], telemetry: state.thread.activity.telemetry },
+    });
+    await copilotkitEmitState(config, {
+      thread: pendingView,
+    });
+
+    const interruptResult = await requestInterruptPayload({
+      request: {
+        type: 'gmx-funding-token-request',
+        message: 'Select the wallet token to swap into USDC collateral for the GMX position.',
+        payloadSchema: z.toJSONSchema(FundingTokenInputSchema),
+        options: swapSourceOptions,
+      },
+      interrupt,
+    });
+    const parsed = FundingTokenInputSchema.safeParse(interruptResult.decoded);
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((issue) => issue.message).join('; ');
+      const failureMessage = `Invalid funding-token input: ${issues}`;
+      const { task, statusEvent } = buildTaskStatus(awaitingInput.task, 'failed', failureMessage);
+      const failedView = applyThreadPatch(state, {
+        task,
+        activity: { events: [statusEvent], telemetry: state.thread.activity.telemetry },
+      });
+      await copilotkitEmitState(config, {
+        thread: failedView,
+      });
+      const haltedView = applyThreadPatch(state, {
+        haltReason: failureMessage,
+        task,
+        activity: { events: [statusEvent], telemetry: state.thread.activity.telemetry },
+      });
+      return {
+        thread: haltedView,
+      };
+    }
+
+    const selectedFundingToken = normalizeHexAddress(
+      parsed.data.fundingTokenAddress,
+      'funding token address',
+    );
+    const isEligible = swapSourceOptions.some(
+      (option) => option.address.toLowerCase() === selectedFundingToken.toLowerCase(),
+    );
+    if (!isEligible) {
+      const failureMessage = 'Selected funding token is not eligible for swap-to-USDC collateral.';
+      const { task, statusEvent } = buildTaskStatus(awaitingInput.task, 'failed', failureMessage);
+      const failedView = applyThreadPatch(state, {
+        task,
+        activity: { events: [statusEvent], telemetry: state.thread.activity.telemetry },
+      });
+      await copilotkitEmitState(config, {
+        thread: failedView,
+      });
+      const haltedView = applyThreadPatch(state, {
+        haltReason: failureMessage,
+        task,
+        activity: { events: [statusEvent], telemetry: state.thread.activity.telemetry },
+      });
+      return {
+        thread: haltedView,
+      };
+    }
+
+    const input: FundingTokenInput = {
+      fundingTokenAddress: selectedFundingToken,
+      collateralTokenAddress: normalizedFundingToken,
+    };
+    const { task, statusEvent } = buildTaskStatus(
+      awaitingInput.task,
+      'working',
+      'Funding token selected. Preparing delegation request.',
+    );
+    const completedView = applyThreadPatch(state, {
+      fundingTokenInput: input,
+      onboarding:
+        state.thread.delegationsBypassActive === true
+          ? { step: 2, key: FUNDING_STEP_KEY }
+          : { step: 3, key: DELEGATION_STEP_KEY },
+      task,
+      activity: { events: [statusEvent], telemetry: state.thread.activity.telemetry },
+    });
+    return {
+      thread: completedView,
+    };
+  }
+
+  const awaitingInput = buildTaskStatus(
+    state.thread.task,
+    'working',
+    'Using USDC as collateral for GMX perps.',
+  );
+  const pendingView = applyThreadPatch(state, {
+    onboarding: { step: 2, key: FUNDING_STEP_KEY },
+    task: awaitingInput.task,
+    activity: { events: [awaitingInput.statusEvent], telemetry: state.thread.activity.telemetry },
+  });
+  await copilotkitEmitState(config, {
+    thread: pendingView,
+  });
+
   const { task, statusEvent } = buildTaskStatus(
     awaitingInput.task,
     'working',
@@ -158,6 +403,7 @@ export const collectFundingTokenInputNode = async (
 
   const input: FundingTokenInput = {
     fundingTokenAddress: normalizedFundingToken,
+    collateralTokenAddress: normalizedFundingToken,
   };
 
   const completedView = applyThreadPatch(state, {

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.ts
@@ -1,7 +1,11 @@
 import { copilotkitEmitState } from '@copilotkit/sdk-js/langgraph';
-import { interrupt } from '@langchain/langgraph';
-import { requestInterruptPayload } from 'agent-workflow-core';
-import { parseUnits } from 'viem';
+import { interrupt, type Command } from '@langchain/langgraph';
+import {
+  buildInterruptPauseTransition,
+  requestInterruptPayload,
+  shouldPersistInputRequiredCheckpoint,
+} from 'agent-workflow-core';
+import { formatUnits, parseUnits } from 'viem';
 import { z } from 'zod';
 
 import type { PerpetualMarket } from '../../clients/onchainActions.js';
@@ -13,12 +17,14 @@ import {
   applyThreadPatch,
   buildTaskStatus,
   logInfo,
+  logPauseSnapshot,
   logWarn,
   normalizeHexAddress,
   type ClmmState,
   type ClmmUpdate,
   type OnboardingState,
 } from '../context.js';
+import { createLangGraphCommand } from '../langGraphCommandFactory.js';
 
 type CopilotKitConfig = Parameters<typeof copilotkitEmitState>[0];
 
@@ -104,6 +110,54 @@ function hasSufficientUsdcBalance(params: {
   return availableAmount >= requiredAmount;
 }
 
+function findWalletBalance(params: {
+  walletBalances:
+    | Array<{
+        tokenUid: { address: string };
+        amount: string;
+        symbol?: string;
+        decimals?: number;
+        valueUsd?: number;
+      }>
+    | undefined;
+  tokenAddress: `0x${string}`;
+}):
+  | {
+      tokenUid: { address: string };
+      amount: string;
+      symbol?: string;
+      decimals?: number;
+      valueUsd?: number;
+    }
+  | undefined {
+  return params.walletBalances?.find(
+    (balance) => balance.tokenUid.address.toLowerCase() === params.tokenAddress.toLowerCase(),
+  );
+}
+
+function estimateUsdPriceFromBalance(params: {
+  amountBaseUnits: string;
+  decimals: number;
+  valueUsd: number | undefined;
+}): number | undefined {
+  if (typeof params.valueUsd !== 'number' || !Number.isFinite(params.valueUsd) || params.valueUsd <= 0) {
+    return undefined;
+  }
+
+  let amount: number;
+  try {
+    amount = Number(formatUnits(BigInt(params.amountBaseUnits), params.decimals));
+  } catch {
+    return undefined;
+  }
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return undefined;
+  }
+
+  const usdPrice = params.valueUsd / amount;
+  return Number.isFinite(usdPrice) && usdPrice > 0 ? usdPrice : undefined;
+}
+
 function buildSwapSourceOptions(params: {
   walletBalances:
     | Array<{
@@ -120,6 +174,7 @@ function buildSwapSourceOptions(params: {
   symbol: string;
   decimals: number;
   balance: string;
+  valueUsd?: number;
 }> {
   return (params.walletBalances ?? [])
     .filter((balance) => balance.tokenUid.chainId === ARBITRUM_CHAIN_ID.toString())
@@ -151,13 +206,14 @@ function buildSwapSourceOptions(params: {
       symbol: balance.symbol?.trim() ?? 'UNKNOWN',
       decimals: balance.decimals ?? 0,
       balance: balance.amount,
+      valueUsd: balance.valueUsd,
     }));
 }
 
 export const collectFundingTokenInputNode = async (
   state: ClmmState,
   config: CopilotKitConfig,
-): Promise<ClmmUpdate> => {
+): Promise<ClmmUpdate | Command<string, ClmmUpdate>> => {
   logInfo('collectFundingTokenInput: entering node', {
     hasOperatorInput: Boolean(state.thread.operatorInput),
     onboardingStep: state.thread.onboarding?.step,
@@ -198,6 +254,7 @@ export const collectFundingTokenInputNode = async (
   }
 
   let normalizedFundingToken: `0x${string}`;
+  let usdcDecimals = 6;
   let walletBalances:
     | Array<{
         tokenUid: { chainId: string; address: string };
@@ -222,7 +279,7 @@ export const collectFundingTokenInputNode = async (
     }
 
     normalizedFundingToken = resolveUsdcTokenAddressFromMarket(selectedMarket);
-    const usdcDecimals = resolveUsdcDecimalsFromMarket(selectedMarket);
+    usdcDecimals = resolveUsdcDecimalsFromMarket(selectedMarket);
     walletBalances =
       'listWalletBalances' in onchainActionsClient &&
       typeof onchainActionsClient.listWalletBalances === 'function'
@@ -238,9 +295,17 @@ export const collectFundingTokenInputNode = async (
         usdcDecimals,
       })
     ) {
+      const usdcBalance = findWalletBalance({
+        walletBalances,
+        tokenAddress: normalizedFundingToken,
+      });
       const input: FundingTokenInput = {
         fundingTokenAddress: normalizedFundingToken,
         collateralTokenAddress: normalizedFundingToken,
+        fundingTokenDecimals: usdcDecimals,
+        fundingTokenBalanceBaseUnits: usdcBalance?.amount,
+        fundingTokenUsdPrice: 1,
+        collateralTokenDecimals: usdcDecimals,
       };
       const completedView = applyThreadPatch(state, {
         fundingTokenInput: input,
@@ -284,13 +349,49 @@ export const collectFundingTokenInputNode = async (
       'input-required',
       'Select a wallet token to swap into USDC collateral before opening the GMX position.',
     );
-    const pendingView = applyThreadPatch(state, {
+    const pendingView = {
       onboarding: { step: 2, key: FUNDING_STEP_KEY },
       task: awaitingInput.task,
       activity: { events: [awaitingInput.statusEvent], telemetry: state.thread.activity.telemetry },
+    };
+    const awaitingMessage = awaitingInput.task.taskStatus.message?.content;
+    const shouldPersistPendingState = shouldPersistInputRequiredCheckpoint({
+      currentTaskState: state.thread.task?.taskStatus?.state,
+      currentTaskMessage: state.thread.task?.taskStatus?.message?.content,
+      currentOnboardingKey: state.thread.onboarding?.key,
+      nextOnboardingKey: pendingView.onboarding.key,
+      nextTaskMessage: awaitingMessage,
     });
-    await copilotkitEmitState(config, {
-      thread: pendingView,
+    const hasRunnableConfig = Boolean((config as { configurable?: unknown }).configurable);
+    const pauseSnapshotView = applyThreadPatch(state, pendingView);
+    if (hasRunnableConfig && shouldPersistPendingState) {
+      logPauseSnapshot({
+        node: 'collectFundingTokenInput',
+        reason: 'awaiting funding token input',
+        thread: pauseSnapshotView,
+        metadata: {
+          pauseMechanism: 'checkpoint-and-interrupt',
+        },
+      });
+      await copilotkitEmitState(config, {
+        thread: pauseSnapshotView,
+      });
+      return buildInterruptPauseTransition({
+        node: 'collectFundingTokenInput',
+        update: {
+          thread: pendingView,
+        },
+        createCommand: createLangGraphCommand,
+      });
+    }
+    logPauseSnapshot({
+      node: 'collectFundingTokenInput',
+      reason: 'awaiting funding token input',
+      thread: pauseSnapshotView,
+      metadata: {
+        pauseMechanism: 'interrupt',
+        checkpointPersisted: false,
+      },
     });
 
     const interruptResult = await requestInterruptPayload({
@@ -328,10 +429,10 @@ export const collectFundingTokenInputNode = async (
       parsed.data.fundingTokenAddress,
       'funding token address',
     );
-    const isEligible = swapSourceOptions.some(
+    const selectedFundingTokenOption = swapSourceOptions.find(
       (option) => option.address.toLowerCase() === selectedFundingToken.toLowerCase(),
     );
-    if (!isEligible) {
+    if (!selectedFundingTokenOption) {
       const failureMessage = 'Selected funding token is not eligible for swap-to-USDC collateral.';
       const { task, statusEvent } = buildTaskStatus(awaitingInput.task, 'failed', failureMessage);
       const failedView = applyThreadPatch(state, {
@@ -354,6 +455,14 @@ export const collectFundingTokenInputNode = async (
     const input: FundingTokenInput = {
       fundingTokenAddress: selectedFundingToken,
       collateralTokenAddress: normalizedFundingToken,
+      fundingTokenDecimals: selectedFundingTokenOption.decimals,
+      fundingTokenBalanceBaseUnits: selectedFundingTokenOption.balance,
+      fundingTokenUsdPrice: estimateUsdPriceFromBalance({
+        amountBaseUnits: selectedFundingTokenOption.balance,
+        decimals: selectedFundingTokenOption.decimals,
+        valueUsd: selectedFundingTokenOption.valueUsd,
+      }),
+      collateralTokenDecimals: usdcDecimals,
     };
     const { task, statusEvent } = buildTaskStatus(
       awaitingInput.task,
@@ -404,6 +513,9 @@ export const collectFundingTokenInputNode = async (
   const input: FundingTokenInput = {
     fundingTokenAddress: normalizedFundingToken,
     collateralTokenAddress: normalizedFundingToken,
+    fundingTokenDecimals: usdcDecimals,
+    fundingTokenUsdPrice: 1,
+    collateralTokenDecimals: usdcDecimals,
   };
 
   const completedView = applyThreadPatch(state, {

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.unit.test.ts
@@ -167,6 +167,10 @@ describe('collectFundingTokenInputNode', () => {
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
           collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          fundingTokenDecimals: 6,
+          fundingTokenBalanceBaseUnits: '150000000',
+          fundingTokenUsdPrice: 1,
+          collateralTokenDecimals: 6,
         },
         onboarding: { step: 3, key: 'delegation-signing' },
       },
@@ -270,6 +274,217 @@ describe('collectFundingTokenInputNode', () => {
         ],
       }),
     );
+    expect(result).toMatchObject({
+      thread: {
+        fundingTokenInput: {
+          fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          fundingTokenDecimals: 18,
+          fundingTokenBalanceBaseUnits: '1000000000000000000',
+          fundingTokenUsdPrice: 1800,
+          collateralTokenDecimals: 6,
+        },
+        onboarding: { step: 3, key: 'delegation-signing' },
+      },
+    });
+  });
+
+  it('persists input-required funding-token state before interrupting when runnable config exists', async () => {
+    copilotkitEmitStateMock.mockReset();
+    copilotkitEmitStateMock.mockResolvedValue(undefined);
+    getOnchainActionsClientMock.mockReset();
+    interruptMock.mockReset();
+    getOnchainActionsClientMock.mockReturnValue({
+      listPerpetualMarkets: vi.fn().mockResolvedValue([
+        {
+          marketToken: { chainId: '42161', address: '0x4444444444444444444444444444444444444444' },
+          longFundingFee: '0',
+          shortFundingFee: '0',
+          longBorrowingFee: '0',
+          shortBorrowingFee: '0',
+          chainId: '42161',
+          name: 'BTC/USD [WBTC-USDC]',
+          indexToken: {
+            tokenUid: { chainId: '42161', address: '0x1111111111111111111111111111111111111111' },
+            name: 'Bitcoin',
+            symbol: 'BTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          longToken: {
+            tokenUid: { chainId: '42161', address: '0x2222222222222222222222222222222222222222' },
+            name: 'Wrapped BTC',
+            symbol: 'WBTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          shortToken: {
+            tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+            name: 'USD Coin',
+            symbol: 'USDC',
+            isNative: false,
+            decimals: 6,
+            iconUri: null,
+            isVetted: true,
+          },
+        },
+      ]),
+      listWalletBalances: vi.fn().mockResolvedValue([
+        {
+          tokenUid: { chainId: '42161', address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' },
+          amount: '1000000000000000000',
+          symbol: 'WETH',
+          decimals: 18,
+          valueUsd: 1800,
+        },
+      ]),
+    });
+
+    const state = {
+      thread: {
+        operatorInput: {
+          walletAddress: '0x1111111111111111111111111111111111111111',
+          usdcAllocation: 100,
+          targetMarket: 'BTC',
+        },
+        onboarding: { step: 2, key: 'funding-token' },
+        task: { id: 'task-1', taskStatus: { state: 'working' } },
+        activity: { telemetry: [], events: [] },
+        profile: {
+          agentIncome: undefined,
+          aum: undefined,
+          totalUsers: undefined,
+          apy: undefined,
+          chains: [],
+          protocols: [],
+          tokens: [],
+          pools: [],
+          allowedPools: [],
+        },
+        metrics: {},
+        transactionHistory: [],
+        delegationsBypassActive: false,
+      },
+    } as unknown as ClmmState;
+
+    const result = await collectFundingTokenInputNode(state, { configurable: { thread_id: 'thread-1' } });
+
+    expect(interruptMock).not.toHaveBeenCalled();
+    expect(copilotkitEmitStateMock).toHaveBeenCalledTimes(1);
+
+    const commandResult = result as {
+      goto?: string[];
+      update?: {
+        thread?: {
+          task?: { taskStatus?: { state?: string; message?: { content?: string } } };
+          onboarding?: { step?: number; key?: string };
+          profile?: unknown;
+        };
+      };
+    };
+
+    expect(commandResult.goto).toContain('collectFundingTokenInput');
+    expect(commandResult.update?.thread?.task?.taskStatus?.state).toBe('input-required');
+    expect(commandResult.update?.thread?.task?.taskStatus?.message?.content).toContain(
+      'Select a wallet token to swap into USDC collateral',
+    );
+    expect(commandResult.update?.thread?.onboarding).toEqual({ step: 2, key: 'funding-token' });
+    expect(commandResult.update?.thread?.profile).toBeUndefined();
+  });
+
+  it('does not emit another pending funding-token checkpoint when the step is already persisted', async () => {
+    copilotkitEmitStateMock.mockReset();
+    copilotkitEmitStateMock.mockResolvedValue(undefined);
+    getOnchainActionsClientMock.mockReset();
+    interruptMock.mockReset();
+    interruptMock.mockResolvedValue(
+      JSON.stringify({
+        fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+      }),
+    );
+    getOnchainActionsClientMock.mockReturnValue({
+      listPerpetualMarkets: vi.fn().mockResolvedValue([
+        {
+          marketToken: { chainId: '42161', address: '0x4444444444444444444444444444444444444444' },
+          longFundingFee: '0',
+          shortFundingFee: '0',
+          longBorrowingFee: '0',
+          shortBorrowingFee: '0',
+          chainId: '42161',
+          name: 'BTC/USD [WBTC-USDC]',
+          indexToken: {
+            tokenUid: { chainId: '42161', address: '0x1111111111111111111111111111111111111111' },
+            name: 'Bitcoin',
+            symbol: 'BTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          longToken: {
+            tokenUid: { chainId: '42161', address: '0x2222222222222222222222222222222222222222' },
+            name: 'Wrapped BTC',
+            symbol: 'WBTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          shortToken: {
+            tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+            name: 'USD Coin',
+            symbol: 'USDC',
+            isNative: false,
+            decimals: 6,
+            iconUri: null,
+            isVetted: true,
+          },
+        },
+      ]),
+      listWalletBalances: vi.fn().mockResolvedValue([
+        {
+          tokenUid: { chainId: '42161', address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' },
+          amount: '1000000000000000000',
+          symbol: 'WETH',
+          decimals: 18,
+          valueUsd: 1800,
+        },
+      ]),
+    });
+
+    const state = {
+      thread: {
+        operatorInput: {
+          walletAddress: '0x1111111111111111111111111111111111111111',
+          usdcAllocation: 100,
+          targetMarket: 'BTC',
+        },
+        onboarding: { step: 2, key: 'funding-token' },
+        task: {
+          id: 'task-1',
+          taskStatus: {
+            state: 'input-required',
+            message: {
+              content:
+                'Select a wallet token to swap into USDC collateral before opening the GMX position.',
+            },
+          },
+        },
+        activity: { telemetry: [], events: [] },
+        metrics: {},
+        transactionHistory: [],
+        delegationsBypassActive: false,
+      },
+    } as unknown as ClmmState;
+
+    const result = await collectFundingTokenInputNode(state, { configurable: { thread_id: 'thread-1' } });
+
+    expect(interruptMock).toHaveBeenCalledTimes(1);
+    expect(copilotkitEmitStateMock).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       thread: {
         fundingTokenInput: {

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/collectFundingTokenInput.unit.test.ts
@@ -6,12 +6,29 @@ import type { ClmmState } from '../context.js';
 
 import { collectFundingTokenInputNode } from './collectFundingTokenInput.js';
 
-const { copilotkitEmitStateMock } = vi.hoisted(() => ({
+const { copilotkitEmitStateMock, getOnchainActionsClientMock, interruptMock } = vi.hoisted(() => ({
   copilotkitEmitStateMock: vi.fn(),
+  getOnchainActionsClientMock: vi.fn(),
+  interruptMock: vi.fn(),
 }));
 
 vi.mock('@copilotkit/sdk-js/langgraph', () => ({
   copilotkitEmitState: copilotkitEmitStateMock,
+}));
+
+vi.mock('@langchain/langgraph', async (importOriginal) => {
+  const actual: unknown = await importOriginal();
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error('Unexpected @langchain/langgraph mock import shape');
+  }
+  return {
+    ...(actual as Record<string, unknown>),
+    interrupt: interruptMock,
+  };
+});
+
+vi.mock('../clientFactory.js', () => ({
+  getOnchainActionsClient: getOnchainActionsClientMock,
 }));
 
 describe('collectFundingTokenInputNode', () => {
@@ -37,6 +54,7 @@ describe('collectFundingTokenInputNode', () => {
   it('returns a no-op update when funding token is already set after onboarding completion', async () => {
     copilotkitEmitStateMock.mockReset();
     copilotkitEmitStateMock.mockResolvedValue(undefined);
+    getOnchainActionsClientMock.mockReset();
 
     const state = {
       thread: {
@@ -47,6 +65,7 @@ describe('collectFundingTokenInputNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         operatorConfig: {
           delegatorWalletAddress: '0x1111111111111111111111111111111111111111',
@@ -68,5 +87,197 @@ describe('collectFundingTokenInputNode', () => {
 
     expect(result).toEqual({});
     expect(copilotkitEmitStateMock).not.toHaveBeenCalled();
+  });
+
+  it('skips funding-token selection when wallet USDC already covers the requested collateral amount', async () => {
+    copilotkitEmitStateMock.mockReset();
+    copilotkitEmitStateMock.mockResolvedValue(undefined);
+    getOnchainActionsClientMock.mockReset();
+    getOnchainActionsClientMock.mockReturnValue({
+      listPerpetualMarkets: vi.fn().mockResolvedValue([
+        {
+          marketToken: { chainId: '42161', address: '0x4444444444444444444444444444444444444444' },
+          longFundingFee: '0',
+          shortFundingFee: '0',
+          longBorrowingFee: '0',
+          shortBorrowingFee: '0',
+          chainId: '42161',
+          name: 'BTC/USD [WBTC-USDC]',
+          indexToken: {
+            tokenUid: { chainId: '42161', address: '0x1111111111111111111111111111111111111111' },
+            name: 'Bitcoin',
+            symbol: 'BTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          longToken: {
+            tokenUid: { chainId: '42161', address: '0x2222222222222222222222222222222222222222' },
+            name: 'Wrapped BTC',
+            symbol: 'WBTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          shortToken: {
+            tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+            name: 'USD Coin',
+            symbol: 'USDC',
+            isNative: false,
+            decimals: 6,
+            iconUri: null,
+            isVetted: true,
+          },
+        },
+      ]),
+      listWalletBalances: vi.fn().mockResolvedValue([
+        {
+          tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+          amount: '150000000',
+          symbol: 'USDC',
+          decimals: 6,
+          valueUsd: 150,
+        },
+      ]),
+    });
+
+    const state = {
+      thread: {
+        operatorInput: {
+          walletAddress: '0x1111111111111111111111111111111111111111',
+          usdcAllocation: 100,
+          targetMarket: 'BTC',
+        },
+        onboarding: { step: 2, key: 'funding-token' },
+        task: { id: 'task-1', taskStatus: { state: 'working' } },
+        activity: { telemetry: [], events: [] },
+        profile: {},
+        metrics: {},
+        transactionHistory: [],
+        delegationsBypassActive: false,
+      },
+    } as unknown as ClmmState;
+
+    const result = await collectFundingTokenInputNode(state, {});
+
+    expect(result).toMatchObject({
+      thread: {
+        fundingTokenInput: {
+          fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        },
+        onboarding: { step: 3, key: 'delegation-signing' },
+      },
+    });
+    expect(copilotkitEmitStateMock).not.toHaveBeenCalled();
+  });
+
+  it('collects a swap-source token when wallet USDC is insufficient and preserves USDC as collateral', async () => {
+    copilotkitEmitStateMock.mockReset();
+    copilotkitEmitStateMock.mockResolvedValue(undefined);
+    getOnchainActionsClientMock.mockReset();
+    interruptMock.mockReset();
+    interruptMock.mockResolvedValue({
+      fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+    });
+    getOnchainActionsClientMock.mockReturnValue({
+      listPerpetualMarkets: vi.fn().mockResolvedValue([
+        {
+          marketToken: { chainId: '42161', address: '0x4444444444444444444444444444444444444444' },
+          longFundingFee: '0',
+          shortFundingFee: '0',
+          longBorrowingFee: '0',
+          shortBorrowingFee: '0',
+          chainId: '42161',
+          name: 'BTC/USD [WBTC-USDC]',
+          indexToken: {
+            tokenUid: { chainId: '42161', address: '0x1111111111111111111111111111111111111111' },
+            name: 'Bitcoin',
+            symbol: 'BTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          longToken: {
+            tokenUid: { chainId: '42161', address: '0x2222222222222222222222222222222222222222' },
+            name: 'Wrapped BTC',
+            symbol: 'WBTC',
+            isNative: false,
+            decimals: 8,
+            iconUri: null,
+            isVetted: true,
+          },
+          shortToken: {
+            tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+            name: 'USD Coin',
+            symbol: 'USDC',
+            isNative: false,
+            decimals: 6,
+            iconUri: null,
+            isVetted: true,
+          },
+        },
+      ]),
+      listWalletBalances: vi.fn().mockResolvedValue([
+        {
+          tokenUid: { chainId: '42161', address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831' },
+          amount: '25000000',
+          symbol: 'USDC',
+          decimals: 6,
+          valueUsd: 25,
+        },
+        {
+          tokenUid: { chainId: '42161', address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' },
+          amount: '1000000000000000000',
+          symbol: 'WETH',
+          decimals: 18,
+          valueUsd: 1800,
+        },
+      ]),
+    });
+
+    const state = {
+      thread: {
+        operatorInput: {
+          walletAddress: '0x1111111111111111111111111111111111111111',
+          usdcAllocation: 100,
+          targetMarket: 'BTC',
+        },
+        onboarding: { step: 2, key: 'funding-token' },
+        task: { id: 'task-1', taskStatus: { state: 'submitted' } },
+        activity: { telemetry: [], events: [] },
+        profile: {},
+        metrics: {},
+        transactionHistory: [],
+        delegationsBypassActive: false,
+      },
+    } as unknown as ClmmState;
+
+    const result = await collectFundingTokenInputNode(state, {});
+
+    expect(interruptMock).toHaveBeenCalledTimes(1);
+    expect(interruptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'gmx-funding-token-request',
+        options: [
+          expect.objectContaining({
+            address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+            symbol: 'WETH',
+          }),
+        ],
+      }),
+    );
+    expect(result).toMatchObject({
+      thread: {
+        fundingTokenInput: {
+          fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        },
+        onboarding: { step: 3, key: 'delegation-signing' },
+      },
+    });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/fireCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/fireCommand.unit.test.ts
@@ -54,6 +54,7 @@ function makeResolvedConfig(params: {
   delegatorWalletAddress: `0x${string}`;
   delegateeWalletAddress: `0x${string}`;
   fundingTokenAddress: `0x${string}`;
+  collateralTokenAddress?: `0x${string}`;
   marketAddress: `0x${string}`;
 }): ResolvedGmxConfig {
   return {
@@ -61,6 +62,7 @@ function makeResolvedConfig(params: {
     delegateeWalletAddress: params.delegateeWalletAddress,
     baseContributionUsd: 10,
     fundingTokenAddress: params.fundingTokenAddress,
+    collateralTokenAddress: params.collateralTokenAddress ?? params.fundingTokenAddress,
     targetMarket: {
       address: params.marketAddress,
       baseSymbol: 'BTC',

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
@@ -1627,7 +1627,7 @@ export const pollCycleNode = async (
     marketAddress: gmxMarketAddress as `0x${string}`,
     walletAddress: planBuilderWalletAddress,
     payTokenAddress: operatorConfig.fundingTokenAddress,
-    collateralTokenAddress: operatorConfig.fundingTokenAddress,
+    collateralTokenAddress: operatorConfig.collateralTokenAddress,
     actualPositionSide: currentPositionSide,
     assumedPositionSide: reconciledAssumedPositionSide ?? activePositionSyncGuard?.expectedSide,
     positionContractKey: positionForReduce?.contractKey,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
@@ -1719,8 +1719,12 @@ export const pollCycleNode = async (
     positionContractKey: positionForReduce?.contractKey,
     positionSizeInUsd: positionForReduce?.sizeInUsd,
   });
+  const fundingTokenAddress = operatorConfig.fundingTokenAddress;
+  const collateralTokenAddress = operatorConfig.collateralTokenAddress;
   const collateralSwapFundingEstimate =
-    operatorConfig.fundingTokenAddress.toLowerCase() === operatorConfig.collateralTokenAddress.toLowerCase()
+    typeof fundingTokenAddress !== 'string' ||
+    typeof collateralTokenAddress !== 'string' ||
+    fundingTokenAddress.toLowerCase() === collateralTokenAddress.toLowerCase()
       ? undefined
       : {
           fromTokenDecimals: operatorConfig.fundingTokenDecimals,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.ts
@@ -1,5 +1,6 @@
 import { copilotkitEmitState } from '@copilotkit/sdk-js/langgraph';
 import type { TaskState } from 'agent-workflow-core';
+import { formatUnits, parseUnits } from 'viem';
 
 import { fetchAlloraInference, type AlloraInference } from '../../clients/allora.js';
 import {
@@ -311,6 +312,60 @@ type ExecutionFeeTopUpLogContext = {
   iteration: number;
 };
 
+export function estimateFundingTokenUsdPrice(params: {
+  amountBaseUnits?: string;
+  decimals?: number;
+  valueUsd?: number;
+  fallbackUsdPrice?: number;
+}): number | undefined {
+  if (
+    typeof params.amountBaseUnits !== 'string' ||
+    typeof params.decimals !== 'number' ||
+    typeof params.valueUsd !== 'number' ||
+    !Number.isFinite(params.valueUsd) ||
+    params.valueUsd <= 0
+  ) {
+    return params.fallbackUsdPrice;
+  }
+
+  let amount: number;
+  try {
+    amount = Number(formatUnits(BigInt(params.amountBaseUnits), params.decimals));
+  } catch {
+    return params.fallbackUsdPrice;
+  }
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return params.fallbackUsdPrice;
+  }
+
+  const usdPrice = params.valueUsd / amount;
+  return Number.isFinite(usdPrice) && usdPrice > 0 ? usdPrice : params.fallbackUsdPrice;
+}
+
+export function estimateExecutionFeeTopUpExactInAmountBaseUnits(params: {
+  targetFeeUsd: number;
+  fundingTokenDecimals: number;
+  fundingTokenUsdPrice: number;
+}): string {
+  if (!Number.isFinite(params.targetFeeUsd) || params.targetFeeUsd <= 0) {
+    throw new Error('Execution-fee top-up target must be positive.');
+  }
+  if (!Number.isFinite(params.fundingTokenUsdPrice) || params.fundingTokenUsdPrice <= 0) {
+    throw new Error('Funding token USD price is required to price the execution-fee top-up.');
+  }
+
+  const amountIn = params.targetFeeUsd / params.fundingTokenUsdPrice;
+  let amountInBaseUnits = parseUnits(
+    amountIn.toFixed(params.fundingTokenDecimals),
+    params.fundingTokenDecimals,
+  );
+  if (amountInBaseUnits <= 0n) {
+    amountInBaseUnits = 1n;
+  }
+  return amountInBaseUnits.toString();
+}
+
 function isExecutionFeeFundingShortfall(errorMessage: string | undefined): boolean {
   if (!errorMessage) {
     return false;
@@ -370,6 +425,7 @@ async function executeConfirmedFlipPlan(params: {
     OnchainActionsClient,
     | 'listPerpetualPositions'
     | 'getPerpetualLifecycle'
+    | 'createSwap'
     | 'createPerpetualLong'
     | 'createPerpetualShort'
     | 'createPerpetualClose'
@@ -382,6 +438,13 @@ async function executeConfirmedFlipPlan(params: {
   delegationBundle: ClmmState['thread']['delegationBundle'];
   delegatorWalletAddress: `0x${string}`;
   delegateeWalletAddress: `0x${string}`;
+  swapFundingEstimate?: {
+    fromTokenDecimals?: number;
+    fromTokenBalanceBaseUnits?: string;
+    fromTokenUsdPrice?: number;
+    toTokenDecimals?: number;
+    toTokenUsdPrice?: number;
+  };
   runtimeThreadId: string | undefined;
   runtimeCheckpointId: string | undefined;
   runtimeCheckpointNamespace: string | undefined;
@@ -397,6 +460,7 @@ async function executeConfirmedFlipPlan(params: {
       delegationBundle: params.delegationBundle,
       delegatorWalletAddress: params.delegatorWalletAddress,
       delegateeWalletAddress: params.delegateeWalletAddress,
+      swapFundingEstimate: params.swapFundingEstimate,
     });
   }
 
@@ -413,6 +477,7 @@ async function executeConfirmedFlipPlan(params: {
     delegationBundle: params.delegationBundle,
     delegatorWalletAddress: params.delegatorWalletAddress,
     delegateeWalletAddress: params.delegateeWalletAddress,
+    swapFundingEstimate: params.swapFundingEstimate,
   });
 
   if (!closeExecution.ok) {
@@ -535,6 +600,7 @@ async function executeConfirmedFlipPlan(params: {
     delegationBundle: params.delegationBundle,
     delegatorWalletAddress: params.delegatorWalletAddress,
     delegateeWalletAddress: params.delegateeWalletAddress,
+    swapFundingEstimate: params.swapFundingEstimate,
   });
 
   return {
@@ -627,6 +693,7 @@ async function maybeAutoFundExecutionFee(params: {
   delegatorWalletAddress: `0x${string}`;
   delegateeWalletAddress: `0x${string}`;
   fundingTokenAddress: `0x${string}`;
+  fundingTokenUsdPrice?: number;
   executionPlan: ExecutionPlan;
   logContext: ExecutionFeeTopUpLogContext;
 }): Promise<ExecutionFeeTopUpAttempt> {
@@ -710,8 +777,6 @@ async function maybeAutoFundExecutionFee(params: {
       EXECUTION_FEE_TOP_UP_MIN_USD,
       Math.min(EXECUTION_FEE_TOP_UP_MAX_USD, bufferedFeeUsd),
     );
-    const scale = 10 ** fundingToken.decimals;
-    const exactInAmountBaseUnits = Math.max(1, Math.ceil(targetFeeUsd * scale)).toString();
     const balances = await params.onchainActionsClient.listWalletBalances({
       walletAddress: params.planBuilderWalletAddress,
     });
@@ -730,11 +795,38 @@ async function maybeAutoFundExecutionFee(params: {
       nativeBalance.valueUsd >= 0
         ? nativeBalance.valueUsd
         : undefined;
+    const fundingBalance = balances.find(
+      (balance) =>
+        balance.tokenUid.chainId === chainId &&
+        balance.tokenUid.address.toLowerCase() === fundingToken.tokenUid.address.toLowerCase(),
+    );
+    const fundingTokenDecimals = fundingBalance?.decimals ?? fundingToken.decimals;
+    const fundingTokenUsdPrice = estimateFundingTokenUsdPrice({
+      amountBaseUnits: fundingBalance?.amount,
+      decimals: fundingTokenDecimals,
+      valueUsd: fundingBalance?.valueUsd,
+      fallbackUsdPrice:
+        fundingToken.symbol.toUpperCase() === 'USDC' ? 1 : params.fundingTokenUsdPrice,
+    });
+    if (fundingTokenUsdPrice === undefined) {
+      return {
+        attempted: true,
+        funded: false,
+        error: 'Unable to price the funding token for automatic execution-fee top-up.',
+      };
+    }
+    const exactInAmountBaseUnits = estimateExecutionFeeTopUpExactInAmountBaseUnits({
+      targetFeeUsd,
+      fundingTokenDecimals,
+      fundingTokenUsdPrice,
+    });
     logWarn('pollCycle: execution-fee top-up preflight computed', {
       ...params.logContext,
       estimatedFeeUsdRaw,
       perExecutionFeeUsd,
       targetFeeUsd,
+      fundingTokenDecimals,
+      fundingTokenUsdPrice,
       exactInAmountBaseUnits,
       nativeBalanceAmount: nativeBalance?.amount,
       nativeBalanceUsd,
@@ -750,12 +842,6 @@ async function maybeAutoFundExecutionFee(params: {
       });
       return { attempted: false, funded: false };
     }
-
-    const fundingBalance = balances.find(
-      (balance) =>
-        balance.tokenUid.chainId === chainId &&
-        balance.tokenUid.address.toLowerCase() === fundingToken.tokenUid.address.toLowerCase(),
-    );
     if (fundingBalance && BigInt(fundingBalance.amount) < BigInt(exactInAmountBaseUnits)) {
       return {
         attempted: true,
@@ -1633,6 +1719,16 @@ export const pollCycleNode = async (
     positionContractKey: positionForReduce?.contractKey,
     positionSizeInUsd: positionForReduce?.sizeInUsd,
   });
+  const collateralSwapFundingEstimate =
+    operatorConfig.fundingTokenAddress.toLowerCase() === operatorConfig.collateralTokenAddress.toLowerCase()
+      ? undefined
+      : {
+          fromTokenDecimals: operatorConfig.fundingTokenDecimals,
+          fromTokenBalanceBaseUnits: operatorConfig.fundingTokenBalanceBaseUnits,
+          fromTokenUsdPrice: operatorConfig.fundingTokenUsdPrice,
+          toTokenDecimals: operatorConfig.collateralTokenDecimals,
+          toTokenUsdPrice: 1,
+        };
 
   const skipTradeForUnchangedInference =
     isTradePlanAction(plannedExecutionPlan.action) &&
@@ -1768,6 +1864,7 @@ export const pollCycleNode = async (
           delegationBundle: state.thread.delegationBundle,
           delegatorWalletAddress: operatorConfig.delegatorWalletAddress,
           delegateeWalletAddress: operatorConfig.delegateeWalletAddress,
+          swapFundingEstimate: collateralSwapFundingEstimate,
           runtimeThreadId,
           runtimeCheckpointId,
           runtimeCheckpointNamespace,
@@ -1782,6 +1879,7 @@ export const pollCycleNode = async (
           delegationBundle: state.thread.delegationBundle,
           delegatorWalletAddress: operatorConfig.delegatorWalletAddress,
           delegateeWalletAddress: operatorConfig.delegateeWalletAddress,
+          swapFundingEstimate: collateralSwapFundingEstimate,
         });
   logWarn('pollCycle: executePerpetualPlan resolved', {
     threadId: runtimeThreadId,
@@ -1825,6 +1923,7 @@ export const pollCycleNode = async (
       delegatorWalletAddress: operatorConfig.delegatorWalletAddress,
       delegateeWalletAddress: operatorConfig.delegateeWalletAddress,
       fundingTokenAddress: operatorConfig.fundingTokenAddress,
+      fundingTokenUsdPrice: operatorConfig.fundingTokenUsdPrice,
       executionPlan,
       logContext: {
         threadId: runtimeThreadId,
@@ -1869,6 +1968,7 @@ export const pollCycleNode = async (
               delegationBundle: state.thread.delegationBundle,
               delegatorWalletAddress: operatorConfig.delegatorWalletAddress,
               delegateeWalletAddress: operatorConfig.delegateeWalletAddress,
+              swapFundingEstimate: collateralSwapFundingEstimate,
               runtimeThreadId,
               runtimeCheckpointId,
               runtimeCheckpointNamespace,
@@ -1883,6 +1983,7 @@ export const pollCycleNode = async (
               delegationBundle: state.thread.delegationBundle,
               delegatorWalletAddress: operatorConfig.delegatorWalletAddress,
               delegateeWalletAddress: operatorConfig.delegateeWalletAddress,
+              swapFundingEstimate: collateralSwapFundingEstimate,
             });
       logWarn('pollCycle: retry after execution-fee top-up resolved', {
         threadId: runtimeThreadId,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.unit.test.ts
@@ -33,6 +33,7 @@ describe('pollCycleNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         task: { id: 'task-1', taskStatus: { state: 'working' } },
         activity: { telemetry: [], events: [] },

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/pollCycle.unit.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { ClmmState } from '../context.js';
 
-import { pollCycleNode } from './pollCycle.js';
+import {
+  estimateExecutionFeeTopUpExactInAmountBaseUnits,
+  estimateFundingTokenUsdPrice,
+  pollCycleNode,
+} from './pollCycle.js';
 
 const { copilotkitEmitStateMock } = vi.hoisted(() => ({
   copilotkitEmitStateMock: vi.fn(),
@@ -15,6 +19,26 @@ vi.mock('@copilotkit/sdk-js/langgraph', () => ({
 }));
 
 describe('pollCycleNode', () => {
+  it('derives the funding token USD price from the live wallet balance snapshot', () => {
+    expect(
+      estimateFundingTokenUsdPrice({
+        amountBaseUnits: '1000000000000000000',
+        decimals: 18,
+        valueUsd: 1600,
+      }),
+    ).toBe(1600);
+  });
+
+  it('prices execution-fee top-up exact-in amounts using the funding token USD price', () => {
+    expect(
+      estimateExecutionFeeTopUpExactInAmountBaseUnits({
+        targetFeeUsd: 5,
+        fundingTokenDecimals: 18,
+        fundingTokenUsdPrice: 1600,
+      }),
+    ).toBe('3125000000000000');
+  });
+
   it('uses state-driven routing and avoids direct Command construction', async () => {
     const source = await readFile(new URL('./pollCycle.ts', import.meta.url), 'utf8');
     expect(source.includes('new Command(')).toBe(false);

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.ts
@@ -180,6 +180,10 @@ export const prepareOperatorNode = async (
     baseContributionUsd: operatorInput.usdcAllocation,
     fundingTokenAddress,
     collateralTokenAddress,
+    fundingTokenDecimals: fundingTokenInput.fundingTokenDecimals,
+    fundingTokenBalanceBaseUnits: fundingTokenInput.fundingTokenBalanceBaseUnits,
+    fundingTokenUsdPrice: fundingTokenInput.fundingTokenUsdPrice,
+    collateralTokenDecimals: fundingTokenInput.collateralTokenDecimals,
     targetMarket,
     maxLeverage: targetMarket.maxLeverage,
   };

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.ts
@@ -97,6 +97,10 @@ export const prepareOperatorNode = async (
     fundingTokenInput.fundingTokenAddress,
     'funding token address',
   );
+  const collateralTokenAddress = normalizeHexAddress(
+    fundingTokenInput.collateralTokenAddress,
+    'collateral token address',
+  );
 
   const delegationsBypassActive = state.thread.delegationsBypassActive === true;
   const agentWalletAddress = resolveAgentWalletAddress();
@@ -175,6 +179,7 @@ export const prepareOperatorNode = async (
     delegateeWalletAddress,
     baseContributionUsd: operatorInput.usdcAllocation,
     fundingTokenAddress,
+    collateralTokenAddress,
     targetMarket,
     maxLeverage: targetMarket.maxLeverage,
   };
@@ -185,6 +190,7 @@ export const prepareOperatorNode = async (
     delegateeWalletAddress: operatorConfig.delegateeWalletAddress,
     usdcAllocation: operatorConfig.baseContributionUsd,
     fundingToken: fundingTokenAddress,
+    collateralToken: collateralTokenAddress,
     market: `${targetMarket.baseSymbol}/${targetMarket.quoteSymbol}`,
     maxLeverage: targetMarket.maxLeverage,
   });

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.unit.test.ts
@@ -185,6 +185,10 @@ describe('prepareOperatorNode', () => {
         fundingTokenInput: {
           fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
           collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          fundingTokenDecimals: 18,
+          fundingTokenBalanceBaseUnits: '1000000000000000000',
+          fundingTokenUsdPrice: 1800,
+          collateralTokenDecimals: 6,
         },
         delegationsBypassActive: true,
         delegationBundle: undefined,
@@ -203,6 +207,10 @@ describe('prepareOperatorNode', () => {
         operatorConfig: {
           fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
           collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          fundingTokenDecimals: 18,
+          fundingTokenBalanceBaseUnits: '1000000000000000000',
+          fundingTokenUsdPrice: 1800,
+          collateralTokenDecimals: 6,
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/prepareOperator.unit.test.ts
@@ -51,6 +51,7 @@ describe('prepareOperatorNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         delegationsBypassActive: false,
         delegationBundle: undefined,
@@ -99,6 +100,7 @@ describe('prepareOperatorNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         delegationsBypassActive: false,
         delegationBundle: undefined,
@@ -135,6 +137,7 @@ describe('prepareOperatorNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         delegationsBypassActive: false,
         delegationBundle: undefined,
@@ -163,6 +166,48 @@ describe('prepareOperatorNode', () => {
     expect(copilotkitEmitStateMock).not.toHaveBeenCalled();
   });
 
+  it('preserves a distinct collateral token when funding input selected a swap source', async () => {
+    process.env['GMX_ALLORA_AGENT_WALLET_ADDRESS'] = '0x3333333333333333333333333333333333333333';
+    copilotkitEmitStateMock.mockResolvedValue(undefined);
+    ensureCronForThreadMock.mockReturnValue({ stop: vi.fn() });
+
+    const state = {
+      private: {
+        pollIntervalMs: 60000,
+        cronScheduled: false,
+      },
+      thread: {
+        operatorInput: {
+          walletAddress: '0x1111111111111111111111111111111111111111',
+          usdcAllocation: 100,
+          targetMarket: 'BTC',
+        },
+        fundingTokenInput: {
+          fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        },
+        delegationsBypassActive: true,
+        delegationBundle: undefined,
+        task: { id: 'task-1', taskStatus: { state: 'working' } },
+        activity: { telemetry: [], events: [] },
+        profile: {},
+        metrics: {},
+        transactionHistory: [],
+      },
+    } as unknown as ClmmState;
+
+    const result = await prepareOperatorNode(state, { configurable: { thread_id: 'thread-1' } });
+
+    expect(result).toMatchObject({
+      thread: {
+        operatorConfig: {
+          fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        },
+      },
+    });
+  });
+
   it('arms cron scheduling when onboarding completes on an active thread', async () => {
     process.env['GMX_ALLORA_AGENT_WALLET_ADDRESS'] = '0x3333333333333333333333333333333333333333';
     copilotkitEmitStateMock.mockResolvedValue(undefined);
@@ -181,6 +226,7 @@ describe('prepareOperatorNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         delegationsBypassActive: false,
         delegationBundle: {

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCycleCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCycleCommand.unit.test.ts
@@ -33,6 +33,7 @@ describe('runCycleCommandNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
       },
     } as unknown as ClmmState;
@@ -56,6 +57,7 @@ describe('runCycleCommandNode', () => {
         },
         fundingTokenInput: {
           fundingTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          collateralTokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
         },
         delegationBundle: {
           delegations: [],

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/onboardingRouting.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/onboardingRouting.ts
@@ -9,6 +9,8 @@ export type OnboardingNodeTarget =
   | 'prepareOperator'
   | 'syncState';
 
+export type PostFundingTokenNodeTarget = Exclude<OnboardingNodeTarget, 'syncState'>;
+
 export function resolveNextOnboardingNode(state: ClmmState): OnboardingNodeTarget {
   const phase = resolveOnboardingPhase({
     hasSetupInput: Boolean(state.thread.operatorInput),
@@ -28,4 +30,9 @@ export function resolveNextOnboardingNode(state: ClmmState): OnboardingNodeTarge
       ready: 'syncState',
     },
   });
+}
+
+export function resolvePostFundingTokenNode(state: ClmmState): PostFundingTokenNodeTarget {
+  const nextOnboardingNode = resolveNextOnboardingNode(state);
+  return nextOnboardingNode === 'syncState' ? 'prepareOperator' : nextOnboardingNode;
 }

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/onboardingRouting.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/onboardingRouting.unit.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ClmmState } from './context.js';
+import {
+  resolveNextOnboardingNode,
+  resolvePostFundingTokenNode,
+} from './onboardingRouting.js';
+
+function createState(overrides?: Partial<ClmmState['thread']>): ClmmState {
+  return {
+    messages: [],
+    thread: {
+      profile: {
+        chains: [],
+        protocols: [],
+        tokens: [],
+      },
+      metrics: {
+        iteration: 0,
+        cyclesSinceRebalance: 0,
+        staleCycles: 0,
+      },
+      activity: {
+        telemetry: [],
+        events: [],
+      },
+      transactionHistory: [],
+      ...overrides,
+    },
+  } as ClmmState;
+}
+
+describe('onboardingRouting', () => {
+  it('keeps GMX onboarding on the funding-token node until a funding token is selected', () => {
+    const state = createState({
+      operatorInput: {
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        targetMarket: 'BTC',
+        usdcAllocation: 10,
+      },
+    });
+
+    expect(resolveNextOnboardingNode(state)).toBe('collectFundingTokenInput');
+    expect(resolvePostFundingTokenNode(state)).toBe('collectFundingTokenInput');
+  });
+
+  it('advances to delegations after funding-token selection when signing is still required', () => {
+    const state = createState({
+      operatorInput: {
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        targetMarket: 'BTC',
+        usdcAllocation: 10,
+      },
+      fundingTokenInput: {
+        fundingTokenAddress: '0x0000000000000000000000000000000000000002',
+        collateralTokenAddress: '0x0000000000000000000000000000000000000003',
+      },
+    });
+
+    expect(resolveNextOnboardingNode(state)).toBe('collectDelegations');
+    expect(resolvePostFundingTokenNode(state)).toBe('collectDelegations');
+  });
+
+  it('advances directly to operator preparation when delegations are bypassed', () => {
+    const state = createState({
+      delegationsBypassActive: true,
+      operatorInput: {
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        targetMarket: 'BTC',
+        usdcAllocation: 10,
+      },
+      fundingTokenInput: {
+        fundingTokenAddress: '0x0000000000000000000000000000000000000002',
+        collateralTokenAddress: '0x0000000000000000000000000000000000000003',
+      },
+    });
+
+    expect(resolveNextOnboardingNode(state)).toBe('prepareOperator');
+    expect(resolvePostFundingTokenNode(state)).toBe('prepareOperator');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/pollCycle.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/pollCycle.int.test.ts
@@ -124,6 +124,7 @@ function buildBaseState(): ClmmState {
         delegateeWalletAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         baseContributionUsd: 200,
         fundingTokenAddress: '0x1111111111111111111111111111111111111111',
+        collateralTokenAddress: '0x1111111111111111111111111111111111111111',
         targetMarket: {
           address: '0xmarket',
           baseSymbol: 'BTC',

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
@@ -62,6 +62,24 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
   const incomingMetrics = isRecord(incomingThread.metrics)
     ? incomingThread.metrics
     : ({} as Partial<ThreadState['metrics']>);
+  const incomingLifecyclePhase = incomingThread.lifecycle?.phase;
+  const baseThread =
+    incomingLifecyclePhase === 'prehire'
+      ? {
+          ...projected.thread,
+          task: defaultThreadState.task,
+          onboardingFlow: defaultThreadState.onboardingFlow,
+          poolArtifact: defaultThreadState.poolArtifact,
+          operatorInput: defaultThreadState.operatorInput,
+          fundingTokenInput: defaultThreadState.fundingTokenInput,
+          selectedPool: defaultThreadState.selectedPool,
+          operatorConfig: defaultThreadState.operatorConfig,
+          delegationBundle: defaultThreadState.delegationBundle,
+          haltReason: defaultThreadState.haltReason,
+          executionError: defaultThreadState.executionError,
+          delegationsBypassActive: defaultThreadState.delegationsBypassActive,
+        }
+      : projected.thread;
 
   projected.messages = Array.isArray(incoming.messages) ? incoming.messages : projected.messages;
 
@@ -84,44 +102,44 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
   }
 
   projected.thread = {
-    ...projected.thread,
+    ...baseThread,
     ...incomingThread,
     profile: {
-      ...projected.thread.profile,
+      ...baseThread.profile,
       ...incomingProfile,
       chains: Array.isArray(incomingProfile.chains)
         ? incomingProfile.chains
-        : projected.thread.profile.chains,
+        : baseThread.profile.chains,
       protocols: Array.isArray(incomingProfile.protocols)
         ? incomingProfile.protocols
-        : projected.thread.profile.protocols,
+        : baseThread.profile.protocols,
       tokens: Array.isArray(incomingProfile.tokens)
         ? incomingProfile.tokens
-        : projected.thread.profile.tokens,
+        : baseThread.profile.tokens,
       pools: Array.isArray(incomingProfile.pools)
         ? incomingProfile.pools
-        : projected.thread.profile.pools,
+        : baseThread.profile.pools,
       allowedPools: Array.isArray(incomingProfile.allowedPools)
         ? incomingProfile.allowedPools
-        : projected.thread.profile.allowedPools,
+        : baseThread.profile.allowedPools,
     },
     activity: {
-      ...projected.thread.activity,
+      ...baseThread.activity,
       ...incomingActivity,
       telemetry: Array.isArray(incomingActivity.telemetry)
         ? incomingActivity.telemetry
-        : projected.thread.activity.telemetry,
+        : baseThread.activity.telemetry,
       events: Array.isArray(incomingActivity.events)
         ? incomingActivity.events
-        : projected.thread.activity.events,
+        : baseThread.activity.events,
     },
     metrics: {
-      ...projected.thread.metrics,
+      ...baseThread.metrics,
       ...incomingMetrics,
     },
     transactionHistory: Array.isArray(incomingThread.transactionHistory)
       ? incomingThread.transactionHistory
-      : projected.thread.transactionHistory,
+      : baseThread.transactionHistory,
   };
   return projected;
 }

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.unit.test.ts
@@ -165,4 +165,54 @@ describe('agentProjection', () => {
     expect(projected?.thread.metrics.apy).toBe(8.46);
     expect(projected?.thread.task?.id).toBe('task-2');
   });
+
+  it('clears onboarding-specific fields when a fresh prehire snapshot arrives', () => {
+    const previous = projectDetailStateFromPayload({
+      thread: {
+        lifecycle: {
+          phase: 'onboarding',
+        },
+        task: {
+          id: 'task-setup',
+          taskStatus: {
+            state: 'input-required',
+          },
+        },
+        onboardingFlow: {
+          status: 'in_progress',
+          revision: 2,
+          activeStepId: 'funding-token',
+          steps: [],
+        },
+        operatorInput: {
+          walletAddress: '0x0000000000000000000000000000000000000001',
+          baseContributionUsd: 500,
+        },
+        fundingTokenInput: {
+          tokenAddress: '0x0000000000000000000000000000000000000002',
+        },
+        profile: {
+          chains: ['Arbitrum'],
+        },
+      },
+    });
+
+    const projected = projectDetailStateFromPayload(
+      {
+        thread: {
+          lifecycle: {
+            phase: 'prehire',
+          },
+        },
+      },
+      previous,
+    );
+
+    expect(projected?.thread.lifecycle?.phase).toBe('prehire');
+    expect(projected?.thread.task).toBeUndefined();
+    expect(projected?.thread.onboardingFlow).toBeUndefined();
+    expect(projected?.thread.operatorInput).toBeUndefined();
+    expect(projected?.thread.fundingTokenInput).toBeUndefined();
+    expect(projected?.thread.profile.chains).toEqual(['Arbitrum']);
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -1972,6 +1972,139 @@ describe('useAgentConnection integration', () => {
     });
   });
 
+  it('prefers the synced funding-token interrupt over a stale streamed setup interrupt', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.interruptState.activeInterrupt = {
+      type: 'gmx-setup-request',
+      message: 'Select the GMX market and enter the USDC allocation for low-leverage trades.',
+    };
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-gmx-allora"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    subscriber?.onRunInitialized?.({
+      input: { threadId: 'thread-1' },
+      state: {
+        thread: {
+          lifecycle: {
+            phase: 'onboarding',
+          },
+          task: {
+            id: 'exec-2',
+            taskStatus: {
+              state: 'input-required',
+            },
+          },
+        },
+        tasks: [
+          {
+            interrupts: [
+              {
+                value: {
+                  type: 'gmx-funding-token-request',
+                  message: 'Choose the wallet token to swap into USDC before opening.',
+                  options: [],
+                },
+              },
+            ],
+          },
+        ],
+      } as ReturnType<AgentSubscriber['onRunInitialized']> extends ((event: infer T) => unknown)
+        ? T['state']
+        : never,
+    });
+    await flushEffects();
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-gmx-allora"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.activeInterrupt).toEqual({
+      type: 'gmx-funding-token-request',
+      message: 'Choose the wallet token to swap into USDC before opening.',
+      options: [],
+    });
+  });
+
+  it('clears stale streamed interrupts after a prehire snapshot is applied', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.interruptState.activeInterrupt = {
+      type: 'gmx-setup-request',
+      message: 'Select the GMX market and enter the USDC allocation for low-leverage trades.',
+    };
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-gmx-allora"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    subscriber?.onRunInitialized?.({
+      input: { threadId: 'thread-1' },
+      state: {
+        thread: {
+          lifecycle: {
+            phase: 'prehire',
+          },
+        },
+      } as ReturnType<AgentSubscriber['onRunInitialized']> extends ((event: infer T) => unknown)
+        ? T['state']
+        : never,
+    });
+    await flushEffects();
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-gmx-allora"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.activeInterrupt).toBeNull();
+  });
+
   it('routes Pi operator-note interrupt resolution through CopilotKit run orchestration with explicit resume payloads', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
 
@@ -2087,6 +2220,67 @@ describe('useAgentConnection integration', () => {
       },
     });
     expect(mocks.interruptState.resolve).not.toHaveBeenCalled();
+    expect(latestValue?.uiError).toBeNull();
+  });
+
+  it('allows interrupt resume while the current thread is still marked as locally in flight', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.interruptState.activeInterrupt = {
+      type: 'gmx-funding-token-request',
+      message: 'Select a token to swap into USDC',
+      options: [
+        {
+          address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          symbol: 'WETH',
+        },
+      ],
+    };
+    mocks.interruptState.canResolve = false;
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-gmx-allora"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    subscriber?.onRunStartedEvent?.({
+      input: {
+        threadId: 'thread-1',
+        runId: 'run-1',
+      },
+    });
+    await flushEffects();
+
+    latestValue?.resolveInterrupt({
+      fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+    });
+    await flushEffects();
+
+    expect(mocks.runAgent).toHaveBeenCalledWith({
+      agent: mocks.agent,
+      threadId: 'thread-1',
+      forwardedProps: {
+        command: {
+          resume: JSON.stringify({
+            fundingTokenAddress: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          }),
+        },
+      },
+    });
     expect(latestValue?.uiError).toBeNull();
   });
 

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -869,7 +869,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         commandSchedulerRef.current = null;
       }
     };
-  }, [agentId, copilotkit, setRunInFlight]);
+  }, [agentId, copilotkit, runAgentOnCurrentThread, setRunInFlight]);
 
   useEffect(() => {
     const ownerId = streamOwnerIdRef.current;
@@ -1287,7 +1287,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     }
 
     setTimeout(() => setIsFiring(false), 3000);
-  }, [config.imperativeCommandTransport, copilotkit, isFiring, threadId]);
+  }, [config.imperativeCommandTransport, copilotkit, isFiring, runAgentOnCurrentThread, threadId]);
 
   const sendChatMessage = useCallback(
     (content: string) => {
@@ -1331,6 +1331,8 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
   const effectiveActiveInterrupt = selectActiveInterrupt({
     streamInterrupt: activeInterrupt ?? null,
     syncPendingInterrupt: syncedPendingInterrupt,
+    lifecyclePhase: threadState.lifecycle?.phase ?? null,
+    hasLoadedSnapshot: hasLoadedView,
   });
 
   useEffect(() => {
@@ -1386,6 +1388,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
 
       const accepted = scheduler.dispatchCustom({
         command: 'resume',
+        allowPreemptive: true,
         run: async (currentAgent) => {
           emitConnectTrace('interrupt-submit-run-start', {
             interruptType: interruptType ?? null,
@@ -1429,7 +1432,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         runInFlight: runInFlightRef.current,
       });
     },
-    [copilotkit, effectiveActiveInterrupt?.type, emitConnectTrace, runCommand],
+    [effectiveActiveInterrupt?.type, emitConnectTrace, runAgentOnCurrentThread, runCommand],
   );
 
   // Local settings mutation helper; caller decides whether to enqueue a sync run.

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.unit.test.ts
@@ -22,7 +22,7 @@ describe('interruptSelection', () => {
     expect(normalizeAgentInterrupt('{not-json')).toBeNull();
   });
 
-  it('prefers stream interrupt over sync fallback', () => {
+  it('prefers the synced interrupt when the stream interrupt type is stale', () => {
     const streamInterrupt: AgentInterrupt = {
       type: 'operator-config-request',
       message: 'From stream',
@@ -32,7 +32,12 @@ describe('interruptSelection', () => {
       message: 'From sync',
     };
 
-    expect(selectActiveInterrupt({ streamInterrupt, syncPendingInterrupt })).toEqual(streamInterrupt);
+    expect(
+      selectActiveInterrupt({
+        streamInterrupt,
+        syncPendingInterrupt,
+      }),
+    ).toEqual(syncPendingInterrupt);
   });
 
   it('uses sync fallback when stream interrupt is absent', () => {
@@ -51,5 +56,41 @@ describe('interruptSelection', () => {
     expect(selectActiveInterrupt({ streamInterrupt: null, syncPendingInterrupt })).toEqual(
       syncPendingInterrupt,
     );
+  });
+
+  it('keeps the stream interrupt when the synced interrupt matches the same type', () => {
+    const streamInterrupt: AgentInterrupt = {
+      type: 'gmx-funding-token-request',
+      message: 'From stream',
+      options: [],
+    };
+    const syncPendingInterrupt: AgentInterrupt = {
+      type: 'gmx-funding-token-request',
+      message: 'From sync',
+      options: [],
+    };
+
+    expect(
+      selectActiveInterrupt({
+        streamInterrupt,
+        syncPendingInterrupt,
+      }),
+    ).toEqual(streamInterrupt);
+  });
+
+  it('clears stream-only interrupts after a prehire snapshot has loaded', () => {
+    const streamInterrupt: AgentInterrupt = {
+      type: 'gmx-setup-request',
+      message: 'Stale setup interrupt',
+    };
+
+    expect(
+      selectActiveInterrupt({
+        streamInterrupt,
+        syncPendingInterrupt: null,
+        lifecyclePhase: 'prehire',
+        hasLoadedSnapshot: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/interruptSelection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/interruptSelection.ts
@@ -41,4 +41,22 @@ export const normalizeAgentInterrupt = (value: unknown): AgentInterrupt | null =
 export const selectActiveInterrupt = (params: {
   streamInterrupt: AgentInterrupt | null;
   syncPendingInterrupt: AgentInterrupt | null;
-}): AgentInterrupt | null => params.streamInterrupt ?? params.syncPendingInterrupt;
+  lifecyclePhase?: string | null;
+  hasLoadedSnapshot?: boolean;
+}): AgentInterrupt | null => {
+  if (params.syncPendingInterrupt) {
+    if (!params.streamInterrupt) {
+      return params.syncPendingInterrupt;
+    }
+
+    return params.streamInterrupt.type === params.syncPendingInterrupt.type
+      ? params.streamInterrupt
+      : params.syncPendingInterrupt;
+  }
+
+  if (params.hasLoadedSnapshot && params.lifecyclePhase === 'prehire') {
+    return null;
+  }
+
+  return params.streamInterrupt;
+};


### PR DESCRIPTION
## Summary
- skip GMX funding selection when the wallet already has enough USDC collateral
- carry distinct funding and collateral token addresses through operator setup and cycle planning
- prepend an exact-out swap into USDC before GMX open and flip-reopen execution when the selected funding token is not USDC

## Testing
- `pnpm test:unit -- src/workflow/nodes/prepareOperator.unit.test.ts src/workflow/execution.unit.test.ts`

## Related
- Closes #575
