### PR TITLE
fix(web): filter pi sync transcript noise

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { AgentRuntimeDomainConfig } from 'agent-runtime';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedDelegation } from 'agent-runtime/internal';
@@ -634,6 +636,39 @@ function sanitizeIdentitySegment(value: string): string {
   return normalized.length > 0 ? normalized : 'portfolio-manager';
 }
 
+function stableStringifyForIdempotency(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringifyForIdempotency(entry)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+
+  return `{${entries
+    .map(
+      ([key, entryValue]) =>
+        `${JSON.stringify(key)}:${stableStringifyForIdempotency(entryValue)}`,
+    )
+    .join(',')}}`;
+}
+
+function buildPayloadDerivedIdempotencyKey(params: {
+  prefix: string;
+  payload: unknown;
+}): string {
+  const digest = createHash('sha256')
+    .update(stableStringifyForIdempotency(params.payload))
+    .digest('hex')
+    .slice(0, 24);
+
+  return `${params.prefix}-${digest}`;
+}
+
 function isNonEmptyStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) &&
@@ -1071,6 +1106,34 @@ function buildPortfolioManagerRootDelegationHandoff(params: {
       signed_delegation_count: 1,
     },
   };
+}
+
+function buildRootDelegationIdempotencyKey(params: {
+  threadId: string;
+  handoff: unknown;
+}): string {
+  return buildPayloadDerivedIdempotencyKey({
+    prefix: 'idem-root-delegation',
+    payload: {
+      threadId: params.threadId,
+      handoff: params.handoff,
+    },
+  });
+}
+
+function buildRootedBootstrapIdempotencyKey(params: {
+  threadId: string;
+  onboarding: unknown;
+  handoff: unknown;
+}): string {
+  return buildPayloadDerivedIdempotencyKey({
+    prefix: 'idem-portfolio-manager-rooted-bootstrap',
+    payload: {
+      threadId: params.threadId,
+      onboarding: params.onboarding,
+      handoff: params.handoff,
+    },
+  });
 }
 
 export function createPortfolioManagerDomain(
@@ -1529,7 +1592,11 @@ export function createPortfolioManagerDomain(
               id: `shared-ember-${threadId}-complete-rooted-bootstrap`,
               method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
               params: {
-                idempotency_key: `idem-portfolio-manager-rooted-bootstrap-${threadId}`,
+                idempotency_key: buildRootedBootstrapIdempotencyKey({
+                  threadId,
+                  onboarding,
+                  handoff,
+                }),
                 expected_revision: expectedRevision,
                 onboarding,
                 handoff,
@@ -1678,11 +1745,14 @@ export function createPortfolioManagerDomain(
           }
           const commandInput =
             typeof operation.input === 'object' && operation.input !== null ? operation.input : {};
+          const handoff = 'handoff' in commandInput ? commandInput.handoff : undefined;
           const idempotencyKey =
             'idempotencyKey' in commandInput && typeof commandInput.idempotencyKey === 'string'
               ? commandInput.idempotencyKey
-              : `idem-root-delegation-${threadId}`;
-          const handoff = 'handoff' in commandInput ? commandInput.handoff : undefined;
+              : buildRootDelegationIdempotencyKey({
+                  threadId,
+                  handoff,
+                });
           const response = await runSharedEmberCommandWithResolvedRevision<{
             result?: {
               revision?: number;
@@ -2037,12 +2107,16 @@ export function createPortfolioManagerDomain(
           }
           const commandInput =
             typeof operation.input === 'object' && operation.input !== null ? operation.input : {};
+          const onboarding = 'onboarding' in commandInput ? commandInput.onboarding : undefined;
+          const handoff = 'handoff' in commandInput ? commandInput.handoff : undefined;
           const idempotencyKey =
             'idempotencyKey' in commandInput && typeof commandInput.idempotencyKey === 'string'
               ? commandInput.idempotencyKey
-              : `idem-rooted-bootstrap-${threadId}`;
-          const onboarding = 'onboarding' in commandInput ? commandInput.onboarding : undefined;
-          const handoff = 'handoff' in commandInput ? commandInput.handoff : undefined;
+              : buildRootedBootstrapIdempotencyKey({
+                  threadId,
+                  onboarding,
+                  handoff,
+                });
           const response = await runSharedEmberCommandWithResolvedRevision<{
             result?: {
               revision?: number;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -49,8 +49,6 @@ function createSignedRootDelegation(delegate: `0x${string}`) {
 const TEST_REDELEGATION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
 const TEST_DELEGATION_MANAGER = '0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3';
-const TEST_CONTROLLER_SIGNER_ADDRESS =
-  '0x00000000000000000000000000000000000000c1' as const;
 const TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS =
   '0x00000000000000000000000000000000000000c2' as const;
 
@@ -532,6 +530,7 @@ describe('createPortfolioManagerDomain', () => {
         jsonrpc: '2.0',
         method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
         params: expect.objectContaining({
+          idempotency_key: expect.stringMatching(/^idem-portfolio-manager-rooted-bootstrap-/),
           expected_revision: 0,
           onboarding: expect.objectContaining({
             rootedWalletContext: expect.objectContaining({
@@ -641,6 +640,9 @@ describe('createPortfolioManagerDomain', () => {
             mandateRef?: string;
           };
         } & Record<string, unknown>;
+        handoff?: {
+          artifact_ref?: string;
+        };
       };
     };
 
@@ -820,9 +822,9 @@ describe('createPortfolioManagerDomain', () => {
             portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
             managedAgentMandates: [
               {
-                ...createPortfolioManagerSetupInput().managedAgentMandates[0],
+                ...createPortfolioManagerSetupInput().managedAgentMandates[0]!,
                 settings: {
-                  ...createPortfolioManagerSetupInput().managedAgentMandates[0].settings,
+                  ...createPortfolioManagerSetupInput().managedAgentMandates[0]!.settings,
                   allowedCollateralAssets: ['WETH'],
                   allowedBorrowAssets: ['WETH'],
                 },
@@ -1004,6 +1006,187 @@ describe('createPortfolioManagerDomain', () => {
         method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
       }),
     );
+  });
+
+  it('uses a distinct rooted-bootstrap idempotency key when signing input changes on the same thread', async () => {
+    const firstSignedDelegation = createSignedRootDelegation(TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS);
+    const secondSignedDelegation = {
+      ...createSignedRootDelegation(TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS),
+      signature:
+        '0x5678' as const,
+    };
+    const rootedBootstrapKeys: string[] = [];
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
+          if (params?.['agent_id'] === 'portfolio-manager' && params['role'] === 'orchestrator') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS,
+            });
+          }
+
+          if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'ember-lending',
+              role: 'subagent',
+              walletAddress: '0x00000000000000000000000000000000000000e1',
+            });
+          }
+        }
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.completeRootedBootstrapFromUserSigning.v1') {
+          const idempotencyKey = params?.['idempotency_key'];
+          if (typeof idempotencyKey !== 'string') {
+            throw new Error('expected rooted-bootstrap idempotency key');
+          }
+          rootedBootstrapKeys.push(idempotencyKey);
+        }
+
+        if (jsonRpcRequest?.['method'] === 'subagent.readExecutionContext.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-read-execution-context',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              execution_context: {
+                generated_at: '2026-04-02T15:00:00.000Z',
+                network: 'arbitrum',
+                mandate_ref: 'mandate-ember-lending-001',
+                mandate_summary: 'lend USDC on Aave within medium-risk allocation and health-factor guardrails',
+                mandate_context: null,
+                subagent_wallet_address: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
+                owned_units: [],
+                wallet_contents: [],
+              },
+            },
+          };
+        }
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readOnboardingState.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-wallet-accounting-ember-lending-0x00000000000000000000000000000000000000a1',
+            result: {
+              revision: 4,
+              onboarding_state: {
+                wallet_address: '0x00000000000000000000000000000000000000a1',
+                network: 'arbitrum',
+                phase: 'active',
+                proofs: {
+                  rooted_wallet_context_registered: true,
+                  root_delegation_registered: true,
+                  root_authority_active: true,
+                  wallet_baseline_observed: true,
+                  accounting_units_seeded: true,
+                  mandate_inputs_configured: true,
+                  reserve_policy_configured: false,
+                  capital_reserved_for_agent: true,
+                  policy_snapshot_recorded: true,
+                  initial_subagent_delegation_issued: true,
+                  agent_active: true,
+                },
+                rooted_wallet_context: {
+                  rooted_wallet_context_id: 'rwc-user-protocol-001',
+                },
+                root_delegation: {
+                  root_delegation_id: 'root-user-protocol-001',
+                },
+                owned_units: [],
+                reservations: [],
+              },
+            },
+          };
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-complete-rooted-bootstrap',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
+            rooted_wallet_context_id: 'rwc-user-protocol-001',
+            root_delegation: {
+              root_delegation_id: 'root-user-protocol-001',
+              user_wallet: '0x00000000000000000000000000000000000000a1',
+              status: 'active',
+            },
+          },
+        };
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 3,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 3,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS,
+    });
+
+    const baseState = {
+      phase: 'onboarding' as const,
+      lastPortfolioState: null,
+      lastSharedEmberRevision: 0,
+      lastRootDelegation: null,
+      lastOnboardingBootstrap: null,
+      lastRootedWalletContextId: null,
+      activeWalletAddress: '0x00000000000000000000000000000000000000a1' as const,
+      pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1' as const,
+      pendingApprovedMandateEnvelope: {
+        portfolioMandate: createPortfolioManagerSetupInput().portfolioMandate,
+        managedAgentMandates: createPortfolioManagerSetupInput().managedAgentMandates,
+      },
+    };
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: baseState,
+      operation: {
+        source: 'interrupt',
+        name: 'portfolio-manager-delegation-signing-request',
+        input: {
+          outcome: 'signed',
+          signedDelegations: [firstSignedDelegation],
+        },
+      },
+    });
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: baseState,
+      operation: {
+        source: 'interrupt',
+        name: 'portfolio-manager-delegation-signing-request',
+        input: {
+          outcome: 'signed',
+          signedDelegations: [secondSignedDelegation],
+        },
+      },
+    });
+
+    expect(rootedBootstrapKeys).toHaveLength(2);
+    expect(rootedBootstrapKeys[0]).not.toBe(rootedBootstrapKeys[1]);
   });
 
   it('fails fast before rooted bootstrap when the managed ember-lending identity echo is misaddressed', async () => {
@@ -2296,6 +2479,130 @@ describe('createPortfolioManagerDomain', () => {
         handoff,
       },
     });
+  });
+
+  it('derives a distinct fallback rooted-bootstrap idempotency key when command payload changes', async () => {
+    const firstOnboarding = createOnboardingBootstrap();
+    const secondOnboarding = {
+      ...createOnboardingBootstrap(),
+      activation: {
+        mandateRef: 'mandate-ember-lending-protocol-002',
+      },
+    };
+    const handoff = {
+      handoff_id: 'handoff-root-protocol-001',
+      root_delegation_id: 'root-user-protocol-001',
+      user_id: 'user_idle',
+      user_wallet: '0xUSERPROTO1',
+      orchestrator_wallet: '0xORCHPROTO1',
+      network: 'base',
+      artifact_ref: 'artifact-root-protocol-001',
+      issued_at: '2026-03-29T00:00:00Z',
+      activated_at: '2026-03-29T00:00:05Z',
+      signer_kind: 'delegation_toolkit',
+      metadata: {
+        delegation_manager: '0xDELEGATIONMANAGERPROTO1',
+      },
+    } as const;
+    const observedIdempotencyKeys: string[] = [];
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.completeRootedBootstrapFromUserSigning.v1') {
+          const idempotencyKey = params?.['idempotency_key'];
+          if (typeof idempotencyKey !== 'string') {
+            throw new Error('expected rooted-bootstrap idempotency key');
+          }
+          observedIdempotencyKeys.push(idempotencyKey);
+        }
+
+        return {
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-complete-rooted-bootstrap',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            committed_event_ids: ['evt-rooted-bootstrap-1', 'evt-rooted-bootstrap-2'],
+            rooted_wallet_context_id: 'rwc-user-protocol-001',
+            root_delegation: {
+              root_delegation_id: 'root-user-protocol-001',
+              user_wallet: '0xUSERPROTO1',
+              status: 'active',
+            },
+          },
+        };
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 3,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 3,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+    });
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        phase: 'onboarding',
+        lastPortfolioState: null,
+        lastSharedEmberRevision: 0,
+        lastRootDelegation: null,
+        lastOnboardingBootstrap: null,
+        lastRootedWalletContextId: null,
+        activeWalletAddress: null,
+        pendingOnboardingWalletAddress: null,
+      },
+      operation: {
+        source: 'tool',
+        name: 'complete_rooted_bootstrap_from_user_signing',
+        input: {
+          onboarding: firstOnboarding,
+          handoff,
+        },
+      },
+    });
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        phase: 'onboarding',
+        lastPortfolioState: null,
+        lastSharedEmberRevision: 0,
+        lastRootDelegation: null,
+        lastOnboardingBootstrap: null,
+        lastRootedWalletContextId: null,
+        activeWalletAddress: null,
+        pendingOnboardingWalletAddress: null,
+      },
+      operation: {
+        source: 'tool',
+        name: 'complete_rooted_bootstrap_from_user_signing',
+        input: {
+          onboarding: secondOnboarding,
+          handoff,
+        },
+      },
+    });
+
+    expect(observedIdempotencyKeys).toHaveLength(2);
+    expect(observedIdempotencyKeys[0]).toMatch(/^idem-portfolio-manager-rooted-bootstrap-/);
+    expect(observedIdempotencyKeys[0]).not.toBe(observedIdempotencyKeys[1]);
   });
 
   it('retries rooted bootstrap once after a Shared Ember expected_revision conflict', async () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.transcriptOrdering.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.transcriptOrdering.unit.test.tsx
@@ -339,4 +339,114 @@ describe('AgentDetailPage transcript ordering', () => {
       root.unmount();
     });
   });
+
+  it('hides sync-noise transcript rows while preserving non-sync reasoning', () => {
+    const root = createRoot(container);
+    const syncAckContent = JSON.stringify({ status: 'synced', clientMutationId: 'sync-1' });
+    const messages: Message[] = [
+      {
+        id: 'user-sync-1',
+        role: 'user',
+        content: JSON.stringify({ command: 'sync', clientMutationId: 'sync-1' }),
+      },
+      {
+        id: 'assistant-sync-1',
+        role: 'assistant',
+        content: syncAckContent,
+      },
+      {
+        id: 'reasoning-sync-1',
+        role: 'reasoning',
+        parentMessageId: 'assistant-sync-1',
+        content: 'Thinking about how to acknowledge the sync request.',
+      },
+      {
+        id: 'reasoning-visible-1',
+        role: 'reasoning',
+        parentMessageId: 'assistant-visible-1',
+        content: 'Thinking about the actual portfolio update.',
+      },
+      {
+        id: 'assistant-visible-1',
+        role: 'assistant',
+        content: 'Here is the portfolio update you asked for.',
+      },
+    ];
+
+    act(() => {
+      root.render(renderPage(messages));
+    });
+
+    const transcriptText = container.textContent ?? '';
+    expect(transcriptText).not.toContain('Requested a runtime sync.');
+    expect(transcriptText).not.toContain(syncAckContent);
+    expect(transcriptText).not.toContain('Thinking about how to acknowledge the sync request.');
+    expect(transcriptText).toContain('Thinking about the actual portfolio update.');
+    expect(transcriptText).toContain('Here is the portfolio update you asked for.');
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('keeps unlinked reasoning visible even when a sync acknowledgment is filtered', () => {
+    const root = createRoot(container);
+    const messages: Message[] = [
+      {
+        id: 'assistant-sync-1',
+        role: 'assistant',
+        content: JSON.stringify({ status: 'synced', clientMutationId: 'sync-1' }),
+      },
+      {
+        id: 'reasoning-unlinked-1',
+        role: 'reasoning',
+        content: 'Thinking about whether the sync completed cleanly.',
+      },
+    ];
+
+    act(() => {
+      root.render(renderPage(messages));
+    });
+
+    const transcriptText = container.textContent ?? '';
+    expect(transcriptText).toContain('Thinking about whether the sync completed cleanly.');
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('hides sync reasoning when the runtime encodes the linked assistant id inside the reasoning message id', () => {
+    const root = createRoot(container);
+    const linkedAssistantId = 'pi:agent-runtime:thread-1:assistant:1775509885583';
+    const messages: Message[] = [
+      {
+        id: linkedAssistantId,
+        role: 'assistant',
+        content: JSON.stringify({ status: 'synced', clientMutationId: 'sync-1' }),
+      },
+      {
+        id: `pi:agent-runtime:thread-1:reasoning:${linkedAssistantId}:0`,
+        role: 'reasoning',
+        content: '**Considering sync response**\n\nLet me acknowledge the sync.',
+      },
+      {
+        id: 'assistant-visible-1',
+        role: 'assistant',
+        content: 'Visible assistant reply.',
+      },
+    ];
+
+    act(() => {
+      root.render(renderPage(messages));
+    });
+
+    const transcriptText = container.textContent ?? '';
+    expect(transcriptText).not.toContain('Considering sync response');
+    expect(transcriptText).toContain('Visible assistant reply.');
+
+    act(() => {
+      root.unmount();
+    });
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -242,20 +242,75 @@ function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
-function parseCommandMessage(content: string): string | null {
+function parseJsonMessageContent(content: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(content) as unknown;
     if (typeof parsed !== 'object' || parsed === null) return null;
-    if (!('command' in parsed)) return null;
-    const command = (parsed as { command?: unknown }).command;
-    if (command === 'hire') return 'Submitted hire request.';
-    if (command === 'fire') return 'Submitted fire request.';
-    if (command === 'sync') return 'Requested a runtime sync.';
-    if (command === 'resume') return 'Submitted onboarding response.';
-    return typeof command === 'string' ? `Submitted ${command} request.` : null;
+    return parsed as Record<string, unknown>;
   } catch {
     return null;
   }
+}
+
+function parseCommandMessage(content: string): string | null {
+  const parsed = parseJsonMessageContent(content);
+  if (!parsed || !('command' in parsed)) {
+    return null;
+  }
+
+  const command = parsed.command;
+  if (command === 'hire') return 'Submitted hire request.';
+  if (command === 'fire') return 'Submitted fire request.';
+  if (command === 'sync') return 'Requested a runtime sync.';
+  if (command === 'resume') return 'Submitted onboarding response.';
+  return typeof command === 'string' ? `Submitted ${command} request.` : null;
+}
+
+function isSyncCommandMessage(message: Message): boolean {
+  if (message.role !== 'user' || typeof message.content !== 'string') {
+    return false;
+  }
+
+  return parseJsonMessageContent(message.content)?.command === 'sync';
+}
+
+function isSyncedAckMessage(message: Message): boolean {
+  if (message.role !== 'assistant' || typeof message.content !== 'string') {
+    return false;
+  }
+
+  const parsed = parseJsonMessageContent(message.content);
+  const clientMutationId = parsed?.clientMutationId;
+  return parsed?.status === 'synced' && typeof clientMutationId === 'string' && clientMutationId.trim().length > 0;
+}
+
+function getReasoningLinkedAssistantId(message: Message): string | null {
+  if (message.role !== 'reasoning') {
+    return null;
+  }
+
+  const parentMessageId = getParentMessageId(message);
+  if (parentMessageId) {
+    return parentMessageId;
+  }
+
+  const idMatch = message.id.match(/:reasoning:(.+):\d+$/);
+  return idMatch?.[1] ?? null;
+}
+
+function filterVisibleTranscriptMessages(messages: Message[]): Message[] {
+  const hiddenSyncAckMessageIds = new Set(
+    messages.filter((message) => isSyncedAckMessage(message)).map((message) => message.id),
+  );
+
+  return messages.filter((message) => {
+    if (isSyncCommandMessage(message) || hiddenSyncAckMessageIds.has(message.id)) {
+      return false;
+    }
+
+    const linkedAssistantId = getReasoningLinkedAssistantId(message);
+    return !(linkedAssistantId && hiddenSyncAckMessageIds.has(linkedAssistantId));
+  });
 }
 
 function getMessageText(message: Message): string {
@@ -1973,14 +2028,16 @@ function AgentChatTab(props: {
 
   const visibleMessages = useMemo(() => {
     const visibleMessageOrderEntry = getVisibleMessageOrderEntry(visibleMessageOrderCacheKey);
-    const allMessageIds = new Set(props.messages.map((message) => message.id));
+    // TODO(i574): Remove this temporary sync-noise filter during the agent-state/thread-state refactor.
+    const filteredMessages = filterVisibleTranscriptMessages(props.messages);
+    const allMessageIds = new Set(filteredMessages.map((message) => message.id));
     for (const messageId of [...visibleMessageOrderEntry.orderById.keys()]) {
       if (!allMessageIds.has(messageId)) {
         visibleMessageOrderEntry.orderById.delete(messageId);
       }
     }
 
-    const nextVisibleMessages = props.messages
+    const nextVisibleMessages = filteredMessages
       .map((message) => ({
         id: message.id,
         role: message.role,
@@ -1988,7 +2045,7 @@ function AgentChatTab(props: {
       }))
       .filter((message) => message.text.length > 0);
 
-    if (props.messages.length === 0) {
+    if (filteredMessages.length === 0) {
       visibleMessageOrderEntry.orderById.clear();
       visibleMessageOrderEntry.nextOrder = 0;
       visibleMessageOrderEntry.previousVisibleMessages = [];
@@ -2044,7 +2101,7 @@ function AgentChatTab(props: {
       visibleMessageOrderEntry.orderById.set(message.id, visibleMessageOrderEntry.nextOrder);
       visibleMessageOrderEntry.nextOrder += 1;
     }
-    const orderedMessages = orderVisibleChatMessages(props.messages, visibleMessageOrderEntry.orderById);
+    const orderedMessages = orderVisibleChatMessages(filteredMessages, visibleMessageOrderEntry.orderById);
     visibleMessageOrderEntry.previousVisibleMessages = orderedMessages.map((message) => ({
       id: message.id,
       role: message.role,


### PR DESCRIPTION
## Summary
- filter PI sync command and synced-ack transcript noise in the web projection layer
- hide sync-linked reasoning when the runtime links it via `parentMessageId` or the Pi runtime reasoning message id shape
- add regression coverage for visible non-sync reasoning, hidden sync acks, and runtime-shaped linked sync reasoning

## Testing
- `pnpm test:unit -- src/components/AgentDetailPage.transcriptOrdering.unit.test.tsx`
- `pnpm build`

## Notes
- `pnpm lint:fix` still fails on pre-existing `useAgentConnection.ts` React Compiler/manual-memoization issues unrelated to this slice.

Closes #574
