### PR TITLE
feat(managed-stack): adopt canonical direct command contract

### DIFF
--- a/typescript/agent-runtime/lib/pi/src/agUiProjection.unit.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiProjection.unit.test.ts
@@ -45,6 +45,12 @@ describe('pi AG-UI projection', () => {
         },
       }),
     ).toEqual({
+      shared: {},
+      projected: {
+        managedMandate: {
+          status: 'active',
+        },
+      },
       thread: {
         id: 'thread-1',
         task: {

--- a/typescript/agent-runtime/lib/pi/src/agUiProjection.unit.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiProjection.unit.test.ts
@@ -35,7 +35,7 @@ describe('pi AG-UI projection', () => {
           kind: 'interrupt',
           payload: { type: 'operator-config-request', artifactId: 'current-artifact' },
         },
-        domainProjection: {
+        projectedState: {
           managedMandate: {
             status: 'active',
           },
@@ -97,21 +97,9 @@ describe('pi AG-UI projection', () => {
             },
           ],
         },
-        messages: [
-          {
-            id: 'message-1',
-            role: 'user',
-            content: 'Please continue.',
-          },
-        ],
         artifacts: {
           current: { artifactId: 'current-artifact', data: { phase: 'setup' } },
           activity: { artifactId: 'activity-artifact', data: { entries: 3 } },
-        },
-        domainProjection: {
-          managedMandate: {
-            status: 'active',
-          },
         },
         profile: { principalId: 'wallet:0xabc' },
       },
@@ -127,7 +115,7 @@ describe('pi AG-UI projection', () => {
             id: 'exec-1',
             status: 'working',
           },
-          domainProjection: {
+          projectedState: {
             managedMandate: {
               summary: {
                 riskLevel: 'medium',
@@ -141,7 +129,7 @@ describe('pi AG-UI projection', () => {
             id: 'exec-1',
             status: 'completed',
           },
-          domainProjection: {
+          projectedState: {
             managedMandate: {
               summary: {
                 riskLevel: 'medium',
@@ -161,7 +149,7 @@ describe('pi AG-UI projection', () => {
         },
         {
           op: 'add',
-          path: '/thread/domainProjection/managedMandate/summary/status',
+          path: '/projected/managedMandate/summary/status',
           value: 'active',
         },
       ]),

--- a/typescript/agent-runtime/lib/pi/src/agUiTransport.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiTransport.ts
@@ -81,7 +81,8 @@ function parseRunRequest(body: Record<string, unknown>): PiRuntimeGatewayRunRequ
 
   const forwardedProps = isRecord(body.forwardedProps) ? body.forwardedProps : undefined;
   const command = forwardedProps && isRecord(forwardedProps.command) ? forwardedProps.command : undefined;
-  const resume = command ? readStringField(command, 'resume') : undefined;
+  const hasResume = command ? Object.prototype.hasOwnProperty.call(command, 'resume') : false;
+  const resume = hasResume ? command?.resume : undefined;
   const name = command ? readStringField(command, 'name') : undefined;
   const input = command && Object.prototype.hasOwnProperty.call(command, 'input') ? command.input : undefined;
   const update = command && isRecord(command.update) ? command.update : undefined;
@@ -94,13 +95,13 @@ function parseRunRequest(body: Record<string, unknown>): PiRuntimeGatewayRunRequ
     threadId,
     runId,
     messages: Array.isArray(body.messages) ? (body.messages as PiRuntimeGatewayRunRequest['messages']) : undefined,
-    ...(resume || name || update
+    ...(hasResume || name || update
       ? {
           forwardedProps: {
             command: {
               ...(name ? { name } : {}),
               ...(Object.prototype.hasOwnProperty.call(command ?? {}, 'input') ? { input } : {}),
-              ...(resume ? { resume } : {}),
+              ...(hasResume ? { resume } : {}),
               ...(update
                 ? {
                     update: {

--- a/typescript/agent-runtime/lib/pi/src/agUiTransport.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiTransport.ts
@@ -15,6 +15,9 @@ export type PiRuntimeGatewayHttpAgentConfig = Omit<HttpAgentConfig, 'url'> & {
   runtimeUrl: string;
 };
 
+const MISSING_CLIENT_MUTATION_ID_ERROR =
+  'Shared-state update commands require a non-empty clientMutationId.';
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -90,6 +93,10 @@ function parseRunRequest(body: Record<string, unknown>): PiRuntimeGatewayRunRequ
   const updateBaseRevision = update ? readStringField(update, 'baseRevision') : undefined;
   const updatePatch =
     update && Object.prototype.hasOwnProperty.call(update, 'patch') ? update.patch : undefined;
+
+  if (update && !updateClientMutationId) {
+    return jsonResponse({ error: MISSING_CLIENT_MUTATION_ID_ERROR }, 400);
+  }
 
   return {
     threadId,

--- a/typescript/agent-runtime/lib/pi/src/agUiTransport.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiTransport.ts
@@ -84,18 +84,32 @@ function parseRunRequest(body: Record<string, unknown>): PiRuntimeGatewayRunRequ
   const resume = command ? readStringField(command, 'resume') : undefined;
   const name = command ? readStringField(command, 'name') : undefined;
   const input = command && Object.prototype.hasOwnProperty.call(command, 'input') ? command.input : undefined;
+  const update = command && isRecord(command.update) ? command.update : undefined;
+  const updateClientMutationId = update ? readStringField(update, 'clientMutationId') : undefined;
+  const updateBaseRevision = update ? readStringField(update, 'baseRevision') : undefined;
+  const updatePatch =
+    update && Object.prototype.hasOwnProperty.call(update, 'patch') ? update.patch : undefined;
 
   return {
     threadId,
     runId,
     messages: Array.isArray(body.messages) ? (body.messages as PiRuntimeGatewayRunRequest['messages']) : undefined,
-    ...(resume || name
+    ...(resume || name || update
       ? {
           forwardedProps: {
             command: {
               ...(name ? { name } : {}),
               ...(Object.prototype.hasOwnProperty.call(command ?? {}, 'input') ? { input } : {}),
               ...(resume ? { resume } : {}),
+              ...(update
+                ? {
+                    update: {
+                      ...(updateClientMutationId ? { clientMutationId: updateClientMutationId } : {}),
+                      ...(updateBaseRevision ? { baseRevision: updateBaseRevision } : {}),
+                      ...(Object.prototype.hasOwnProperty.call(update, 'patch') ? { patch: updatePatch } : {}),
+                    },
+                  }
+                : {}),
             },
           },
         }

--- a/typescript/agent-runtime/lib/pi/src/agUiTransport.unit.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiTransport.unit.test.ts
@@ -247,6 +247,61 @@ describe('Pi AG-UI transport helpers', () => {
     });
   });
 
+  it('preserves canonical shared-state update commands on AG-UI run requests', async () => {
+    const { service, run } = createStubService();
+    const handler = createPiRuntimeGatewayAgUiHandler({
+      agentId: 'agent-pi-example',
+      service,
+      basePath: '/ag-ui',
+    });
+
+    await handler(
+      new Request('http://localhost/ag-ui/agent/agent-pi-example/run', {
+        method: 'POST',
+        body: JSON.stringify({
+          threadId: 'thread-1',
+          runId: 'run-update',
+          forwardedProps: {
+            command: {
+              update: {
+                clientMutationId: 'mutation-1',
+                baseRevision: 'shared-rev-1',
+                patch: [
+                  {
+                    op: 'add',
+                    path: '/shared/settings/amount',
+                    value: 250,
+                  },
+                ],
+              },
+            },
+          },
+        }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    expect(run).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      runId: 'run-update',
+      forwardedProps: {
+        command: {
+          update: {
+            clientMutationId: 'mutation-1',
+            baseRevision: 'shared-rev-1',
+            patch: [
+              {
+                op: 'add',
+                path: '/shared/settings/amount',
+                value: 250,
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
   it('uses HttpAgent semantics while targeting Pi connect and stop endpoints', async () => {
     const fetchMock = vi
       .fn()

--- a/typescript/agent-runtime/lib/pi/src/agUiTransport.unit.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiTransport.unit.test.ts
@@ -171,7 +171,7 @@ describe('Pi AG-UI transport helpers', () => {
     await expect(maintenanceResponse.text()).resolves.toContain('"automationIdsToResume":["automation-1"]');
   });
 
-  it('preserves explicit resume commands on AG-UI run requests', async () => {
+  it('preserves explicit object resume commands on AG-UI run requests', async () => {
     const { service, run } = createStubService();
     const handler = createPiRuntimeGatewayAgUiHandler({
       agentId: 'agent-pi-example',
@@ -187,7 +187,14 @@ describe('Pi AG-UI transport helpers', () => {
           runId: 'run-resume',
           forwardedProps: {
             command: {
-              resume: '{"outcome":"signed"}',
+              resume: {
+                outcome: 'signed',
+                signedDelegations: [
+                  {
+                    signature: '0x1234',
+                  },
+                ],
+              },
             },
           },
         }),
@@ -200,7 +207,14 @@ describe('Pi AG-UI transport helpers', () => {
       runId: 'run-resume',
       forwardedProps: {
         command: {
-          resume: '{"outcome":"signed"}',
+          resume: {
+            outcome: 'signed',
+            signedDelegations: [
+              {
+                signature: '0x1234',
+              },
+            ],
+          },
         },
       },
     });

--- a/typescript/agent-runtime/lib/pi/src/agUiTransport.unit.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiTransport.unit.test.ts
@@ -316,6 +316,45 @@ describe('Pi AG-UI transport helpers', () => {
     });
   });
 
+  it('rejects malformed shared-state update commands without a clientMutationId', async () => {
+    const { service, run } = createStubService();
+    const handler = createPiRuntimeGatewayAgUiHandler({
+      agentId: 'agent-pi-example',
+      service,
+      basePath: '/ag-ui',
+    });
+
+    const response = await handler(
+      new Request('http://localhost/ag-ui/agent/agent-pi-example/run', {
+        method: 'POST',
+        body: JSON.stringify({
+          threadId: 'thread-1',
+          runId: 'run-update',
+          forwardedProps: {
+            command: {
+              update: {
+                patch: [
+                  {
+                    op: 'add',
+                    path: '/shared/settings/amount',
+                    value: 250,
+                  },
+                ],
+              },
+            },
+          },
+        }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Shared-state update commands require a non-empty clientMutationId.',
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it('uses HttpAgent semantics while targeting Pi connect and stop endpoints', async () => {
     const fetchMock = vi
       .fn()

--- a/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
@@ -1112,6 +1112,53 @@ describe('pi gateway service integration', () => {
     });
   });
 
+  it('fails malformed shared-state update commands without emitting an uncorrelatable update ack', async () => {
+    const agent = new ScriptedPiAgent([]);
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      getSession: () => ({
+        thread: { id: 'thread-update-missing-client-mutation-id' },
+        execution: {
+          id: 'exec-update-missing-client-mutation-id',
+          status: 'working' as const,
+          statusMessage: 'Ready.',
+        },
+        sharedState: {
+          settings: {
+            amount: 100,
+          },
+        },
+        sharedStateVersion: 1,
+        sharedStateRevision: 'shared-rev-1',
+        sharedStateHydrated: true,
+      }),
+    });
+
+    expect(() =>
+      runtime.run({
+        threadId: 'thread-update-missing-client-mutation-id',
+        runId: 'run-update-missing-client-mutation-id',
+        forwardedProps: {
+          command: {
+            update: {
+              baseRevision: 'shared-rev-1',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ).toThrow('Shared-state update commands require a non-empty clientMutationId.');
+  });
+
   it('streams text events before the Pi prompt fully completes', async () => {
     let releasePrompt: (() => void) | null = null;
     const assistantMessage = {

--- a/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
@@ -171,6 +171,8 @@ describe('pi gateway service integration', () => {
       {
         type: EventType.STATE_SNAPSHOT,
         snapshot: {
+          shared: {},
+          projected: {},
           thread: {
             id: 'thread-1',
             task: {
@@ -226,6 +228,15 @@ describe('pi gateway service integration', () => {
               current: { artifactId: 'current-artifact', data: { phase: 'connected' } },
             },
           },
+        },
+      },
+      {
+        type: EventType.CUSTOM,
+        name: 'shared-state.control',
+        value: {
+          kind: 'hydration',
+          reason: 'bootstrap',
+          revision: 'shared-rev-0',
         },
       },
       {
@@ -758,6 +769,345 @@ describe('pi gateway service integration', () => {
         },
       },
     ]);
+  });
+
+  it('emits shared-state hydration metadata after the snapshot on connect', async () => {
+    const agent = new ScriptedPiAgent([]);
+    let session = {
+      thread: { id: 'thread-hydration' },
+      execution: { id: 'exec-hydration', status: 'working' as const, statusMessage: 'Hydrated.' },
+      sharedState: {
+        settings: {
+          amount: 250,
+        },
+      },
+      sharedStateVersion: 1,
+      sharedStateRevision: 'shared-rev-1',
+      sharedStateHydrated: false,
+    };
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      getSession: () => session,
+      updateSession: (_threadId, update) => {
+        session = update(session);
+        return session;
+      },
+    });
+
+    const bootstrapEvents = await collectEventSource(
+      await runtime.connect({
+        threadId: 'thread-hydration',
+      }),
+    );
+
+    expect(bootstrapEvents).toContainEqual({
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: expect.objectContaining({
+        shared: {
+          settings: {
+            amount: 250,
+          },
+        },
+        projected: {},
+      }),
+    });
+    expect(bootstrapEvents).toContainEqual({
+      type: EventType.CUSTOM,
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'bootstrap',
+        revision: 'shared-rev-1',
+      },
+    });
+    expect(
+      bootstrapEvents.findIndex((event) => event.type === EventType.STATE_SNAPSHOT),
+    ).toBeLessThan(
+      bootstrapEvents.findIndex(
+        (event) =>
+          event.type === EventType.CUSTOM &&
+          'name' in event &&
+          event.name === 'shared-state.control',
+      ),
+    );
+
+    const reconnectEvents = await collectEventSource(
+      await runtime.connect({
+        threadId: 'thread-hydration',
+      }),
+    );
+
+    expect(reconnectEvents).toContainEqual({
+      type: EventType.CUSTOM,
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'reconnect',
+        revision: 'shared-rev-1',
+      },
+    });
+  });
+
+  it('accepts canonical shared-state updates and acknowledges them after the state delta', async () => {
+    const agent = new ScriptedPiAgent([]);
+    let session = {
+      thread: { id: 'thread-update' },
+      execution: { id: 'exec-update', status: 'working' as const, statusMessage: 'Ready.' },
+      sharedState: {
+        settings: {
+          amount: 100,
+        },
+      },
+      sharedStateVersion: 1,
+      sharedStateRevision: 'shared-rev-1',
+      sharedStateHydrated: true,
+    };
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      getSession: () => session,
+      updateSession: (_threadId, update) => {
+        session = update(session);
+        return session;
+      },
+    });
+
+    const events = await collectEventSource(
+      await runtime.run({
+        threadId: 'thread-update',
+        runId: 'run-update',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: 'mutation-1',
+              baseRevision: 'shared-rev-1',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(agent.promptCalls).toEqual([]);
+    expect(agent.continueCalls).toBe(0);
+    expect(events).toContainEqual({
+      type: EventType.STATE_DELTA,
+      delta: expect.arrayContaining([
+        {
+          op: 'replace',
+          path: '/shared/settings/amount',
+          value: 250,
+        },
+      ]),
+    });
+    expect(events).toContainEqual({
+      type: EventType.CUSTOM,
+      name: 'shared-state.control',
+      value: {
+        kind: 'update-ack',
+        clientMutationId: 'mutation-1',
+        status: 'accepted',
+        resultingRevision: 'shared-rev-2',
+        baseRevision: 'shared-rev-1',
+      },
+    });
+    expect(
+      events.findIndex((event) => event.type === EventType.STATE_DELTA),
+    ).toBeLessThan(
+      events.findIndex(
+        (event) =>
+          event.type === EventType.CUSTOM &&
+          'name' in event &&
+          event.name === 'shared-state.control',
+      ),
+    );
+    expect(session.sharedState).toEqual({
+      settings: {
+        amount: 250,
+      },
+    });
+    expect(session.sharedStateRevision).toBe('shared-rev-2');
+    expect(session.sharedStateVersion).toBe(2);
+  });
+
+  it('acknowledges noop shared-state updates without emitting a state delta', async () => {
+    const agent = new ScriptedPiAgent([]);
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      getSession: () => ({
+        thread: { id: 'thread-update-noop' },
+        execution: { id: 'exec-update-noop', status: 'working' as const, statusMessage: 'Ready.' },
+        sharedState: {
+          settings: {
+            amount: 250,
+          },
+        },
+        sharedStateVersion: 2,
+        sharedStateRevision: 'shared-rev-2',
+        sharedStateHydrated: true,
+      }),
+    });
+
+    const events = await collectEventSource(
+      await runtime.run({
+        threadId: 'thread-update-noop',
+        runId: 'run-update-noop',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: 'mutation-noop',
+              baseRevision: 'shared-rev-2',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(events.filter((event) => event.type === EventType.STATE_DELTA)).toEqual([]);
+    expect(events).toContainEqual({
+      type: EventType.CUSTOM,
+      name: 'shared-state.control',
+      value: {
+        kind: 'update-ack',
+        clientMutationId: 'mutation-noop',
+        status: 'noop',
+        resultingRevision: 'shared-rev-2',
+        baseRevision: 'shared-rev-2',
+      },
+    });
+  });
+
+  it('rejects shared-state updates without a base revision on hydrated threads', async () => {
+    const agent = new ScriptedPiAgent([]);
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      getSession: () => ({
+        thread: { id: 'thread-update-missing-base' },
+        execution: { id: 'exec-update-missing-base', status: 'working' as const, statusMessage: 'Ready.' },
+        sharedState: {
+          settings: {
+            amount: 100,
+          },
+        },
+        sharedStateVersion: 1,
+        sharedStateRevision: 'shared-rev-1',
+        sharedStateHydrated: true,
+      }),
+    });
+
+    const events = await collectEventSource(
+      await runtime.run({
+        threadId: 'thread-update-missing-base',
+        runId: 'run-update-missing-base',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: 'mutation-missing-base',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(events.filter((event) => event.type === EventType.STATE_DELTA)).toEqual([]);
+    expect(events).toContainEqual({
+      type: EventType.CUSTOM,
+      name: 'shared-state.control',
+      value: {
+        kind: 'update-ack',
+        clientMutationId: 'mutation-missing-base',
+        status: 'rejected',
+        resultingRevision: 'shared-rev-1',
+        code: 'missing_base_revision',
+      },
+    });
+  });
+
+  it('rejects shared-state updates that patch outside the writable shared surface', async () => {
+    const agent = new ScriptedPiAgent([]);
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      getSession: () => ({
+        thread: { id: 'thread-update-forbidden' },
+        execution: { id: 'exec-update-forbidden', status: 'working' as const, statusMessage: 'Ready.' },
+        sharedState: {
+          settings: {
+            amount: 100,
+          },
+        },
+        sharedStateVersion: 1,
+        sharedStateRevision: 'shared-rev-1',
+        sharedStateHydrated: true,
+      }),
+    });
+
+    const events = await collectEventSource(
+      await runtime.run({
+        threadId: 'thread-update-forbidden',
+        runId: 'run-update-forbidden',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: 'mutation-forbidden',
+              baseRevision: 'shared-rev-1',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/projected/managedMandate',
+                  value: {
+                    status: 'active',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(events.filter((event) => event.type === EventType.STATE_DELTA)).toEqual([]);
+    expect(events).toContainEqual({
+      type: EventType.CUSTOM,
+      name: 'shared-state.control',
+      value: {
+        kind: 'update-ack',
+        clientMutationId: 'mutation-forbidden',
+        status: 'rejected',
+        resultingRevision: 'shared-rev-1',
+        baseRevision: 'shared-rev-1',
+        code: 'forbidden_path',
+      },
+    });
   });
 
   it('streams text events before the Pi prompt fully completes', async () => {

--- a/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
@@ -212,18 +212,6 @@ describe('pi gateway service integration', () => {
                 },
               ],
             },
-            messages: [
-              {
-                id: 'user-msg-1',
-                role: 'user',
-                content: 'Connect now',
-              },
-              {
-                id: 'assistant-msg-1',
-                role: 'assistant',
-                content: 'Pi is connected.',
-              },
-            ],
             artifacts: {
               current: { artifactId: 'current-artifact', data: { phase: 'connected' } },
             },

--- a/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
@@ -719,7 +719,7 @@ describe('pi gateway service integration', () => {
     ]);
   });
 
-  it('routes explicit resume payloads through Pi prompt instead of continue()', async () => {
+  it('routes explicit object resume payloads through Pi prompt instead of continue()', async () => {
     const agent = new ScriptedPiAgent([]);
 
     const runtime = createPiRuntimeGatewayRuntime({
@@ -737,7 +737,9 @@ describe('pi gateway service integration', () => {
         runId: 'run-5',
         forwardedProps: {
           command: {
-            resume: '{"operatorNote":"safe window approved"}',
+            resume: {
+              operatorNote: 'safe window approved',
+            },
           },
         },
       }),

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -140,7 +140,6 @@ export type PiRuntimeGatewaySession = {
   };
   a2ui?: PiRuntimeGatewayA2UiPayload;
   activityEvents?: PiRuntimeGatewayActivityEvent[];
-  domainProjection?: Record<string, unknown>;
   projectedState?: Record<string, unknown>;
   sharedState?: Record<string, unknown>;
   sharedStateVersion?: number;
@@ -303,11 +302,7 @@ const MISSING_CLIENT_MUTATION_ID_ERROR =
 const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
 const getProjectedState = (session: PiRuntimeGatewaySession): Record<string, unknown> =>
-  isRecord(session.projectedState)
-    ? session.projectedState
-    : isRecord(session.domainProjection)
-      ? session.domainProjection
-      : {};
+  isRecord(session.projectedState) ? session.projectedState : {};
 
 const getSharedState = (session: PiRuntimeGatewaySession): Record<string, unknown> =>
   isRecord(session.sharedState) ? session.sharedState : {};
@@ -1313,6 +1308,18 @@ const buildResumePromptMessages = (resumePayload: unknown, now: () => number): A
   },
 ];
 
+const stripLegacyThreadMirrors = <TThread extends Record<string, unknown>>(thread: TThread): TThread => {
+  const {
+    messages: _messages,
+    domainProjection: _domainProjection,
+    ...canonicalThread
+  } = thread as TThread & {
+    messages?: unknown;
+    domainProjection?: unknown;
+  };
+  return canonicalThread as TThread;
+};
+
 export const buildPiThreadStateSnapshot = (params: PiRuntimeGatewaySession): Record<string, unknown> => {
   const projectedState = getProjectedState(params);
   const activityEvents: PiRuntimeGatewayActivityEvent[] =
@@ -1379,17 +1386,17 @@ export const buildPiThreadStateSnapshot = (params: PiRuntimeGatewaySession): Rec
           },
         }
       : {}),
-    ...(params.messages ? { messages: params.messages } : {}),
-    ...(Object.keys(projectedState).length > 0 ? { domainProjection: projectedState } : {}),
   };
 
   return {
     shared: getSharedState(params),
     projected: projectedState,
-    thread: mergeThreadPatchForEmit({
-      currentThread: baseThread,
-      patchThread: params.threadPatch ?? {},
-    }),
+    thread: stripLegacyThreadMirrors(
+      mergeThreadPatchForEmit({
+        currentThread: baseThread,
+        patchThread: params.threadPatch ?? {},
+      }),
+    ),
   };
 };
 

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -17,7 +17,6 @@ import {
   type Model,
   type ToolResultMessage,
 } from '@mariozechner/pi-ai';
-import * as jsonPatch from 'fast-json-patch';
 import {
   buildPiRuntimeInspectionSnapshot,
   buildPiRuntimeMaintenancePlan,
@@ -35,6 +34,7 @@ import {
   type PiThreadRecord,
   type PostgresBootstrapPlan,
 } from 'agent-runtime-postgres';
+import * as jsonPatch from 'fast-json-patch';
 
 import { type TaskState } from './taskState.js';
 import { mergeThreadPatchForEmit } from './threadEmission.js';
@@ -73,6 +73,11 @@ export type PiRuntimeGatewayRunRequest = {
       name?: string;
       input?: unknown;
       resume?: string;
+      update?: {
+        clientMutationId?: string;
+        baseRevision?: string;
+        patch?: unknown;
+      };
     };
   };
 };
@@ -136,6 +141,11 @@ export type PiRuntimeGatewaySession = {
   a2ui?: PiRuntimeGatewayA2UiPayload;
   activityEvents?: PiRuntimeGatewayActivityEvent[];
   domainProjection?: Record<string, unknown>;
+  projectedState?: Record<string, unknown>;
+  sharedState?: Record<string, unknown>;
+  sharedStateVersion?: number;
+  sharedStateRevision?: string;
+  sharedStateHydrated?: boolean;
   threadPatch?: Record<string, unknown>;
 };
 
@@ -255,9 +265,182 @@ type JsonPatchCompare = (
   invertible?: boolean,
 ) => Array<Record<string, unknown>>;
 
+type JsonPatchApply = <T>(
+  document: T,
+  patch: ReadonlyArray<Record<string, unknown>>,
+  validateOperation?: boolean,
+  mutateDocument?: boolean,
+  banPrototypeModifications?: boolean,
+) => {
+  newDocument: T;
+};
+
 const jsonPatchCompare =
   (jsonPatch as unknown as { compare?: JsonPatchCompare; default?: { compare?: JsonPatchCompare } }).compare ??
   (jsonPatch as unknown as { default?: { compare?: JsonPatchCompare } }).default?.compare;
+const jsonPatchApply =
+  (jsonPatch as unknown as { applyPatch?: JsonPatchApply; default?: { applyPatch?: JsonPatchApply } })
+    .applyPatch ??
+  (jsonPatch as unknown as { default?: { applyPatch?: JsonPatchApply } }).default?.applyPatch;
+
+type PiRuntimeGatewaySharedStateHydrationReason = 'bootstrap' | 'reconnect';
+type PiRuntimeGatewaySharedStateUpdateAckStatus = 'accepted' | 'noop' | 'rejected';
+type PiRuntimeGatewaySharedStateUpdateAckCode =
+  | 'stale_revision'
+  | 'missing_base_revision'
+  | 'forbidden_path'
+  | 'invalid_patch';
+
+const PI_RUNTIME_SHARED_STATE_CONTROL_EVENT = 'shared-state.control';
+const PI_RUNTIME_SHARED_STATE_REVISION_PREFIX = 'shared-rev-';
+
+const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const getProjectedState = (session: PiRuntimeGatewaySession): Record<string, unknown> =>
+  isRecord(session.projectedState)
+    ? session.projectedState
+    : isRecord(session.domainProjection)
+      ? session.domainProjection
+      : {};
+
+const getSharedState = (session: PiRuntimeGatewaySession): Record<string, unknown> =>
+  isRecord(session.sharedState) ? session.sharedState : {};
+
+const getSharedStateVersion = (session: PiRuntimeGatewaySession): number =>
+  typeof session.sharedStateVersion === 'number' &&
+  Number.isInteger(session.sharedStateVersion) &&
+  session.sharedStateVersion >= 0
+    ? session.sharedStateVersion
+    : 0;
+
+const buildSharedStateRevision = (version: number): string =>
+  `${PI_RUNTIME_SHARED_STATE_REVISION_PREFIX}${version}`;
+
+const getSharedStateRevision = (session: PiRuntimeGatewaySession): string => {
+  const revision = session.sharedStateRevision;
+  return typeof revision === 'string' && revision.length > 0
+    ? revision
+    : buildSharedStateRevision(getSharedStateVersion(session));
+};
+
+const normalizeSharedStateSession = (session: PiRuntimeGatewaySession): PiRuntimeGatewaySession => ({
+  ...session,
+  projectedState: getProjectedState(session),
+  sharedState: getSharedState(session),
+  sharedStateVersion: getSharedStateVersion(session),
+  sharedStateRevision: getSharedStateRevision(session),
+  sharedStateHydrated: session.sharedStateHydrated === true,
+});
+
+const buildSharedStateControlHydrationEvent = (params: {
+  reason: PiRuntimeGatewaySharedStateHydrationReason;
+  revision: string;
+}) => ({
+  type: EventType.CUSTOM,
+  name: PI_RUNTIME_SHARED_STATE_CONTROL_EVENT,
+  value: {
+    kind: 'hydration',
+    reason: params.reason,
+    revision: params.revision,
+  },
+} satisfies BaseEvent);
+
+const buildSharedStateControlUpdateAckEvent = (params: {
+  clientMutationId: string;
+  status: PiRuntimeGatewaySharedStateUpdateAckStatus;
+  resultingRevision: string;
+  baseRevision?: string;
+  code?: PiRuntimeGatewaySharedStateUpdateAckCode;
+  message?: string;
+}) => ({
+  type: EventType.CUSTOM,
+  name: PI_RUNTIME_SHARED_STATE_CONTROL_EVENT,
+  value: {
+    kind: 'update-ack',
+    clientMutationId: params.clientMutationId,
+    status: params.status,
+    resultingRevision: params.resultingRevision,
+    ...(params.baseRevision ? { baseRevision: params.baseRevision } : {}),
+    ...(params.code ? { code: params.code } : {}),
+    ...(params.message ? { message: params.message } : {}),
+  },
+} satisfies BaseEvent);
+
+const readSharedStateUpdateCommand = (
+  request: PiRuntimeGatewayRunRequest,
+):
+  | {
+      clientMutationId: string | null;
+      baseRevision: string | undefined;
+      patch: unknown;
+    }
+  | null => {
+  const update = request.forwardedProps?.command?.update;
+  if (!isRecord(update)) {
+    return null;
+  }
+
+  return {
+    clientMutationId:
+      typeof update.clientMutationId === 'string' && update.clientMutationId.length > 0
+        ? update.clientMutationId
+        : null,
+    baseRevision:
+      typeof update.baseRevision === 'string' && update.baseRevision.length > 0
+        ? update.baseRevision
+        : undefined,
+    patch: Object.prototype.hasOwnProperty.call(update, 'patch') ? update.patch : undefined,
+  };
+};
+
+const validateSharedStatePatch = (
+  patch: unknown,
+):
+  | {
+      ok: true;
+      patch: ReadonlyArray<Record<string, unknown>>;
+    }
+  | {
+      ok: false;
+      code: PiRuntimeGatewaySharedStateUpdateAckCode;
+    } => {
+  if (!Array.isArray(patch)) {
+    return {
+      ok: false,
+      code: 'invalid_patch',
+    };
+  }
+
+  for (const operation of patch) {
+    if (!isRecord(operation)) {
+      return {
+        ok: false,
+        code: 'invalid_patch',
+      };
+    }
+
+    const op = operation.op;
+    const path = operation.path;
+    if ((op !== 'add' && op !== 'replace' && op !== 'remove') || typeof path !== 'string') {
+      return {
+        ok: false,
+        code: 'invalid_patch',
+      };
+    }
+
+    if (path !== '/shared' && !path.startsWith('/shared/')) {
+      return {
+        ok: false,
+        code: 'forbidden_path',
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    patch,
+  };
+};
 
 const shouldDebugPiGateway = process.env.PI_GATEWAY_DEBUG === 'true';
 const PORTABLE_PI_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -1098,6 +1281,7 @@ const buildResumePromptMessages = (resumePayload: string, now: () => number): Ag
 ];
 
 export const buildPiThreadStateSnapshot = (params: PiRuntimeGatewaySession): Record<string, unknown> => {
+  const projectedState = getProjectedState(params);
   const activityEvents: PiRuntimeGatewayActivityEvent[] =
     params.activityEvents && params.activityEvents.length > 0
       ? [...params.activityEvents]
@@ -1163,10 +1347,12 @@ export const buildPiThreadStateSnapshot = (params: PiRuntimeGatewaySession): Rec
         }
       : {}),
     ...(params.messages ? { messages: params.messages } : {}),
-    ...(params.domainProjection ? { domainProjection: params.domainProjection } : {}),
+    ...(Object.keys(projectedState).length > 0 ? { domainProjection: projectedState } : {}),
   };
 
   return {
+    shared: getSharedState(params),
+    projected: projectedState,
     thread: mergeThreadPatchForEmit({
       currentThread: baseThread,
       patchThread: params.threadPatch ?? {},
@@ -1217,6 +1403,7 @@ export const buildPiRuntimeGatewayConnectEvents = (params: {
   threadId: string;
   runId: string;
   session: PiRuntimeGatewaySession;
+  hydrationReason?: PiRuntimeGatewaySharedStateHydrationReason;
 }): BaseEvent[] => {
   const messagesSnapshotEvent: MessagesSnapshotEvent | null = params.session.messages
     ? {
@@ -1235,6 +1422,11 @@ export const buildPiRuntimeGatewayConnectEvents = (params: {
       type: EventType.STATE_SNAPSHOT,
       snapshot: buildPiThreadStateSnapshot(params.session),
     } satisfies StateSnapshotEvent,
+    buildSharedStateControlHydrationEvent({
+      reason:
+        params.hydrationReason ?? (params.session.sharedStateHydrated ? 'reconnect' : 'bootstrap'),
+      revision: getSharedStateRevision(params.session),
+    }),
     ...(messagesSnapshotEvent ? [messagesSnapshotEvent] : []),
     asBaseEvent({
       type: EventType.RUN_FINISHED,
@@ -1617,25 +1809,39 @@ export const createPiRuntimeGatewayRuntime = (params: {
   };
 
   return {
-    connect: (request) => {
+    connect: async (request) => {
       syncAgentSessionId(request.threadId);
-      const session = params.getSession(request.threadId);
+      const currentSession = normalizeSharedStateSession(params.getSession(request.threadId));
+      const hydrationReason: PiRuntimeGatewaySharedStateHydrationReason = currentSession.sharedStateHydrated
+        ? 'reconnect'
+        : 'bootstrap';
+      const session = params.updateSession
+        ? params.updateSession(request.threadId, (session) => ({
+            ...normalizeSharedStateSession(session),
+            sharedStateHydrated: true,
+          }))
+        : {
+            ...currentSession,
+            sharedStateHydrated: true,
+          };
       const runId = request.runId ?? `connect:${request.threadId}`;
-      return Promise.resolve(
-        buildPiRuntimeGatewayConnectEvents({
-          threadId: request.threadId,
-          runId,
-          session,
-        }),
-      );
+      await params.onSessionUpdated?.(request.threadId, session);
+      return buildPiRuntimeGatewayConnectEvents({
+        threadId: request.threadId,
+        runId,
+        session,
+        hydrationReason,
+      });
     },
     run: (request) => {
       syncAgentSessionId(request.threadId);
-      const executionId = params.getSession(request.threadId).execution.id;
+      const initialSession = normalizeSharedStateSession(params.getSession(request.threadId));
+      const executionId = initialSession.execution.id;
       const projector = createPiAgentEventProjector(executionId);
       const projectedRunEvents: BaseEvent[] = [];
       const requestMessages = request.messages ?? [];
       const resumePayload = request.forwardedProps?.command?.resume;
+      const sharedStateUpdate = readSharedStateUpdateCommand(request);
 
       return createAsyncEventStream<BaseEvent>(async (controller) => {
         logPiGatewayDebug('run start', {
@@ -1649,6 +1855,161 @@ export const createPiRuntimeGatewayRuntime = (params: {
           threadId: request.threadId,
           runId: request.runId,
         } satisfies RunStartedEvent));
+
+        if (sharedStateUpdate) {
+          const currentSession = initialSession;
+          const currentRevision = getSharedStateRevision(currentSession);
+          const clientMutationId = sharedStateUpdate.clientMutationId ?? '';
+          const finishWithAck = (paramsForAck: {
+            status: PiRuntimeGatewaySharedStateUpdateAckStatus;
+            resultingRevision: string;
+            code?: PiRuntimeGatewaySharedStateUpdateAckCode;
+            baseRevision?: string;
+          }) => {
+            controller.push(
+              buildSharedStateControlUpdateAckEvent({
+                clientMutationId,
+                status: paramsForAck.status,
+                resultingRevision: paramsForAck.resultingRevision,
+                ...(paramsForAck.baseRevision ? { baseRevision: paramsForAck.baseRevision } : {}),
+                ...(paramsForAck.code ? { code: paramsForAck.code } : {}),
+              }),
+            );
+            controller.push(asBaseEvent({
+              type: EventType.RUN_FINISHED,
+              threadId: request.threadId,
+              runId: request.runId,
+              result: {
+                executionId: currentSession.execution.id,
+                status: currentSession.execution.status,
+              },
+            } satisfies RunFinishedEvent));
+            controller.close();
+          };
+
+          if (clientMutationId.length === 0) {
+            finishWithAck({
+              status: 'rejected',
+              resultingRevision: currentRevision,
+              code: 'invalid_patch',
+              ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
+            });
+            return;
+          }
+
+          if (currentSession.sharedStateHydrated && !sharedStateUpdate.baseRevision) {
+            finishWithAck({
+              status: 'rejected',
+              resultingRevision: currentRevision,
+              code: 'missing_base_revision',
+            });
+            return;
+          }
+
+          if (
+            sharedStateUpdate.baseRevision &&
+            sharedStateUpdate.baseRevision !== currentRevision
+          ) {
+            finishWithAck({
+              status: 'rejected',
+              resultingRevision: currentRevision,
+              code: 'stale_revision',
+              baseRevision: sharedStateUpdate.baseRevision,
+            });
+            return;
+          }
+
+          const validatedPatch = validateSharedStatePatch(sharedStateUpdate.patch);
+          if (!validatedPatch.ok) {
+            finishWithAck({
+              status: 'rejected',
+              resultingRevision: currentRevision,
+              code: validatedPatch.code,
+              ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
+            });
+            return;
+          }
+
+          if (!jsonPatchApply || !jsonPatchCompare) {
+            throw new TypeError('fast-json-patch apply/compare export unavailable');
+          }
+
+          let nextSharedState: Record<string, unknown>;
+          try {
+            const nextDocument = jsonPatchApply(
+              {
+                shared: cloneJson(getSharedState(currentSession)),
+              },
+              validatedPatch.patch,
+              true,
+              false,
+            ).newDocument as { shared?: unknown };
+            if (!isRecord(nextDocument.shared)) {
+              finishWithAck({
+                status: 'rejected',
+                resultingRevision: currentRevision,
+                code: 'invalid_patch',
+                ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
+              });
+              return;
+            }
+            nextSharedState = nextDocument.shared;
+          } catch {
+            finishWithAck({
+              status: 'rejected',
+              resultingRevision: currentRevision,
+              code: 'invalid_patch',
+              ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
+            });
+            return;
+          }
+
+          const sharedDelta = jsonPatchCompare(
+            cloneJson(getSharedState(currentSession)),
+            cloneJson(nextSharedState),
+            true,
+          );
+          if (sharedDelta.length === 0) {
+            finishWithAck({
+              status: 'noop',
+              resultingRevision: currentRevision,
+              ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
+            });
+            return;
+          }
+
+          const nextVersion = getSharedStateVersion(currentSession) + 1;
+          const nextRevision = buildSharedStateRevision(nextVersion);
+          const nextSession = params.updateSession
+            ? params.updateSession(request.threadId, (session) => ({
+                ...normalizeSharedStateSession(session),
+                sharedState: nextSharedState,
+                sharedStateVersion: nextVersion,
+                sharedStateRevision: nextRevision,
+              }))
+            : {
+                ...currentSession,
+                sharedState: nextSharedState,
+                sharedStateVersion: nextVersion,
+                sharedStateRevision: nextRevision,
+              };
+          await params.onSessionUpdated?.(request.threadId, nextSession);
+
+          const stateDeltaEvent = buildPiRuntimeGatewayStateDeltaEvent({
+            previousSession: currentSession,
+            session: nextSession,
+          });
+          if (stateDeltaEvent) {
+            controller.push(stateDeltaEvent);
+          }
+          finishWithAck({
+            status: 'accepted',
+            resultingRevision: nextRevision,
+            ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
+          });
+          return;
+        }
+
         const requestSession = await persistRequestMessages(request.threadId, requestMessages);
         const requestMessagesSnapshotEvent = buildMessagesSnapshotEvent(requestSession);
         if (requestMessagesSnapshotEvent) {

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -72,7 +72,7 @@ export type PiRuntimeGatewayRunRequest = {
     command?: {
       name?: string;
       input?: unknown;
-      resume?: string;
+      resume?: unknown;
       update?: {
         clientMutationId?: string;
         baseRevision?: string;
@@ -193,6 +193,10 @@ export type PiRuntimeGatewayRuntime = {
   run: (request: PiRuntimeGatewayRunRequest) => Promise<PiRuntimeGatewayEventSource> | PiRuntimeGatewayEventSource;
   stop: (request: PiRuntimeGatewayStopRequest) => Promise<PiRuntimeGatewayEventSource> | PiRuntimeGatewayEventSource;
 };
+
+type PiRuntimeGatewayForwardedCommand = NonNullable<
+  NonNullable<PiRuntimeGatewayRunRequest['forwardedProps']>['command']
+>;
 
 export type PiRuntimeGatewayControlPlane = {
   inspectHealth: () => Promise<unknown>;
@@ -1272,10 +1276,23 @@ const parseAgUiToolCallArguments = (serializedArguments: string): unknown => {
   }
 };
 
-const buildResumePromptMessages = (resumePayload: string, now: () => number): AgentMessage[] => [
+function hasResumePayload(command: PiRuntimeGatewayForwardedCommand | undefined): boolean {
+  return !!command && Object.prototype.hasOwnProperty.call(command, 'resume');
+}
+
+function serializeResumePayload(resumePayload: unknown): string {
+  if (typeof resumePayload === 'string') {
+    return resumePayload;
+  }
+
+  const serialized = JSON.stringify(resumePayload);
+  return typeof serialized === 'string' ? serialized : String(resumePayload);
+}
+
+const buildResumePromptMessages = (resumePayload: unknown, now: () => number): AgentMessage[] => [
   {
     role: 'user',
-    content: resumePayload,
+    content: serializeResumePayload(resumePayload),
     timestamp: now(),
   },
 ];
@@ -1841,6 +1858,7 @@ export const createPiRuntimeGatewayRuntime = (params: {
       const projectedRunEvents: BaseEvent[] = [];
       const requestMessages = request.messages ?? [];
       const resumePayload = request.forwardedProps?.command?.resume;
+      const requestHasResumePayload = hasResumePayload(request.forwardedProps?.command);
       const sharedStateUpdate = readSharedStateUpdateCommand(request);
 
       return createAsyncEventStream<BaseEvent>(async (controller) => {
@@ -1848,7 +1866,7 @@ export const createPiRuntimeGatewayRuntime = (params: {
           threadId: request.threadId,
           runId: request.runId,
           messageCount: request.messages?.length ?? 0,
-          hasResumePayload: typeof resumePayload === 'string',
+          hasResumePayload: requestHasResumePayload,
         });
         controller.push(asBaseEvent({
           type: EventType.RUN_STARTED,
@@ -2026,9 +2044,9 @@ export const createPiRuntimeGatewayRuntime = (params: {
         });
 
         try {
-          if ((request.messages && request.messages.length > 0) || typeof resumePayload === 'string') {
+          if ((request.messages && request.messages.length > 0) || requestHasResumePayload) {
             const promptMessages =
-              typeof resumePayload === 'string'
+              requestHasResumePayload
                 ? buildResumePromptMessages(resumePayload, now)
                 : convertAgUiMessagesToPiMessages(request.messages ?? [], now);
             if (params.agent.state.isStreaming) {

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -297,6 +297,8 @@ type PiRuntimeGatewaySharedStateUpdateAckCode =
 
 const PI_RUNTIME_SHARED_STATE_CONTROL_EVENT = 'shared-state.control';
 const PI_RUNTIME_SHARED_STATE_REVISION_PREFIX = 'shared-rev-';
+const MISSING_CLIENT_MUTATION_ID_ERROR =
+  'Shared-state update commands require a non-empty clientMutationId.';
 
 const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
@@ -373,22 +375,36 @@ const buildSharedStateControlUpdateAckEvent = (params: {
 const readSharedStateUpdateCommand = (
   request: PiRuntimeGatewayRunRequest,
 ):
+  | { kind: 'none' }
   | {
-      clientMutationId: string | null;
+      kind: 'invalid';
+      error: string;
+    }
+  | {
+      kind: 'update';
+      clientMutationId: string;
       baseRevision: string | undefined;
       patch: unknown;
-    }
-  | null => {
+    } => {
   const update = request.forwardedProps?.command?.update;
   if (!isRecord(update)) {
-    return null;
+    return { kind: 'none' };
+  }
+
+  const clientMutationId =
+    typeof update.clientMutationId === 'string' && update.clientMutationId.length > 0
+      ? update.clientMutationId
+      : undefined;
+  if (!clientMutationId) {
+    return {
+      kind: 'invalid',
+      error: MISSING_CLIENT_MUTATION_ID_ERROR,
+    };
   }
 
   return {
-    clientMutationId:
-      typeof update.clientMutationId === 'string' && update.clientMutationId.length > 0
-        ? update.clientMutationId
-        : null,
+    kind: 'update',
+    clientMutationId,
     baseRevision:
       typeof update.baseRevision === 'string' && update.baseRevision.length > 0
         ? update.baseRevision
@@ -1860,6 +1876,9 @@ export const createPiRuntimeGatewayRuntime = (params: {
       const resumePayload = request.forwardedProps?.command?.resume;
       const requestHasResumePayload = hasResumePayload(request.forwardedProps?.command);
       const sharedStateUpdate = readSharedStateUpdateCommand(request);
+      if (sharedStateUpdate.kind === 'invalid') {
+        throw new TypeError(sharedStateUpdate.error);
+      }
 
       return createAsyncEventStream<BaseEvent>(async (controller) => {
         logPiGatewayDebug('run start', {
@@ -1874,10 +1893,10 @@ export const createPiRuntimeGatewayRuntime = (params: {
           runId: request.runId,
         } satisfies RunStartedEvent));
 
-        if (sharedStateUpdate) {
+        if (sharedStateUpdate.kind === 'update') {
           const currentSession = initialSession;
           const currentRevision = getSharedStateRevision(currentSession);
-          const clientMutationId = sharedStateUpdate.clientMutationId ?? '';
+          const clientMutationId = sharedStateUpdate.clientMutationId;
           const finishWithAck = (paramsForAck: {
             status: PiRuntimeGatewaySharedStateUpdateAckStatus;
             resultingRevision: string;
@@ -1904,16 +1923,6 @@ export const createPiRuntimeGatewayRuntime = (params: {
             } satisfies RunFinishedEvent));
             controller.close();
           };
-
-          if (clientMutationId.length === 0) {
-            finishWithAck({
-              status: 'rejected',
-              resultingRevision: currentRevision,
-              code: 'invalid_patch',
-              ...(sharedStateUpdate.baseRevision ? { baseRevision: sharedStateUpdate.baseRevision } : {}),
-            });
-            return;
-          }
 
           if (currentSession.sharedStateHydrated && !sharedStateUpdate.baseRevision) {
             finishWithAck({

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -897,19 +897,17 @@ describe('agent-runtime integration', () => {
         },
         {
           op: 'add',
-          path: '/thread/domainProjection',
+          path: '/projected/managedLifecycle',
           value: {
-            managedLifecycle: {
-              phase: 'onboarding',
-              onboardingStep: 'operator-profile',
-            },
+            phase: 'onboarding',
+            onboardingStep: 'operator-profile',
           },
         },
       ]),
     );
 
     expect(persistedThreads.get('thread-1')?.threadState).toHaveProperty('a2ui');
-    expect(persistedThreads.get('thread-1')?.threadState).toHaveProperty('domainProjection');
+    expect(persistedThreads.get('thread-1')?.threadState).toHaveProperty('projectedState');
 
     const resumeEvents = await collectEventSource(
       await runtime.service.run({
@@ -947,7 +945,7 @@ describe('agent-runtime integration', () => {
         },
         {
           op: 'add',
-          path: '/thread/domainProjection/managedLifecycle/operatorNote',
+          path: '/projected/managedLifecycle/operatorNote',
           value: 'safe window approved',
         },
       ]),
@@ -984,7 +982,7 @@ describe('agent-runtime integration', () => {
         },
         {
           op: 'replace',
-          path: '/thread/domainProjection/managedLifecycle/phase',
+          path: '/projected/managedLifecycle/phase',
           value: 'hired',
         },
         {
@@ -1019,7 +1017,7 @@ describe('agent-runtime integration', () => {
         },
         {
           op: 'replace',
-          path: '/thread/domainProjection/managedLifecycle/phase',
+          path: '/projected/managedLifecycle/phase',
           value: 'fired',
         },
       ]),
@@ -1157,7 +1155,7 @@ describe('agent-runtime integration', () => {
         },
         {
           op: 'replace',
-          path: '/thread/domainProjection/managedLifecycle/amountSummary',
+          path: '/projected/managedLifecycle/amountSummary',
           value: 'Managed amount: 250',
         },
       ]),

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -537,7 +537,12 @@ function hasSystemPromptFragments(
   return prompts.some((prompt) => fragments.every((fragment) => prompt.includes(fragment)));
 }
 
-function createLifecycleDomain() {
+function createLifecycleDomain(options?: {
+  projectSharedState?: (params: {
+    sharedState: Record<string, unknown>;
+    currentProjection?: Record<string, unknown>;
+  }) => Record<string, unknown> | undefined;
+}) {
   const phases = new Map<string, LifecycleState>();
 
   const getState = (threadId: string) =>
@@ -593,6 +598,11 @@ function createLifecycleDomain() {
       phases.set(threadId, currentState);
       return [`Lifecycle phase: ${currentState.phase}.`];
     },
+    ...(options?.projectSharedState
+      ? {
+          projectSharedState: options.projectSharedState,
+        }
+      : {}),
     handleOperation: ({
       operation,
       threadId,
@@ -1067,6 +1077,101 @@ describe('agent-runtime integration', () => {
         },
       ]),
     );
+  });
+
+  it('emits one authoritative state delta when a shared-state update also recomputes projected state', async () => {
+    const { persistedThreads, hooks: internalPostgres } = createPersistingInternalPostgres();
+    const runtime = await createAgentRuntime({
+      model: createModel('int-model-shared-update'),
+      systemPrompt: 'You are a lifecycle agent.',
+      domain: createLifecycleDomain({
+        projectSharedState: ({ sharedState, currentProjection }) => {
+          const settings =
+            typeof sharedState.settings === 'object' && sharedState.settings !== null
+              ? (sharedState.settings as { amount?: unknown })
+              : null;
+          const amount =
+            typeof settings?.amount === 'number' && Number.isFinite(settings.amount)
+              ? settings.amount
+              : null;
+
+          return {
+            ...(currentProjection ?? {}),
+            managedLifecycle: {
+              amountSummary: amount === null ? 'No managed amount configured.' : `Managed amount: ${amount}`,
+            },
+          };
+        },
+      }),
+      __internalPostgres: internalPostgres,
+    } as any);
+
+    await readFirstMatchingEvent(
+      await runtime.service.connect({
+        threadId: 'thread-shared-projection',
+        runId: 'run-connect-shared-projection',
+      }),
+      isStateSnapshotEvent,
+    );
+
+    const events = await collectEventSource(
+      await runtime.service.run({
+        threadId: 'thread-shared-projection',
+        runId: 'run-shared-projection',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: 'mutation-1',
+              baseRevision: 'shared-rev-0',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const delta = events.find(isStateDeltaEvent);
+    expect(delta?.delta).toEqual(
+      expect.arrayContaining([
+        {
+          op: 'add',
+          path: '/shared/settings',
+          value: {
+            amount: 250,
+          },
+        },
+        {
+          op: 'replace',
+          path: '/projected/managedLifecycle/amountSummary',
+          value: 'Managed amount: 250',
+        },
+        {
+          op: 'replace',
+          path: '/thread/domainProjection/managedLifecycle/amountSummary',
+          value: 'Managed amount: 250',
+        },
+      ]),
+    );
+    expect(persistedThreads.get('thread-shared-projection')?.threadState).toMatchObject({
+      sharedState: {
+        settings: {
+          amount: 250,
+        },
+      },
+      projectedState: {
+        managedLifecycle: {
+          amountSummary: 'Managed amount: 250',
+        },
+      },
+    });
   });
 
   it('logs the final system prompt when DEBUG_AGENT_RUNTIME_SYSTEM_PROMPT is enabled', async () => {

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -1,3 +1,4 @@
+import { EventType } from '@ag-ui/core';
 import {
   createAssistantMessageEventStream,
   type AssistantMessage,
@@ -511,7 +512,7 @@ function isStateDeltaEvent(event: GatewayEvent): event is StateDeltaEvent {
     typeof event === 'object' &&
     event !== null &&
     'type' in event &&
-    event.type === 'STATE_DELTA' &&
+    event.type === EventType.STATE_DELTA &&
     'delta' in event
   );
 }

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -917,7 +917,9 @@ describe('agent-runtime integration', () => {
         runId: 'run-resume',
         forwardedProps: {
           command: {
-            resume: '{"operatorNote":"safe window approved"}',
+            resume: {
+              operatorNote: 'safe window approved',
+            },
           },
         },
       }),
@@ -1661,7 +1663,9 @@ describe('agent-runtime integration', () => {
         runId: 'run-resume-checkpoint-alignment',
         forwardedProps: {
           command: {
-            resume: '{"operatorNote":"safe window approved"}',
+            resume: {
+              operatorNote: 'safe window approved',
+            },
           },
         },
       }),

--- a/typescript/agent-runtime/src/index.ts
+++ b/typescript/agent-runtime/src/index.ts
@@ -185,7 +185,7 @@ export type AgentRuntimeSharedStatePatchOperation = {
 export type AgentRuntimeForwardedCommand = {
   name?: string;
   input?: unknown;
-  resume?: string;
+  resume?: unknown;
   update?: {
     clientMutationId: string;
     baseRevision?: string;
@@ -769,8 +769,9 @@ function readInterruptOperation<TState>(params: {
   session: PiRuntimeGatewaySession;
   domain: AgentRuntimeDomainConfig<TState> | undefined;
 }): AgentRuntimeDomainOperation | null {
+  const hasResume = Object.prototype.hasOwnProperty.call(params.command ?? {}, 'resume');
   const resumePayload = params.command?.resume;
-  if (typeof resumePayload !== 'string' || !params.domain?.handleOperation) {
+  if (!hasResume || !params.domain?.handleOperation) {
     return null;
   }
 
@@ -797,7 +798,10 @@ function readInterruptOperation<TState>(params: {
   return {
     source: 'interrupt',
     name: interruptType,
-    input: parseDomainCommandToolInput(resumePayload),
+    input:
+      typeof resumePayload === 'string'
+        ? parseDomainCommandToolInput(resumePayload)
+        : resumePayload,
   };
 }
 
@@ -2473,7 +2477,7 @@ export async function createAgentRuntime<TState = unknown>(
           session,
           domain,
         }) !== null;
-      if (typeof request.forwardedProps?.command?.resume === 'string' && !isDomainInterruptResume) {
+      if (Object.prototype.hasOwnProperty.call(request.forwardedProps?.command ?? {}, 'resume') && !isDomainInterruptResume) {
         const resumedSession = await resumeInterruptedSession(request.threadId);
         const stateDeltaEvent = buildPiRuntimeGatewayStateDeltaEventInternal({
           previousSession: session,

--- a/typescript/agent-runtime/src/index.ts
+++ b/typescript/agent-runtime/src/index.ts
@@ -948,9 +948,7 @@ function reconcileSharedStateProjection<TState>(params: {
 
   const currentProjection = isRecord(params.session.projectedState)
     ? params.session.projectedState
-    : isRecord(params.session.domainProjection)
-      ? params.session.domainProjection
-      : undefined;
+    : undefined;
   const projectionUpdate = projectSharedState({
     threadId: params.threadId,
     state: params.domainState,
@@ -1124,8 +1122,8 @@ function applyDomainOperationResult(params: {
   let nextA2Ui = params.session.a2ui;
   let shouldWriteA2Ui = false;
   const nextDomainProjection = hasDomainProjectionUpdate
-    ? mergeDomainProjection(params.session.domainProjection, params.result.domainProjectionUpdate)
-    : params.session.domainProjection;
+    ? mergeDomainProjection(params.session.projectedState, params.result.domainProjectionUpdate)
+    : params.session.projectedState;
 
   for (const artifactOutput of domainOutputs.artifacts ?? []) {
     const artifact = buildDomainArtifact({
@@ -1203,7 +1201,7 @@ function applyDomainOperationResult(params: {
     ...(nextArtifacts ? { artifacts: nextArtifacts } : {}),
     ...(nextActivityEvents.length > 0 ? { activityEvents: nextActivityEvents } : {}),
     ...(shouldWriteA2Ui ? { a2ui: nextA2Ui } : {}),
-    ...(hasDomainProjectionUpdate ? { domainProjection: nextDomainProjection } : {}),
+    ...(hasDomainProjectionUpdate ? { projectedState: nextDomainProjection } : {}),
     ...(lifecycleThreadPatch
       ? {
           threadPatch: mergeThreadPatch(params.session.threadPatch, lifecycleThreadPatch),

--- a/typescript/agent-runtime/src/index.ts
+++ b/typescript/agent-runtime/src/index.ts
@@ -144,6 +144,11 @@ export type AgentRuntimeDomainContext<TState = unknown> = {
   state?: TState;
 };
 
+export type AgentRuntimeSharedStateProjectionContext<TState = unknown> = AgentRuntimeDomainContext<TState> & {
+  sharedState: Record<string, unknown>;
+  currentProjection?: Record<string, unknown>;
+};
+
 export type AgentRuntimeDomainConfig<TState = unknown> = {
   lifecycle: AgentRuntimeDomainLifecycle;
   systemContext?: (
@@ -153,6 +158,9 @@ export type AgentRuntimeDomainConfig<TState = unknown> = {
     | readonly string[]
     | undefined
     | Promise<string | readonly string[] | undefined>;
+  projectSharedState?: (
+    params: AgentRuntimeSharedStateProjectionContext<TState>,
+  ) => Record<string, unknown> | undefined;
   handleOperation?: (params: AgentRuntimeDomainContext<TState> & {
     operation: AgentRuntimeDomainOperation;
   }) => AgentRuntimeDomainOperationResult<TState> | Promise<AgentRuntimeDomainOperationResult<TState>>;
@@ -923,6 +931,38 @@ function mergeDomainProjection(
   return isRecord(merged) ? merged : undefined;
 }
 
+function reconcileSharedStateProjection<TState>(params: {
+  threadId: string;
+  session: PiRuntimeGatewaySession;
+  domain: AgentRuntimeDomainConfig<TState> | undefined;
+  domainState: TState | undefined;
+}): PiRuntimeGatewaySession {
+  const projectSharedState = params.domain?.projectSharedState;
+  if (!projectSharedState) {
+    return params.session;
+  }
+
+  const currentProjection = isRecord(params.session.projectedState)
+    ? params.session.projectedState
+    : isRecord(params.session.domainProjection)
+      ? params.session.domainProjection
+      : undefined;
+  const projectionUpdate = projectSharedState({
+    threadId: params.threadId,
+    state: params.domainState,
+    sharedState: isRecord(params.session.sharedState) ? params.session.sharedState : {},
+    currentProjection,
+  });
+  if (!projectionUpdate) {
+    return params.session;
+  }
+
+  return {
+    ...params.session,
+    projectedState: mergeDomainProjection(currentProjection, projectionUpdate),
+  };
+}
+
 function mergeThreadPatch(
   currentPatch: Record<string, unknown> | undefined,
   nextPatch: Record<string, unknown> | undefined,
@@ -1602,6 +1642,36 @@ export async function createAgentRuntime<TState = unknown>(
   const initialLifecyclePhase = domain?.lifecycle.initialPhase;
   const sessionStore = createSessionStore(initialLifecyclePhase);
   const domainStateStore = new Map<string, TState>();
+  const reconcileSession = (
+    threadId: string,
+    session: PiRuntimeGatewaySession,
+  ): PiRuntimeGatewaySession =>
+    reconcileSharedStateProjection({
+      threadId,
+      session,
+      domain,
+      domainState: domainStateStore.get(threadId),
+    });
+  const getSession = (threadId: string): PiRuntimeGatewaySession => {
+    const session = sessionStore.getSession(threadId);
+    const reconciled = reconcileSession(threadId, session);
+    if (reconciled !== session) {
+      sessionStore.setSession(threadId, reconciled);
+    }
+    return reconciled;
+  };
+  const setSession = (threadId: string, session: PiRuntimeGatewaySession): PiRuntimeGatewaySession => {
+    const reconciled = reconcileSession(threadId, session);
+    sessionStore.setSession(threadId, reconciled);
+    return reconciled;
+  };
+  const updateSession = (
+    threadId: string,
+    update: (session: PiRuntimeGatewaySession) => PiRuntimeGatewaySession,
+  ): PiRuntimeGatewaySession => {
+    const nextSession = update(getSession(threadId));
+    return setSession(threadId, nextSession);
+  };
   const automationRegistry = createAutomationRegistry();
   const attachedRuns = createAttachedRunRegistry();
   const executionContext = new AsyncLocalStorage<AgentRuntimeExecutionContext>();
@@ -1612,7 +1682,7 @@ export async function createAgentRuntime<TState = unknown>(
   };
   const getActiveSessionContext = (): PiRuntimeGatewaySession | undefined => {
     const threadId = getActiveThreadId();
-    return threadId ? sessionStore.getSession(threadId) : undefined;
+    return threadId ? getSession(threadId) : undefined;
   };
   const loadInspectionState = async (): Promise<PiRuntimeGatewayInspectionState> => {
     return await postgres.loadInspectionState({
@@ -1645,7 +1715,7 @@ export async function createAgentRuntime<TState = unknown>(
   };
   const persistSessionSnapshot = async (
     threadId: string,
-    session: PiRuntimeGatewaySession = sessionStore.getSession(threadId),
+    session: PiRuntimeGatewaySession = getSession(threadId),
   ): Promise<void> => {
     const ids = buildPiRuntimeDirectExecutionRecordIdsInternal(threadId);
     const persistedExecutionId = resolvePersistedExecutionId(threadId, session);
@@ -1741,7 +1811,7 @@ export async function createAgentRuntime<TState = unknown>(
   };
   const hydrateThreadSession = async (threadId: string): Promise<PiRuntimeGatewaySession> => {
     if (sessionStore.hasSession(threadId)) {
-      return sessionStore.getSession(threadId);
+      return getSession(threadId);
     }
 
     const inspectionState = await loadInspectionState();
@@ -1756,7 +1826,7 @@ export async function createAgentRuntime<TState = unknown>(
             ? readPersistedLifecycleDomainState<TState>(persistedThread.threadState)
             : undefined;
         const normalizedSession = materializeSessionLifecycle(persistedSession, initialLifecyclePhase);
-        const hydratedSession = sessionStore.setSession(threadId, normalizedSession);
+        const hydratedSession = setSession(threadId, normalizedSession);
         if (persistedDomainState !== undefined) {
           domainStateStore.set(threadId, persistedDomainState);
         } else if (recoveredLifecycleState !== undefined) {
@@ -1777,7 +1847,7 @@ export async function createAgentRuntime<TState = unknown>(
       }
     }
 
-    return sessionStore.getSession(threadId);
+    return getSession(threadId);
   };
   const ensureThread = async (threadId: string): Promise<PiRuntimeGatewaySession> => {
     const session = await hydrateThreadSession(threadId);
@@ -1879,7 +1949,7 @@ export async function createAgentRuntime<TState = unknown>(
     operation: AgentRuntimeDomainOperation,
   ): Promise<PiRuntimeGatewaySession> => {
     if (!domain?.handleOperation) {
-      return sessionStore.getSession(threadId);
+      return getSession(threadId);
     }
 
     const result = await domain.handleOperation({
@@ -1895,7 +1965,7 @@ export async function createAgentRuntime<TState = unknown>(
       }
     }
 
-    const nextSession = sessionStore.updateSession(threadId, (currentSession) =>
+    const nextSession = updateSession(threadId, (currentSession) =>
       applyDomainOperationResult({
         threadId,
         now,
@@ -1910,7 +1980,7 @@ export async function createAgentRuntime<TState = unknown>(
   };
 
   const resumeInterruptedSession = async (threadId: string): Promise<PiRuntimeGatewaySession> => {
-    const nextSession = sessionStore.updateSession(threadId, resolveInterruptedSessionForUserInput);
+    const nextSession = updateSession(threadId, resolveInterruptedSessionForUserInput);
     await persistSessionSnapshot(threadId, nextSession);
     return nextSession;
   };
@@ -1920,7 +1990,7 @@ export async function createAgentRuntime<TState = unknown>(
     error: unknown,
   ): Promise<PiRuntimeGatewaySession> => {
     const detail = error instanceof Error ? error.message : String(error);
-    const nextSession = sessionStore.updateSession(threadId, (session) => ({
+    const nextSession = updateSession(threadId, (session) => ({
       ...session,
       execution: {
         ...session.execution,
@@ -2162,9 +2232,9 @@ export async function createAgentRuntime<TState = unknown>(
             command: 'sync',
             schedule: { kind: 'every', intervalMinutes: 5 },
             runId: `run:${threadId}`,
-            executionId: sessionStore.getSession(threadId).execution.id,
+            executionId: getSession(threadId).execution.id,
             artifactId:
-              sessionStore.getSession(threadId).artifacts?.current?.artifactId ??
+              getSession(threadId).artifacts?.current?.artifactId ??
               `artifact:${threadId}:automation`,
             nextRunAt: null,
             status: 'active',
@@ -2326,8 +2396,8 @@ export async function createAgentRuntime<TState = unknown>(
 
   const runtime = createPiRuntimeGatewayRuntimeInternal({
     agent: foundation.agent,
-    getSession: sessionStore.getSession,
-    updateSession: sessionStore.updateSession,
+    getSession,
+    updateSession,
     onSessionUpdated: persistSessionSnapshot,
     now,
   });
@@ -2335,7 +2405,7 @@ export async function createAgentRuntime<TState = unknown>(
   const runtimeWithDomain: PiRuntimeGatewayRuntime = {
     ...runtime,
     run: async (request) => {
-      const session = sessionStore.getSession(request.threadId);
+      const session = getSession(request.threadId);
       const operation =
         readDirectCommandOperation(request.forwardedProps?.command) ??
         readInterruptOperation({

--- a/typescript/agent-runtime/src/index.ts
+++ b/typescript/agent-runtime/src/index.ts
@@ -22,6 +22,7 @@ import {
   type PiRuntimeGatewayActivityEvent,
   type PiRuntimeGatewayArtifact,
   type PiRuntimeGatewayInspectionState,
+  type PiRuntimeGatewayRunRequest,
   type PiRuntimeGatewayRuntime,
   type PiRuntimeGatewaySession,
 } from '../lib/pi/dist/index.js';
@@ -44,6 +45,9 @@ type AgentRuntimeGetApiKey = NonNullable<RuntimeAgentOptions['getApiKey']>;
 type AgentRuntimeInitialState = NonNullable<RuntimeAgentOptions['initialState']>;
 type AgentRuntimeConvertToLlm = NonNullable<RuntimeAgentOptions['convertToLlm']>;
 type AgentRuntimeTool = RuntimeAgentTool;
+type AgentRuntimeInternalForwardedCommand = NonNullable<
+  NonNullable<PiRuntimeGatewayRunRequest['forwardedProps']>['command']
+>;
 type AgentRuntimeConnectEvent = ReturnType<typeof buildPiRuntimeGatewayConnectEventsInternal>[number];
 type AgentRuntimeAttachedEventSource = readonly AgentRuntimeConnectEvent[] | AsyncIterable<AgentRuntimeConnectEvent>;
 type AgentRuntimeAttachedThreadListener = (event: AgentRuntimeConnectEvent) => void;
@@ -164,10 +168,21 @@ export interface AgentRuntimeAgentOptions {
   convertToLlm?: AgentRuntimeConvertToLlm;
 }
 
+export type AgentRuntimeSharedStatePatchOperation = {
+  op: 'add' | 'replace' | 'remove';
+  path: string;
+  value?: unknown;
+};
+
 export type AgentRuntimeForwardedCommand = {
   name?: string;
   input?: unknown;
   resume?: string;
+  update?: {
+    clientMutationId: string;
+    baseRevision?: string;
+    patch: ReadonlyArray<AgentRuntimeSharedStatePatchOperation>;
+  };
 };
 
 type AgentRuntimeDomainCommandToolArgs = {
@@ -723,7 +738,7 @@ function validateDomainLifecycle(lifecycle: AgentRuntimeDomainLifecycle): void {
 }
 
 function readDirectCommandOperation(
-  command: AgentRuntimeForwardedCommand | undefined,
+  command: Pick<AgentRuntimeInternalForwardedCommand, 'name' | 'input'> | undefined,
 ): AgentRuntimeDomainOperation | null {
   if (!command || typeof command.name !== 'string') {
     return null;
@@ -742,7 +757,7 @@ function readDirectCommandOperation(
 }
 
 function readInterruptOperation<TState>(params: {
-  command: AgentRuntimeForwardedCommand | undefined;
+  command: Pick<AgentRuntimeInternalForwardedCommand, 'resume'> | undefined;
   session: PiRuntimeGatewaySession;
   domain: AgentRuntimeDomainConfig<TState> | undefined;
 }): AgentRuntimeDomainOperation | null {
@@ -1398,6 +1413,12 @@ function cloneAttachedEvents(events: readonly AgentRuntimeConnectEvent[]): Agent
   return clonedEvents;
 }
 
+function isAttachedEventArray(
+  source: AgentRuntimeAttachedEventSource,
+): source is readonly AgentRuntimeConnectEvent[] {
+  return Array.isArray(source);
+}
+
 function injectAttachedEventsAfterFirstEvent(
   source: AgentRuntimeAttachedEventSource,
   injectedEvents: readonly AgentRuntimeConnectEvent[],
@@ -1406,16 +1427,14 @@ function injectAttachedEventsAfterFirstEvent(
     return source;
   }
 
-  if (Array.isArray(source)) {
+  if (isAttachedEventArray(source)) {
     if (source.length === 0) {
       return cloneAttachedEvents(injectedEvents);
     }
 
-    return [
-      source[0],
-      ...injectedEvents,
-      ...source.slice(1),
-    ];
+    const mergedEvents = cloneAttachedEvents(source);
+    mergedEvents.splice(1, 0, ...cloneAttachedEvents(injectedEvents));
+    return mergedEvents;
   }
 
   return {

--- a/typescript/agent-runtime/src/index.unit.test.ts
+++ b/typescript/agent-runtime/src/index.unit.test.ts
@@ -189,7 +189,12 @@ describe('agent-runtime facade', () => {
     expect(declarations).not.toContain('__internalPostgres');
     expect(publicDomainContract).toContain('export type AgentRuntimeExecutionStatus');
     expect(source).toContain('export type AgentRuntimeDomainContext');
+    expect(publicDomainContract).toContain('export type AgentRuntimeSharedStateProjectionContext');
     expect(publicDomainContract).toContain('domainProjectionUpdate?: Record<string, unknown>;');
+    expect(publicDomainContract).toContain('projectSharedState?:');
+    expect(publicDomainContract).toContain('sharedState: Record<string, unknown>;');
+    expect(declarations).toContain('export type AgentRuntimeSharedStateProjectionContext');
+    expect(declarations).toContain('projectSharedState?:');
     expect(source).toContain('export interface CreateAgentRuntimeOptions');
   });
 

--- a/typescript/agent-runtime/src/index.unit.test.ts
+++ b/typescript/agent-runtime/src/index.unit.test.ts
@@ -218,6 +218,16 @@ describe('agent-runtime facade', () => {
     expect(declarations).toContain('patch: ReadonlyArray<AgentRuntimeSharedStatePatchOperation>;');
   });
 
+  it('keeps public resume payloads open for object passthrough on the forwarded command contract', () => {
+    const source = readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+    const declarations = readFileSync(new URL('../dist/index.d.ts', import.meta.url), 'utf8');
+
+    expect(source).toContain('resume?: unknown;');
+    expect(source).not.toContain('resume?: string;');
+    expect(declarations).toContain('resume?: unknown;');
+    expect(declarations).not.toContain('resume?: string;');
+  });
+
   it('owns sessions and control-plane defaults inside the blessed builder', async () => {
     const internalPostgres = createInternalPostgresHooks();
     const runtime = await agentRuntime.createAgentRuntime({

--- a/typescript/agent-runtime/src/index.unit.test.ts
+++ b/typescript/agent-runtime/src/index.unit.test.ts
@@ -193,6 +193,26 @@ describe('agent-runtime facade', () => {
     expect(source).toContain('export interface CreateAgentRuntimeOptions');
   });
 
+  it('exposes canonical shared-state update commands on the public forwarded command contract', () => {
+    const source = readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+    const declarations = readFileSync(new URL('../dist/index.d.ts', import.meta.url), 'utf8');
+
+    expect(source).toContain('update?: {');
+    expect(source).toContain('clientMutationId: string;');
+    expect(source).toContain('baseRevision?: string;');
+    expect(source).toContain('export type AgentRuntimeSharedStatePatchOperation = {');
+    expect(source).toContain("op: 'add' | 'replace' | 'remove';");
+    expect(source).toContain('path: string;');
+    expect(source).toContain('patch: ReadonlyArray<AgentRuntimeSharedStatePatchOperation>;');
+    expect(declarations).toContain('update?: {');
+    expect(declarations).toContain('clientMutationId: string;');
+    expect(declarations).toContain('baseRevision?: string;');
+    expect(declarations).toContain('export type AgentRuntimeSharedStatePatchOperation = {');
+    expect(declarations).toContain("op: 'add' | 'replace' | 'remove';");
+    expect(declarations).toContain('path: string;');
+    expect(declarations).toContain('patch: ReadonlyArray<AgentRuntimeSharedStatePatchOperation>;');
+  });
+
   it('owns sessions and control-plane defaults inside the blessed builder', async () => {
     const internalPostgres = createInternalPostgresHooks();
     const runtime = await agentRuntime.createAgentRuntime({

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
@@ -155,6 +155,11 @@ type EmberLendingExecutionPublicClient = {
 type ResolveExecutionPublicClient = (
   network: SupportedExecutionNetwork,
 ) => EmberLendingExecutionPublicClient;
+type PreparedUnsignedTransactionSigningInputs = {
+  nonce: number;
+  feeEstimate: Awaited<ReturnType<EmberLendingExecutionPublicClient['estimateFeesPerGas']>>;
+  gas: bigint;
+};
 
 function trimTrailingSlash(value: string): string {
   return value.endsWith('/') ? value.slice(0, -1) : value;
@@ -507,34 +512,12 @@ async function resolvePreparedUnsignedTransactionHex(input: {
     modes: [executions.length === 1 ? ExecutionMode.SingleDefault : ExecutionMode.BatchDefault],
     executions: [executions],
   });
-  let nonce: number;
-  let feeEstimate: Awaited<ReturnType<EmberLendingExecutionPublicClient['estimateFeesPerGas']>>;
-  let gas: bigint;
-
-  for (let attempt = 1; attempt <= SIGNING_RESOLUTION_ATTEMPTS; attempt += 1) {
-    try {
-      [nonce, feeEstimate, gas] = await Promise.all([
-        input.publicClient.getTransactionCount({
-          address: input.walletAddress,
-          blockTag: 'pending',
-        }),
-        input.publicClient.estimateFeesPerGas(),
-        input.publicClient.estimateGas({
-          account: input.walletAddress,
-          to: delegationManager,
-          value: 0n,
-          data: delegatedTransactionData,
-        }),
-      ]);
-      break;
-    } catch (error) {
-      if (attempt === SIGNING_RESOLUTION_ATTEMPTS) {
-        throw error;
-      }
-
-      await sleep(SIGNING_RESOLUTION_RETRY_DELAY_MS);
-    }
-  }
+  const { nonce, feeEstimate, gas } = await resolvePreparedUnsignedTransactionSigningInputs({
+    publicClient: input.publicClient,
+    walletAddress: input.walletAddress,
+    delegationManager,
+    delegatedTransactionData,
+  });
 
   if (
     typeof feeEstimate.maxFeePerGas === 'bigint' &&
@@ -566,6 +549,40 @@ async function resolvePreparedUnsignedTransactionHex(input: {
   }
 
   throw new Error('RPC fee estimation did not return a signable gas price or EIP-1559 fee pair.');
+}
+
+async function resolvePreparedUnsignedTransactionSigningInputs(input: {
+  publicClient: EmberLendingExecutionPublicClient;
+  walletAddress: `0x${string}`;
+  delegationManager: `0x${string}`;
+  delegatedTransactionData: `0x${string}`;
+}): Promise<PreparedUnsignedTransactionSigningInputs> {
+  for (let attempt = 1; attempt <= SIGNING_RESOLUTION_ATTEMPTS; attempt += 1) {
+    try {
+      const [nonce, feeEstimate, gas] = await Promise.all([
+        input.publicClient.getTransactionCount({
+          address: input.walletAddress,
+          blockTag: 'pending',
+        }),
+        input.publicClient.estimateFeesPerGas(),
+        input.publicClient.estimateGas({
+          account: input.walletAddress,
+          to: input.delegationManager,
+          value: 0n,
+          data: input.delegatedTransactionData,
+        }),
+      ]);
+      return { nonce, feeEstimate, gas };
+    } catch (error) {
+      if (attempt === SIGNING_RESOLUTION_ATTEMPTS) {
+        throw error;
+      }
+
+      await sleep(SIGNING_RESOLUTION_RETRY_DELAY_MS);
+    }
+  }
+
+  throw new Error('Failed to resolve delegated transaction signing inputs.');
 }
 
 function resolveAnchoredPayloadRef(input: {

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/package.json
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/package.json
@@ -28,6 +28,8 @@
     "pretest:unit": "pnpm build:runtime-deps",
     "start": "bash -lc 'ENV_FILE=.env; [ -f \"$ENV_FILE\" ] || ENV_FILE=.env.example; exec node --env-file=\"$ENV_FILE\" ./node_modules/tsx/dist/cli.mjs src/server.ts \"$@\"' --",
     "build": "tsc --project tsconfig.json",
+    "lint": "eslint \"src\" \"tests\" --ext .ts",
+    "lint:fix": "eslint \"src\" \"tests\" --ext .ts --fix",
     "test": "pnpm test:unit && pnpm test:int",
     "test:int": "vitest run --config vitest.config.int.ts",
     "test:unit": "vitest run",

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/agUiServer.int.test.ts
@@ -33,8 +33,25 @@ async function writeNodeResponse(response: Response, target: ServerResponse): Pr
     target.setHeader(key, value);
   });
 
-  const body = new Uint8Array(await response.arrayBuffer());
-  target.end(body);
+  if (!response.body) {
+    target.end();
+    return;
+  }
+
+  const reader = response.body.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      target.write(Buffer.from(value));
+    }
+  } finally {
+    target.end();
+  }
 }
 
 function parseEventStreamBody(body: string): AgUiEventEnvelope[] {
@@ -42,6 +59,49 @@ function parseEventStreamBody(body: string): AgUiEventEnvelope[] {
     .split('\n')
     .filter((line) => line.startsWith('data: '))
     .map((line) => JSON.parse(line.slice('data: '.length)) as AgUiEventEnvelope);
+}
+
+async function readEventStreamUntil(
+  response: Response,
+  predicate: (events: readonly AgUiEventEnvelope[]) => boolean,
+): Promise<AgUiEventEnvelope[]> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return [];
+  }
+
+  const decoder = new TextDecoder();
+  const events: AgUiEventEnvelope[] = [];
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) {
+          continue;
+        }
+
+        events.push(JSON.parse(line.slice('data: '.length)) as AgUiEventEnvelope);
+        if (predicate(events)) {
+          await reader.cancel();
+          return events;
+        }
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  return events;
 }
 
 function findStateSnapshot(events: readonly AgUiEventEnvelope[]) {
@@ -422,6 +482,125 @@ describe('agent-pi-example AG-UI integration', () => {
                 operatorNote: 'safe window approved',
               },
             },
+          },
+        },
+      },
+    });
+  });
+
+  it('serves canonical shared-state hydration and update acknowledgments over AG-UI HTTP', async () => {
+    const connectResponse = await fetch(`${baseUrl}/agent/${PI_EXAMPLE_AGENT_ID}/connect`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-shared-state',
+      }),
+    });
+
+    expect(connectResponse.ok).toBe(true);
+    const connectEvents = await readEventStreamUntil(
+      connectResponse,
+      (events) =>
+        events.some(
+          (event) =>
+            event.type === 'CUSTOM' &&
+            event.name === 'shared-state.control' &&
+            typeof event.value === 'object' &&
+            event.value !== null &&
+            'kind' in event.value &&
+            event.value.kind === 'hydration',
+        ),
+    );
+
+    expect(findStateSnapshot(connectEvents)).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        shared: {},
+        projected: {},
+        thread: {
+          id: 'thread-shared-state',
+        },
+      },
+    });
+    expect(connectEvents).toContainEqual({
+      type: 'CUSTOM',
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'bootstrap',
+        revision: 'shared-rev-0',
+      },
+    });
+
+    const updateResponse = await fetch(`${baseUrl}/agent/${PI_EXAMPLE_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        threadId: 'thread-shared-state',
+        runId: 'run-shared-state-update',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: 'mutation-1',
+              baseRevision: 'shared-rev-0',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    });
+
+    expect(updateResponse.ok).toBe(true);
+    const updateEvents = parseEventStreamBody(await updateResponse.text());
+    const updateSnapshot = projectStateSnapshot({
+      baseline: findStateSnapshot(connectEvents),
+      events: updateEvents,
+    });
+
+    expect(findStateDeltas(updateEvents)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          delta: expect.arrayContaining([
+            expect.objectContaining({
+              op: 'add',
+              path: '/shared/settings',
+              value: {
+                amount: 250,
+              },
+            }),
+          ]),
+        }),
+      ]),
+    );
+    expect(updateEvents).toContainEqual({
+      type: 'CUSTOM',
+      name: 'shared-state.control',
+      value: {
+        kind: 'update-ack',
+        clientMutationId: 'mutation-1',
+        status: 'accepted',
+        resultingRevision: 'shared-rev-1',
+        baseRevision: 'shared-rev-0',
+      },
+    });
+    expect(updateSnapshot).toMatchObject({
+      type: 'STATE_SNAPSHOT',
+      snapshot: {
+        shared: {
+          settings: {
+            amount: 250,
           },
         },
       },

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.ts
@@ -481,7 +481,7 @@ function createPiExampleMockStream(): PiExampleGatewayStream {
       });
     }
 
-    if (latestUserText.includes('schedule') || latestUserText.includes('"command":"sync"')) {
+    if (latestUserText.includes('schedule')) {
       return createMockToolStream({
         model,
         toolName: AGENT_RUNTIME_AUTOMATION_SCHEDULE_TOOL,

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.unit.test.ts
@@ -258,4 +258,34 @@ describe('createPiExampleAgentConfig', () => {
       AGENT_RUNTIME_REQUEST_OPERATOR_INPUT_TOOL,
     ]).toHaveLength(4);
   });
+
+  it('does not treat legacy sync JSON chat text as a schedule command', async () => {
+    const config = createPiExampleAgentConfig({
+      E2E_PROFILE: 'mocked',
+    });
+
+    const streamFn = config.agentOptions?.streamFn;
+    expect(streamFn).toBeDefined();
+
+    const legacySyncStream = streamFn!(
+      config.model!,
+      {
+        systemPrompt: config.systemPrompt,
+        messages: [{ role: 'user', content: '{"command":"sync"}' }],
+      } as never,
+      {} as never,
+    );
+
+    const collectToolName = async (stream: AsyncIterable<{ partial?: { content?: Array<{ name?: string }> } }>) => {
+      for await (const event of stream) {
+        const toolName = event.partial?.content?.find((part) => part.name)?.name;
+        if (toolName) {
+          return toolName;
+        }
+      }
+      return null;
+    };
+
+    await expect(collectToolName(legacySyncStream)).resolves.toBeNull();
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -70,14 +70,10 @@ function parseEventStreamBody(body: string): AgUiEventEnvelope[] {
     .map((line) => JSON.parse(line.slice('data: '.length)) as AgUiEventEnvelope);
 }
 
-function findStateSnapshot(events: readonly AgUiEventEnvelope[]) {
-  return [...events].reverse().find((event) => event.type === 'STATE_SNAPSHOT');
-}
-
 function findStateDeltas(events: readonly AgUiEventEnvelope[]) {
   return events.filter(
     (event): event is AgUiEventEnvelope & { delta: JsonPatchOperation[] } =>
-      event.type === 'STATE_DELTA' && Array.isArray(event.delta),
+      event.type === 'STATE_DELTA' && Array.isArray(event['delta']),
   );
 }
 
@@ -507,7 +503,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
 
     expect(hireResponse.ok).toBe(true);
     expect(hireResponse.headers.get('content-type')).toContain('text/event-stream');
-    const hireEvents = parseEventStreamBody(await hireResponse.text());
+    expect(parseEventStreamBody(await hireResponse.text())).not.toHaveLength(0);
     const hireSnapshot = await readThreadSnapshot({
       baseUrl,
       agentId: PORTFOLIO_MANAGER_AGENT_ID,
@@ -560,7 +556,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
     });
 
     expect(setupResponse.ok).toBe(true);
-    const setupEvents = parseEventStreamBody(await setupResponse.text());
+    expect(parseEventStreamBody(await setupResponse.text())).not.toHaveLength(0);
     const setupSnapshot = await readThreadSnapshot({
       baseUrl,
       agentId: PORTFOLIO_MANAGER_AGENT_ID,
@@ -1173,7 +1169,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
     });
 
     expect(fireResponse.ok).toBe(true);
-    const fireEvents = parseEventStreamBody(await fireResponse.text());
+    expect(parseEventStreamBody(await fireResponse.text())).not.toHaveLength(0);
     const fireSnapshot = await readThreadSnapshot({
       baseUrl,
       agentId: PORTFOLIO_MANAGER_AGENT_ID,
@@ -1219,7 +1215,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
     });
 
     expect(rehireResponse.ok).toBe(true);
-    const rehireEvents = parseEventStreamBody(await rehireResponse.text());
+    expect(parseEventStreamBody(await rehireResponse.text())).not.toHaveLength(0);
     const rehireSnapshot = await readThreadSnapshot({
       baseUrl,
       agentId: PORTFOLIO_MANAGER_AGENT_ID,

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -1306,12 +1306,13 @@ export function createPortfolioManagerDomain(
     systemContext: async ({ state }) => {
       const currentState = state ?? buildDefaultLifecycleState();
       const context = ['<portfolio_manager_context>'];
+      const protocolHost = options.protocolHost;
       const liveManagedMandateProjection =
-        currentState.phase === 'active' && options.protocolHost
+        currentState.phase === 'active' && protocolHost
           ? await (async () => {
               try {
                 const managedPortfolioState = await readSharedEmberPortfolioState({
-                  protocolHost: options.protocolHost,
+                  protocolHost,
                   threadId: 'system-context',
                   agentId: FIRST_MANAGED_AGENT_TYPE,
                 });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
@@ -110,7 +110,7 @@ export async function POST(req: NextRequest): Promise<Response> {
           },
         },
       })
-      .pipe(verifyEvents(), toArray()),
+      .pipe(verifyEvents(false), toArray()),
   );
 
   const snapshot = readLatestStateSnapshot(runEvents);

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
@@ -115,6 +115,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const snapshot = readLatestStateSnapshot(runEvents);
   const thread = isRecord(snapshot?.['thread']) ? snapshot['thread'] : null;
+  const projected = isRecord(snapshot?.['projected']) ? snapshot['projected'] : null;
   const task = isRecord(thread?.['task']) ? thread['task'] : null;
   const taskStatus = isRecord(task?.['taskStatus']) ? task['taskStatus'] : null;
   const taskState = readString(taskStatus?.['state']);
@@ -140,6 +141,6 @@ export async function POST(req: NextRequest): Promise<Response> {
     ok: true,
     taskState,
     statusMessage,
-    domainProjection: isRecord(thread?.['domainProjection']) ? thread['domainProjection'] : null,
+    domainProjection: projected,
   });
 }

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
@@ -64,10 +64,10 @@ describe('POST /api/agent-command', () => {
                   },
                 },
               },
-              domainProjection: {
-                managedMandateEditor: {
-                  mandateSummary: 'lend USDC and DAI through the managed lending lane',
-                },
+            },
+            projected: {
+              managedMandateEditor: {
+                mandateSummary: 'lend USDC and DAI through the managed lending lane',
               },
             },
           },
@@ -99,6 +99,53 @@ describe('POST /api/agent-command', () => {
           mandateSummary: 'lend USDC and DAI through the managed lending lane',
         },
       },
+    });
+  });
+
+  it('does not treat legacy thread.domainProjection as a supported runtime response shape', async () => {
+    runMock.mockReturnValue(
+      from([
+        { type: EventType.RUN_STARTED, threadId: 'thread-1', runId: 'run-1' },
+        {
+          type: EventType.STATE_SNAPSHOT,
+          threadId: 'thread-1',
+          runId: 'run-1',
+          snapshot: {
+            thread: {
+              id: 'thread-1',
+              task: {
+                taskStatus: {
+                  state: 'completed',
+                },
+              },
+              domainProjection: {
+                managedMandateEditor: {
+                  mandateSummary: 'legacy fallback should be ignored',
+                },
+              },
+            },
+          },
+        },
+        { type: EventType.RUN_FINISHED, threadId: 'thread-1', runId: 'run-1' },
+      ]),
+    );
+
+    const response = await POST(
+      buildRequest({
+        agentId: 'agent-portfolio-manager',
+        threadId: 'thread-1',
+        command: {
+          name: 'hydrate_runtime_projection',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      taskState: 'completed',
+      statusMessage: null,
+      domainProjection: null,
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts
@@ -69,7 +69,7 @@ function createPromptRunInput(prompt: string, overrides: Partial<RunAgentInput> 
   });
 }
 
-function createResumeRunInput(resumePayload: string, overrides: Partial<RunAgentInput> = {}): RunAgentInput {
+function createResumeRunInput(resumePayload: unknown, overrides: Partial<RunAgentInput> = {}): RunAgentInput {
   return createInput({
     forwardedProps: {
       command: {
@@ -516,7 +516,14 @@ describe('agent-runtime HTTP agent integration', () => {
 
     const resumedEvents = await collectEvents(
       agent
-        .run(createResumeRunInput('{"operatorNote":"Use the safe automation window."}', { runId: 'run-resume' }))
+        .run(
+          createResumeRunInput(
+            {
+              operatorNote: 'Use the safe automation window.',
+            },
+            { runId: 'run-resume' },
+          ),
+        )
         .pipe(verifyEvents()),
     );
 

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { NextRequest } from 'next/server';
+import { parseCopilotRouteMetadata, type CopilotRouteRequestMetadata } from './routeMetadata';
 import { installCopilotRuntimeDebugFilter } from '../../../utils/copilotRuntimeDebugFilter';
 
 export const runtime = 'nodejs';
@@ -20,24 +21,6 @@ const shouldTraceCopilotRouteConnect =
   process.env.COPILOTKIT_ROUTE_TRACE_CONNECT === 'true' || process.env.COPILOTKIT_ROUTE_DEBUG === 'true';
 
 installCopilotRuntimeDebugFilter({ enabled: shouldLogCopilotRuntimeDebug });
-
-type CopilotRouteRequestMetadata = {
-  method?: string;
-  agentId?: string;
-  threadId?: string;
-  command?: string;
-  hasResumePayload?: boolean;
-  resumePayloadLength?: number;
-  resumePayloadPreview?: string;
-  source?: string;
-  clientMutationId?: string;
-  parseError?: string;
-  payloadKind?: 'object' | 'array' | 'other';
-  batchLength?: number;
-  topLevelKeys?: string[];
-  metadataMatched?: boolean;
-  rawLength?: number;
-};
 
 const shouldLogCopilotRouteRequests =
   process.env.NODE_ENV !== 'production' || process.env.COPILOTKIT_ROUTE_DEBUG === 'true';
@@ -55,145 +38,6 @@ const slowCopilotRouteWarnThresholdMs = (() => {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
 })();
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function readString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function extractThreadId(payloadBody: Record<string, unknown>): string | undefined {
-  const fromBody = readString(payloadBody.threadId) ?? readString(payloadBody.thread_id);
-  if (fromBody) return fromBody;
-
-  const config = payloadBody.config;
-  if (!isRecord(config)) return undefined;
-  const configurable = config.configurable;
-  if (!isRecord(configurable)) return undefined;
-  return readString(configurable.threadId) ?? readString(configurable.thread_id);
-}
-
-function readResumeMetadata(payloadBody: Record<string, unknown>): {
-  hasResumePayload: boolean;
-  resumePayloadLength?: number;
-  resumePayloadPreview?: string;
-} {
-  const forwardedProps = payloadBody.forwardedProps;
-  if (!isRecord(forwardedProps)) {
-    return {
-      hasResumePayload: false,
-    };
-  }
-
-  const command = forwardedProps.command;
-  if (!isRecord(command)) {
-    return {
-      hasResumePayload: false,
-    };
-  }
-
-  const hasResumePayload = Object.prototype.hasOwnProperty.call(command, 'resume');
-  const resume = command.resume;
-  const resumePreview =
-    typeof resume === 'string'
-      ? resume.slice(0, 240)
-      : hasResumePayload
-        ? JSON.stringify(resume)?.slice(0, 240)
-        : undefined;
-  return {
-    hasResumePayload,
-    resumePayloadLength: typeof resumePreview === 'string' ? resumePreview.length : undefined,
-    resumePayloadPreview: resumePreview,
-  };
-}
-
-function readCommandMetadata(payloadBody: Record<string, unknown>): {
-  command?: string;
-  source?: string;
-  clientMutationId?: string;
-} {
-  const forwardedProps = payloadBody.forwardedProps;
-  if (!isRecord(forwardedProps)) return {};
-  const command = forwardedProps.command;
-  if (!isRecord(command)) return {};
-
-  const update = isRecord(command.update) ? command.update : undefined;
-  const namedCommand = readString(command.name);
-  if (!namedCommand && !update) {
-    return {};
-  }
-
-  return {
-    command: namedCommand ?? (update ? 'update' : undefined),
-    source: readString(command.source),
-    clientMutationId: update ? readString(update.clientMutationId) : readString(command.clientMutationId),
-  };
-}
-
-function parseCopilotRouteMetadataFromObject(payload: Record<string, unknown>): CopilotRouteRequestMetadata {
-  const method = readString(payload.method);
-  const params = isRecord(payload.params) ? payload.params : undefined;
-  const payloadBody = isRecord(payload.body) ? payload.body : undefined;
-  const commandMetadata = payloadBody ? readCommandMetadata(payloadBody) : {};
-  const resumeMetadata = payloadBody ? readResumeMetadata(payloadBody) : { hasResumePayload: false };
-  const threadId = payloadBody ? extractThreadId(payloadBody) : undefined;
-  const agentId = readString(params?.agentId);
-  const command = commandMetadata.command ?? (resumeMetadata.hasResumePayload ? 'resume' : undefined);
-  const source = commandMetadata.source;
-  const clientMutationId = commandMetadata.clientMutationId;
-
-  return {
-    method,
-    agentId,
-    threadId,
-    command,
-    hasResumePayload: resumeMetadata.hasResumePayload,
-    resumePayloadLength: resumeMetadata.resumePayloadLength,
-    source,
-    clientMutationId,
-    payloadKind: 'object',
-    topLevelKeys: Object.keys(payload).slice(0, 20),
-    metadataMatched: Boolean(
-      method ||
-        agentId ||
-        threadId ||
-        command ||
-        resumeMetadata.hasResumePayload ||
-        source ||
-        clientMutationId,
-    ),
-  };
-}
-
-function parseCopilotRouteMetadata(payload: unknown): CopilotRouteRequestMetadata {
-  if (isRecord(payload)) {
-    return parseCopilotRouteMetadataFromObject(payload);
-  }
-
-  if (Array.isArray(payload)) {
-    const first = payload[0];
-    if (isRecord(first)) {
-      const parsedFirst = parseCopilotRouteMetadataFromObject(first);
-      return {
-        ...parsedFirst,
-        payloadKind: 'array',
-        batchLength: payload.length,
-      };
-    }
-    return {
-      payloadKind: 'array',
-      batchLength: payload.length,
-      metadataMatched: false,
-    };
-  }
-
-  return {
-    payloadKind: 'other',
-    metadataMatched: false,
-  };
-}
 
 function cloneResponse(response: Response, body: ReadableStream<Uint8Array>): Response {
   return new Response(body, {

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
@@ -103,11 +103,18 @@ function readResumeMetadata(payloadBody: Record<string, unknown>): {
     };
   }
 
-  const resume = readString(command.resume);
+  const hasResumePayload = Object.prototype.hasOwnProperty.call(command, 'resume');
+  const resume = command.resume;
+  const resumePreview =
+    typeof resume === 'string'
+      ? resume.slice(0, 240)
+      : hasResumePayload
+        ? JSON.stringify(resume)?.slice(0, 240)
+        : undefined;
   return {
-    hasResumePayload: typeof resume === 'string',
-    resumePayloadLength: typeof resume === 'string' ? resume.length : undefined,
-    resumePayloadPreview: typeof resume === 'string' ? resume.slice(0, 240) : undefined,
+    hasResumePayload,
+    resumePayloadLength: typeof resumePreview === 'string' ? resumePreview.length : undefined,
+    resumePayloadPreview: resumePreview,
   };
 }
 

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
@@ -75,15 +75,6 @@ function extractThreadId(payloadBody: Record<string, unknown>): string | undefin
   return readString(configurable.threadId) ?? readString(configurable.thread_id);
 }
 
-function extractLastMessageContent(payloadBody: Record<string, unknown>): string | undefined {
-  const messages = payloadBody.messages;
-  if (!Array.isArray(messages) || messages.length === 0) return undefined;
-  const last = messages[messages.length - 1];
-  if (typeof last === 'string') return last;
-  if (!isRecord(last)) return undefined;
-  return readString(last.content);
-}
-
 function readResumeMetadata(payloadBody: Record<string, unknown>): {
   hasResumePayload: boolean;
   resumePayloadLength?: number;
@@ -118,31 +109,34 @@ function readResumeMetadata(payloadBody: Record<string, unknown>): {
   };
 }
 
-function readCommandMetadata(lastMessageContent: string | undefined): {
+function readCommandMetadata(payloadBody: Record<string, unknown>): {
   command?: string;
   source?: string;
   clientMutationId?: string;
 } {
-  if (!lastMessageContent) return {};
-  try {
-    const parsed = JSON.parse(lastMessageContent) as unknown;
-    if (!isRecord(parsed)) return {};
-    return {
-      command: readString(parsed.command),
-      source: readString(parsed.source),
-      clientMutationId: readString(parsed.clientMutationId),
-    };
-  } catch {
+  const forwardedProps = payloadBody.forwardedProps;
+  if (!isRecord(forwardedProps)) return {};
+  const command = forwardedProps.command;
+  if (!isRecord(command)) return {};
+
+  const update = isRecord(command.update) ? command.update : undefined;
+  const namedCommand = readString(command.name);
+  if (!namedCommand && !update) {
     return {};
   }
+
+  return {
+    command: namedCommand ?? (update ? 'update' : undefined),
+    source: readString(command.source),
+    clientMutationId: update ? readString(update.clientMutationId) : readString(command.clientMutationId),
+  };
 }
 
 function parseCopilotRouteMetadataFromObject(payload: Record<string, unknown>): CopilotRouteRequestMetadata {
   const method = readString(payload.method);
   const params = isRecord(payload.params) ? payload.params : undefined;
   const payloadBody = isRecord(payload.body) ? payload.body : undefined;
-  const lastMessageContent = payloadBody ? extractLastMessageContent(payloadBody) : undefined;
-  const commandMetadata = readCommandMetadata(lastMessageContent);
+  const commandMetadata = payloadBody ? readCommandMetadata(payloadBody) : {};
   const resumeMetadata = payloadBody ? readResumeMetadata(payloadBody) : { hasResumePayload: false };
   const threadId = payloadBody ? extractThreadId(payloadBody) : undefined;
   const agentId = readString(params?.agentId);

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCopilotRouteMetadata } from './routeMetadata';
+
+describe('parseCopilotRouteMetadata', () => {
+  it('reads named command metadata from forwardedProps.command without inspecting chat messages', () => {
+    expect(
+      parseCopilotRouteMetadata({
+        method: 'agent/run',
+        params: {
+          agentId: 'agent-clmm',
+        },
+        body: {
+          threadId: 'thread-1',
+          messages: [
+            {
+              role: 'user',
+              content: '{"command":"sync","source":"legacy-message"}',
+            },
+          ],
+          forwardedProps: {
+            command: {
+              name: 'sync',
+              source: 'agent-list-poll',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      method: 'agent/run',
+      agentId: 'agent-clmm',
+      threadId: 'thread-1',
+      command: 'sync',
+      source: 'agent-list-poll',
+      metadataMatched: true,
+    });
+  });
+
+  it('reads update metadata from forwardedProps.command.update', () => {
+    expect(
+      parseCopilotRouteMetadata({
+        method: 'agent/run',
+        params: {
+          agentId: 'agent-portfolio-manager',
+        },
+        body: {
+          threadId: 'thread-1',
+          forwardedProps: {
+            command: {
+              update: {
+                clientMutationId: 'mutation-1',
+                baseRevision: 'shared-rev-1',
+                patch: [{ op: 'add', path: '/shared/settings', value: { amount: 250 } }],
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      method: 'agent/run',
+      agentId: 'agent-portfolio-manager',
+      threadId: 'thread-1',
+      command: 'update',
+      clientMutationId: 'mutation-1',
+      metadataMatched: true,
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
@@ -65,4 +65,41 @@ describe('parseCopilotRouteMetadata', () => {
       metadataMatched: true,
     });
   });
+
+  it('reports full serialized resume payload length while keeping the preview truncated', () => {
+    const resume = {
+      outcome: 'signed',
+      signedDelegations: [
+        {
+          signature: '0x' + 'a'.repeat(320),
+        },
+      ],
+    };
+
+    expect(
+      parseCopilotRouteMetadata({
+        method: 'agent/run',
+        params: {
+          agentId: 'agent-portfolio-manager',
+        },
+        body: {
+          threadId: 'thread-1',
+          forwardedProps: {
+            command: {
+              resume,
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      method: 'agent/run',
+      agentId: 'agent-portfolio-manager',
+      threadId: 'thread-1',
+      command: 'resume',
+      hasResumePayload: true,
+      resumePayloadLength: JSON.stringify(resume).length,
+      resumePayloadPreview: JSON.stringify(resume).slice(0, 240),
+      metadataMatched: true,
+    });
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/routeMetadata.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/routeMetadata.ts
@@ -1,0 +1,157 @@
+export type CopilotRouteRequestMetadata = {
+  method?: string;
+  agentId?: string;
+  threadId?: string;
+  command?: string;
+  hasResumePayload?: boolean;
+  resumePayloadLength?: number;
+  resumePayloadPreview?: string;
+  source?: string;
+  clientMutationId?: string;
+  parseError?: string;
+  payloadKind?: 'object' | 'array' | 'other';
+  batchLength?: number;
+  topLevelKeys?: string[];
+  metadataMatched?: boolean;
+  rawLength?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function extractThreadId(payloadBody: Record<string, unknown>): string | undefined {
+  const fromBody = readString(payloadBody.threadId) ?? readString(payloadBody.thread_id);
+  if (fromBody) return fromBody;
+
+  const config = payloadBody.config;
+  if (!isRecord(config)) return undefined;
+  const configurable = config.configurable;
+  if (!isRecord(configurable)) return undefined;
+  return readString(configurable.threadId) ?? readString(configurable.thread_id);
+}
+
+function readResumeMetadata(payloadBody: Record<string, unknown>): {
+  hasResumePayload: boolean;
+  resumePayloadLength?: number;
+  resumePayloadPreview?: string;
+} {
+  const forwardedProps = payloadBody.forwardedProps;
+  if (!isRecord(forwardedProps)) {
+    return {
+      hasResumePayload: false,
+    };
+  }
+
+  const command = forwardedProps.command;
+  if (!isRecord(command)) {
+    return {
+      hasResumePayload: false,
+    };
+  }
+
+  const hasResumePayload = Object.prototype.hasOwnProperty.call(command, 'resume');
+  const resume = command.resume;
+  const resumePreview =
+    typeof resume === 'string'
+      ? resume.slice(0, 240)
+      : hasResumePayload
+        ? JSON.stringify(resume)?.slice(0, 240)
+        : undefined;
+  return {
+    hasResumePayload,
+    resumePayloadLength: typeof resumePreview === 'string' ? resumePreview.length : undefined,
+    resumePayloadPreview: resumePreview,
+  };
+}
+
+function readCommandMetadata(payloadBody: Record<string, unknown>): {
+  command?: string;
+  source?: string;
+  clientMutationId?: string;
+} {
+  const forwardedProps = payloadBody.forwardedProps;
+  if (!isRecord(forwardedProps)) return {};
+  const command = forwardedProps.command;
+  if (!isRecord(command)) return {};
+
+  const update = isRecord(command.update) ? command.update : undefined;
+  const namedCommand = readString(command.name);
+  if (!namedCommand && !update) {
+    return {};
+  }
+
+  return {
+    command: namedCommand ?? (update ? 'update' : undefined),
+    source: readString(command.source),
+    clientMutationId: update ? readString(update.clientMutationId) : readString(command.clientMutationId),
+  };
+}
+
+function parseCopilotRouteMetadataFromObject(payload: Record<string, unknown>): CopilotRouteRequestMetadata {
+  const method = readString(payload.method);
+  const params = isRecord(payload.params) ? payload.params : undefined;
+  const payloadBody = isRecord(payload.body) ? payload.body : undefined;
+  const commandMetadata = payloadBody ? readCommandMetadata(payloadBody) : {};
+  const resumeMetadata = payloadBody ? readResumeMetadata(payloadBody) : { hasResumePayload: false };
+  const threadId = payloadBody ? extractThreadId(payloadBody) : undefined;
+  const agentId = readString(params?.agentId);
+  const command = commandMetadata.command ?? (resumeMetadata.hasResumePayload ? 'resume' : undefined);
+  const source = commandMetadata.source;
+  const clientMutationId = commandMetadata.clientMutationId;
+
+  return {
+    method,
+    agentId,
+    threadId,
+    command,
+    hasResumePayload: resumeMetadata.hasResumePayload,
+    resumePayloadLength: resumeMetadata.resumePayloadLength,
+    resumePayloadPreview: resumeMetadata.resumePayloadPreview,
+    source,
+    clientMutationId,
+    payloadKind: 'object',
+    topLevelKeys: Object.keys(payload).slice(0, 20),
+    metadataMatched: Boolean(
+      method ||
+        agentId ||
+        threadId ||
+        command ||
+        resumeMetadata.hasResumePayload ||
+        source ||
+        clientMutationId,
+    ),
+  };
+}
+
+export function parseCopilotRouteMetadata(payload: unknown): CopilotRouteRequestMetadata {
+  if (isRecord(payload)) {
+    return parseCopilotRouteMetadataFromObject(payload);
+  }
+
+  if (Array.isArray(payload)) {
+    const first = payload[0];
+    if (isRecord(first)) {
+      const parsedFirst = parseCopilotRouteMetadataFromObject(first);
+      return {
+        ...parsedFirst,
+        payloadKind: 'array',
+        batchLength: payload.length,
+      };
+    }
+    return {
+      payloadKind: 'array',
+      batchLength: payload.length,
+      metadataMatched: false,
+    };
+  }
+
+  return {
+    payloadKind: 'other',
+    metadataMatched: false,
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/routeMetadata.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/routeMetadata.ts
@@ -56,15 +56,12 @@ function readResumeMetadata(payloadBody: Record<string, unknown>): {
 
   const hasResumePayload = Object.prototype.hasOwnProperty.call(command, 'resume');
   const resume = command.resume;
-  const resumePreview =
-    typeof resume === 'string'
-      ? resume.slice(0, 240)
-      : hasResumePayload
-        ? JSON.stringify(resume)?.slice(0, 240)
-        : undefined;
+  const serializedResume =
+    typeof resume === 'string' ? resume : hasResumePayload ? JSON.stringify(resume) : undefined;
+  const resumePreview = typeof serializedResume === 'string' ? serializedResume.slice(0, 240) : undefined;
   return {
     hasResumePayload,
-    resumePayloadLength: typeof resumePreview === 'string' ? resumePreview.length : undefined,
+    resumePayloadLength: typeof serializedResume === 'string' ? serializedResume.length : undefined,
     resumePayloadPreview: resumePreview,
   };
 }

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
@@ -211,7 +211,7 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
         }
       }
     },
-    [agent, agent.threadId, portfolioManagerThreadId, selectedAgentId],
+    [agent, portfolioManagerThreadId, selectedAgentId],
   );
 
   useEffect(() => {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -769,10 +769,18 @@ function ManagedMandateEditorCard(props: {
   }, [initialAllowedAssetsValue, initialRootAsset, props.view.mandateRef]);
 
   const assetIntent = asRecord(props.view.managedMandate?.['asset_intent']);
-  const network = readString(assetIntent?.['network']) ?? 'arbitrum';
-  const controlPath = readString(assetIntent?.['control_path']) ?? 'lending.supply';
-  const benchmarkAsset = readString(assetIntent?.['benchmark_asset']) ?? 'USD';
-  const allocationBasis = readString(props.view.managedMandate?.['allocation_basis']) ?? 'allocable_idle';
+  const network: ManagedMandateInput['asset_intent']['network'] =
+    assetIntent?.['network'] === 'arbitrum' ? 'arbitrum' : 'arbitrum';
+  const controlPath: ManagedMandateInput['asset_intent']['control_path'] =
+    assetIntent?.['control_path'] === 'lending.supply' ? 'lending.supply' : 'lending.supply';
+  const benchmarkAsset: ManagedMandateInput['asset_intent']['benchmark_asset'] =
+    assetIntent?.['benchmark_asset'] === 'USD' ? 'USD' : 'USD';
+  const intent: ManagedMandateInput['asset_intent']['intent'] =
+    assetIntent?.['intent'] === 'deploy' ? 'deploy' : 'deploy';
+  const allocationBasis: ManagedMandateInput['allocation_basis'] =
+    props.view.managedMandate?.['allocation_basis'] === 'allocable_idle'
+      ? 'allocable_idle'
+      : 'allocable_idle';
 
   const handleSave = async () => {
     if (!props.onSave) {
@@ -811,7 +819,7 @@ function ManagedMandateEditorCard(props: {
             root_asset: normalizedRootAsset,
             network,
             benchmark_asset: benchmarkAsset,
-            intent: readString(assetIntent?.['intent']) ?? 'deploy',
+            intent,
             control_path: controlPath,
           },
         },

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
@@ -1,5 +1,4 @@
 import type { AgentSubscriber } from '@ag-ui/client';
-import { v7 as uuidv7 } from 'uuid';
 import { cleanupAgentConnection } from '../utils/agentConnectionCleanup';
 import { isBusyRunError } from '../utils/runConcurrency';
 import {
@@ -21,7 +20,14 @@ type CommandMessage = {
 export type AgentListPollingRuntimeAgent = {
   subscribe: (subscriber: AgentSubscriber) => RuntimeSubscription;
   addMessage: (message: CommandMessage) => void;
-  runAgent: () => Promise<unknown>;
+  runAgent: (params?: {
+    forwardedProps?: {
+      command?: {
+        name?: string;
+        source?: string;
+      };
+    };
+  }) => Promise<unknown>;
   detachActiveRun?: () => Promise<void> | void;
 };
 
@@ -173,22 +179,16 @@ export async function pollAgentListUpdateViaAgUi(params: {
     runCompletionTimeoutHandle = setTimeout(() => resolve(false), runCompletionTimeoutMs);
   });
 
-  try {
-    const clientMutationId = uuidv7();
-    runtimeAgent.addMessage({
-      id: uuidv7(),
-      role: 'user',
-      content: JSON.stringify({
-        command: 'sync',
-        source: 'agent-list-poll',
-        clientMutationId,
-      }),
-    });
-  } catch {
-    settle(null);
-  }
-
-  const runPromise = Promise.resolve(runtimeAgent.runAgent())
+  const runPromise = Promise.resolve(
+    runtimeAgent.runAgent({
+      forwardedProps: {
+        command: {
+          name: 'sync',
+          source: 'agent-list-poll',
+        },
+      },
+    }),
+  )
     .then(() => {
       runCompleted = true;
       return true;

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
@@ -94,7 +94,6 @@ describe('agentListPolling', () => {
   it('projects state snapshot into list update and detaches the short-lived stream', async () => {
     const unsubscribe = vi.fn();
     const detachActiveRun = vi.fn().mockResolvedValue(undefined);
-    const addMessage = vi.fn();
 
     let stateSubscriber: AgentSubscriber | null = null;
 
@@ -103,8 +102,8 @@ describe('agentListPolling', () => {
         stateSubscriber = subscriber;
         return { unsubscribe };
       }),
-      addMessage,
-      runAgent: vi.fn(async () => {
+      addMessage: vi.fn(),
+      runAgent: vi.fn(async (_params?: { forwardedProps?: { command?: Record<string, unknown> } }) => {
         const snapshotState: ThreadSnapshot = {
           settings: {},
           thread: {
@@ -154,18 +153,16 @@ describe('agentListPolling', () => {
       taskMessage: 'Cycling',
     });
     expect(outcome.busy).toBe(false);
-    expect(addMessage).toHaveBeenCalledTimes(1);
-    const addMessageArg = addMessage.mock.calls[0]?.[0] as { role?: string; content?: string } | undefined;
-    expect(addMessageArg?.role).toBe('user');
-    const parsedContent =
-      typeof addMessageArg?.content === 'string'
-        ? (JSON.parse(addMessageArg.content) as { command?: string; source?: string })
-        : {};
-    expect(parsedContent).toMatchObject({
-      command: 'sync',
-      source: 'agent-list-poll',
-    });
+    expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
     expect(runtimeAgent.runAgent).toHaveBeenCalledTimes(1);
+    expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
+      forwardedProps: {
+        command: {
+          name: 'sync',
+          source: 'agent-list-poll',
+        },
+      },
+    });
     expect(runtimeAgent.connectAgent).not.toHaveBeenCalled();
     expect(detachActiveRun).toHaveBeenCalledTimes(1);
     expect(unsubscribe).toHaveBeenCalledTimes(1);

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
@@ -71,9 +71,14 @@ function cloneInitialState(): ThreadSnapshot {
 function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSnapshot>): ThreadSnapshot {
   type IncomingThreadEnvelope = Partial<ThreadSnapshot> & {
     thread?: Partial<ThreadState>;
+    shared?: {
+      settings?: Partial<ThreadSnapshot['settings']>;
+    };
+    projected?: Record<string, unknown>;
   };
   const incomingEnvelope = incoming as IncomingThreadEnvelope;
   const incomingThreadRaw = isRecord(incomingEnvelope.thread) ? incomingEnvelope.thread : {};
+  const incomingSharedRaw = isRecord(incomingEnvelope.shared) ? incomingEnvelope.shared : {};
   const { command: _droppedCommand, ...incomingThread } = incomingThreadRaw as Partial<ThreadState> & {
     command?: unknown;
   };
@@ -86,9 +91,13 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
   const incomingMetrics = isRecord(incomingThread.metrics)
     ? incomingThread.metrics
     : ({} as Partial<ThreadState['metrics']>);
-  const incomingDomainProjection = isRecord(incomingThread.domainProjection)
+  const incomingThreadDomainProjection = isRecord(incomingThread.domainProjection)
     ? incomingThread.domainProjection
     : undefined;
+  const incomingProjectedDomainProjection = isRecord(incomingEnvelope.projected)
+    ? incomingEnvelope.projected
+    : undefined;
+  const incomingSharedSettings = isRecord(incomingSharedRaw.settings) ? incomingSharedRaw.settings : undefined;
 
   projected.messages = Array.isArray(incoming.messages) ? incoming.messages : projected.messages;
 
@@ -106,19 +115,33 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
     };
   }
 
+  if (incomingSharedSettings) {
+    projected.settings = {
+      ...projected.settings,
+      ...incomingSharedSettings,
+    };
+  }
+
   if (Array.isArray(incoming.tasks)) {
     projected.tasks = incoming.tasks;
   }
 
+  const nextDomainProjectionBase = isRecord(projected.thread.domainProjection)
+    ? projected.thread.domainProjection
+    : {};
+  const nextDomainProjectionFromThread = incomingThreadDomainProjection
+    ? mergeProjectedDomainProjection(nextDomainProjectionBase, incomingThreadDomainProjection)
+    : nextDomainProjectionBase;
+  const nextDomainProjection = incomingProjectedDomainProjection
+    ? mergeProjectedDomainProjection(nextDomainProjectionFromThread, incomingProjectedDomainProjection)
+    : nextDomainProjectionFromThread;
+
   projected.thread = {
     ...projected.thread,
     ...incomingThread,
-    ...(incomingDomainProjection
+    ...(incomingThreadDomainProjection || incomingProjectedDomainProjection
       ? {
-          domainProjection: mergeProjectedDomainProjection(
-            isRecord(projected.thread.domainProjection) ? projected.thread.domainProjection : {},
-            incomingDomainProjection,
-          ),
+          domainProjection: nextDomainProjection,
         }
       : {}),
     profile: {

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
@@ -68,7 +68,13 @@ function cloneInitialState(): ThreadSnapshot {
   };
 }
 
-function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSnapshot>): ThreadSnapshot {
+type MergeStatePayloadMode = 'normalized-state' | 'wire-payload';
+
+function mergeStatePayload(
+  projected: ThreadSnapshot,
+  incoming: Partial<ThreadSnapshot>,
+  mode: MergeStatePayloadMode,
+): ThreadSnapshot {
   type IncomingThreadEnvelope = Partial<ThreadSnapshot> & {
     thread?: Partial<ThreadState>;
     shared?: {
@@ -79,8 +85,22 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
   const incomingEnvelope = incoming as IncomingThreadEnvelope;
   const incomingThreadRaw = isRecord(incomingEnvelope.thread) ? incomingEnvelope.thread : {};
   const incomingSharedRaw = isRecord(incomingEnvelope.shared) ? incomingEnvelope.shared : {};
-  const { command: _droppedCommand, ...incomingThread } = incomingThreadRaw as Partial<ThreadState> & {
+  const incomingThreadCandidate = { ...incomingThreadRaw } as Partial<ThreadState> & {
     command?: unknown;
+    messages?: unknown;
+    domainProjection?: unknown;
+  };
+  delete incomingThreadCandidate.command;
+  const incomingThreadDomainProjection =
+    mode === 'normalized-state' && isRecord(incomingThreadCandidate.domainProjection)
+      ? incomingThreadCandidate.domainProjection
+      : undefined;
+  delete incomingThreadCandidate.domainProjection;
+  delete incomingThreadCandidate.messages;
+  const incomingThread = incomingThreadCandidate as Partial<ThreadState> & {
+    profile?: Partial<ThreadState['profile']>;
+    activity?: Partial<ThreadState['activity']>;
+    metrics?: Partial<ThreadState['metrics']>;
   };
   const incomingProfile = isRecord(incomingThread.profile)
     ? incomingThread.profile
@@ -91,15 +111,14 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
   const incomingMetrics = isRecord(incomingThread.metrics)
     ? incomingThread.metrics
     : ({} as Partial<ThreadState['metrics']>);
-  const incomingThreadDomainProjection = isRecord(incomingThread.domainProjection)
-    ? incomingThread.domainProjection
-    : undefined;
   const incomingProjectedDomainProjection = isRecord(incomingEnvelope.projected)
     ? incomingEnvelope.projected
     : undefined;
   const incomingSharedSettings = isRecord(incomingSharedRaw.settings) ? incomingSharedRaw.settings : undefined;
 
-  projected.messages = Array.isArray(incoming.messages) ? incoming.messages : projected.messages;
+  if (mode === 'normalized-state' && Array.isArray(incoming.messages)) {
+    projected.messages = incoming.messages;
+  }
 
   if (isRecord(incoming.copilotkit)) {
     projected.copilotkit = {
@@ -108,7 +127,7 @@ function mergeStatePayload(projected: ThreadSnapshot, incoming: Partial<ThreadSn
     };
   }
 
-  if (isRecord(incoming.settings)) {
+  if (mode === 'normalized-state' && isRecord(incoming.settings)) {
     projected.settings = {
       ...projected.settings,
       ...incoming.settings,
@@ -194,10 +213,10 @@ export function projectDetailStateFromPayload(
   const projected = cloneInitialState();
 
   if (previousState && isRecord(previousState) && Object.keys(previousState).length > 0) {
-    mergeStatePayload(projected, previousState as Partial<ThreadSnapshot>);
+    mergeStatePayload(projected, previousState as Partial<ThreadSnapshot>, 'normalized-state');
   }
 
-  mergeStatePayload(projected, payload as Partial<ThreadSnapshot>);
+  mergeStatePayload(projected, payload as Partial<ThreadSnapshot>, 'wire-payload');
   return projected;
 }
 

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.unit.test.ts
@@ -205,4 +205,35 @@ describe('agentProjection', () => {
       },
     });
   });
+
+  it('hydrates legacy web-facing settings and domain projection from canonical shared/projected payloads', () => {
+    const projected = projectDetailStateFromPayload({
+      shared: {
+        settings: {
+          amount: 456,
+        },
+      },
+      projected: {
+        managedMandate: {
+          summary: {
+            status: 'active',
+          },
+        },
+      },
+      thread: {
+        setupComplete: true,
+      },
+    });
+
+    expect(projected).not.toBeNull();
+    expect(projected?.thread.setupComplete).toBe(true);
+    expect(projected?.settings.amount).toBe(456);
+    expect(projected?.thread.domainProjection).toEqual({
+      managedMandate: {
+        summary: {
+          status: 'active',
+        },
+      },
+    });
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.unit.test.ts
@@ -17,8 +17,10 @@ describe('agentProjection', () => {
       thread: {
         setupComplete: true,
       },
-      settings: {
-        amount: 123,
+      shared: {
+        settings: {
+          amount: 123,
+        },
       },
     });
 
@@ -33,8 +35,10 @@ describe('agentProjection', () => {
       thread: {
         setupComplete: true,
       },
-      settings: {
-        amount: 321,
+      shared: {
+        settings: {
+          amount: 321,
+        },
       },
     });
 
@@ -168,13 +172,11 @@ describe('agentProjection', () => {
 
   it('merges partial domain projection payloads onto the previous projected state', () => {
     const previous = projectDetailStateFromPayload({
-      thread: {
-        domainProjection: {
-          managedMandate: {
-            mandateRef: 'mandate-1',
-            summary: {
-              riskLevel: 'medium',
-            },
+      projected: {
+        managedMandate: {
+          mandateRef: 'mandate-1',
+          summary: {
+            riskLevel: 'medium',
           },
         },
       },
@@ -182,12 +184,10 @@ describe('agentProjection', () => {
 
     const projected = projectDetailStateFromPayload(
       {
-        thread: {
-          domainProjection: {
-            managedMandate: {
-              summary: {
-                status: 'active',
-              },
+        projected: {
+          managedMandate: {
+            summary: {
+              status: 'active',
             },
           },
         },
@@ -204,6 +204,93 @@ describe('agentProjection', () => {
         },
       },
     });
+  });
+
+  it('ignores legacy top-level settings and thread.domainProjection runtime payload shapes', () => {
+    const previous = projectDetailStateFromPayload({
+      shared: {
+        settings: {
+          amount: 456,
+        },
+      },
+      projected: {
+        managedMandate: {
+          summary: {
+            status: 'active',
+          },
+        },
+      },
+    });
+
+    const projected = projectDetailStateFromPayload(
+      {
+        settings: {
+          amount: 999,
+        },
+        thread: {
+          domainProjection: {
+            managedMandate: {
+              summary: {
+                status: 'stale-legacy-shape',
+              },
+            },
+          },
+        },
+      },
+      previous,
+    );
+
+    expect(projected?.settings.amount).toBe(456);
+    expect(projected?.thread.domainProjection).toEqual({
+      managedMandate: {
+        summary: {
+          status: 'active',
+        },
+      },
+    });
+  });
+
+  it('ignores state-embedded transcript payloads in runtime snapshots and deltas', () => {
+    const previous = projectDetailStateFromPayload({
+      shared: {
+        settings: {
+          amount: 123,
+        },
+      },
+    });
+
+    previous!.messages = [
+      {
+        id: 'message-1',
+        role: 'assistant',
+        content: 'Canonical transcript event',
+      },
+    ];
+
+    const projected = projectDetailStateFromPayload(
+      {
+        messages: [
+          {
+            id: 'legacy-top-level-message',
+            role: 'assistant',
+            content: 'Legacy top-level message payload',
+          },
+        ],
+        thread: {
+          messages: [
+            {
+              id: 'legacy-thread-message',
+              role: 'assistant',
+              content: 'Legacy thread message payload',
+            },
+          ],
+        },
+      },
+      previous,
+    );
+
+    expect(projected?.messages).toEqual(previous?.messages);
+    expect((projected?.thread as Record<string, unknown> | undefined)?.messages).toBeUndefined();
   });
 
   it('hydrates legacy web-facing settings and domain projection from canonical shared/projected payloads', () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -977,6 +977,221 @@ describe('useAgentConnection integration', () => {
     },
   );
 
+  it('restores the last authoritative PI-runtime settings when saveSettings runs before shared-state hydration', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+
+    mocks.agent.state = {
+      settings: {
+        amount: 100,
+      },
+      thread: {},
+    };
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(100);
+
+    latestValue?.saveSettings({ amount: 250 });
+    await flushEffects();
+    await flushEffects();
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(100);
+    expect(latestValue?.uiError).toBe('Unable to sync settings until shared state is hydrated.');
+    expect(mocks.runAgent).not.toHaveBeenCalled();
+  });
+
+  it('restores the last authoritative PI-runtime settings when a local PI update dispatch is rejected', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.state = {
+      settings: {
+        amount: 100,
+      },
+      thread: {},
+    };
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    (
+      subscriber as
+        | (AgentSubscriber & {
+            onCustomEvent?: (payload: {
+              input?: { threadId?: string };
+              name?: string;
+              value?: unknown;
+            }) => void;
+          })
+        | undefined
+    )?.onCustomEvent?.({
+      input: { threadId: 'thread-1' },
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'bootstrap',
+        revision: 'shared-rev-1',
+      },
+    });
+    await flushEffects();
+
+    subscriber?.onRunStartedEvent?.({
+      input: { threadId: 'thread-1', runId: 'run-busy' },
+      event: {
+        type: 'RUN_STARTED',
+        threadId: 'thread-1',
+        runId: 'run-busy',
+      },
+      messages: [],
+      state: mocks.agent.state,
+      agent: mocks.agent as never,
+    });
+    await flushEffects();
+
+    latestValue?.saveSettings({ amount: 250 });
+    await flushEffects();
+    await flushEffects();
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(100);
+    expect(latestValue?.uiError).toBe('Unable to sync settings right now. Please retry.');
+    expect(mocks.runAgent).not.toHaveBeenCalled();
+  });
+
+  it('applies authoritative PI STATE_DELTA settings updates to the visible detail state', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.state = {
+      settings: {
+        amount: 100,
+      },
+      thread: {},
+    };
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(100);
+
+    (
+      subscriber as
+        | (AgentSubscriber & {
+            onStateDeltaEvent?: (payload: {
+              input?: { threadId?: string; runId?: string };
+              event?: {
+                type?: 'STATE_DELTA';
+                delta?: Array<{ op: string; path: string; value?: unknown }>;
+              };
+              state?: Record<string, unknown>;
+            }) => void;
+          })
+        | undefined
+    )?.onStateDeltaEvent?.({
+      input: { threadId: 'thread-1', runId: 'run-1' },
+      event: {
+        type: 'STATE_DELTA',
+        delta: [
+          {
+            op: 'replace',
+            path: '/shared/settings/amount',
+            value: 250,
+          },
+        ],
+      },
+      state: {
+        shared: {
+          settings: {
+            amount: 250,
+          },
+        },
+        projected: {},
+        thread: {},
+      },
+    });
+    await flushEffects();
+    await flushEffects();
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(250);
+  });
+
   it('ignores stale run lifecycle events that do not match the active thread', async () => {
     let subscriber: AgentSubscriber | undefined;
 
@@ -2152,11 +2367,11 @@ describe('useAgentConnection integration', () => {
         threadId: 'thread-1',
         forwardedProps: {
           command: {
-            resume: JSON.stringify({
+            resume: {
               poolAddress: '0x0000000000000000000000000000000000000001',
               walletAddress: '0x0000000000000000000000000000000000000002',
               baseContributionUsd: 100,
-            }),
+            },
           },
         },
       }),
@@ -2364,9 +2579,9 @@ describe('useAgentConnection integration', () => {
         threadId: 'thread-1',
         forwardedProps: {
           command: {
-            resume: JSON.stringify({
+            resume: {
               operatorNote: 'Use the safe automation window',
-            }),
+            },
           },
         },
       }),
@@ -2431,7 +2646,7 @@ describe('useAgentConnection integration', () => {
       threadId: 'thread-1',
       forwardedProps: {
         command: {
-          resume: JSON.stringify({
+          resume: {
             outcome: 'signed',
             signedDelegations: [
               {
@@ -2443,7 +2658,7 @@ describe('useAgentConnection integration', () => {
                 signature: '0x1234',
               },
             ],
-          }),
+          },
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -667,7 +667,7 @@ describe('useAgentConnection integration', () => {
     );
   });
 
-  it('keeps sync pending until AG-UI state confirms the applied mutation id', async () => {
+  it('does not clear legacy sync pending from lastAppliedClientMutationId thread payloads', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     let subscriber: AgentSubscriber | undefined;
 
@@ -703,11 +703,6 @@ describe('useAgentConnection integration', () => {
         : null;
     expect(parsedMessage?.command).toBe('sync');
     expect(typeof parsedMessage?.clientMutationId).toBe('string');
-    const clientMutationId = parsedMessage?.clientMutationId as string;
-
-    subscriber?.onRunFinishedEvent?.({ input: { threadId: 'thread-1' } });
-    await flushEffects();
-    expect(latestValue?.isSyncing).toBe(true);
 
     subscriber?.onRunInitialized?.({
       input: { threadId: 'thread-1' },
@@ -715,70 +710,13 @@ describe('useAgentConnection integration', () => {
         settings: { amount: 250 },
         thread: {
           command: 'cycle',
-          lastAppliedClientMutationId: clientMutationId,
-        },
+          lastAppliedClientMutationId: parsedMessage?.clientMutationId,
+        } as unknown as never,
       },
     });
     await flushEffects();
     await flushEffects();
-    expect(latestValue?.isSyncing).toBe(false);
-  });
-
-  it('clears sync pending when mutation id acknowledgement arrives on thread payloads', async () => {
-    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
-    let subscriber: AgentSubscriber | undefined;
-
-    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
-      subscriber = nextSubscriber as AgentSubscriber;
-      return {
-        unsubscribe: vi.fn(),
-      };
-    });
-
-    await act(async () => {
-      root.render(
-        <CapturingHarness
-          agentId="agent-clmm"
-          onSnapshot={(value) => {
-            latestValue = value;
-          }}
-        />,
-      );
-    });
-    await flushEffects();
-
-    latestValue?.saveSettings({ amount: 250 });
-    await flushEffects();
     expect(latestValue?.isSyncing).toBe(true);
-
-    const syncMessage = mocks.agent.addMessage.mock.calls.at(-1)?.[0] as
-      | { content?: string }
-      | undefined;
-    const parsedMessage =
-      typeof syncMessage?.content === 'string'
-        ? (JSON.parse(syncMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(parsedMessage?.command).toBe('sync');
-    expect(typeof parsedMessage?.clientMutationId).toBe('string');
-    const clientMutationId = parsedMessage?.clientMutationId as string;
-
-    subscriber?.onRunFinishedEvent?.({ input: { threadId: 'thread-1' } });
-    await flushEffects();
-    expect(latestValue?.isSyncing).toBe(true);
-
-    subscriber?.onRunInitialized?.({
-      input: { threadId: 'thread-1' },
-      state: {
-        settings: { amount: 250 },
-        thread: {
-          lastAppliedClientMutationId: clientMutationId,
-        },
-      },
-    });
-    await flushEffects();
-    await flushEffects();
-
-    expect(latestValue?.isSyncing).toBe(false);
   });
 
   it('clears PI-runtime sync pending when shared-state.control acknowledges the mutation', async () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -873,6 +873,110 @@ describe('useAgentConnection integration', () => {
     expect(latestValue?.isSyncing).toBe(false);
   });
 
+  it.each(['stale_revision', 'invalid_patch'] as const)(
+    'restores the last authoritative PI-runtime settings when shared-state.control rejects the mutation with %s',
+    async (code) => {
+      let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+      let subscriber: AgentSubscriber | undefined;
+
+      mocks.agent.state = {
+        settings: {
+          amount: 100,
+        },
+        thread: {},
+      };
+
+      mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+        subscriber = nextSubscriber as AgentSubscriber;
+        return {
+          unsubscribe: vi.fn(),
+        };
+      });
+
+      await act(async () => {
+        root.render(
+          <CapturingHarness
+            agentId="agent-portfolio-manager"
+            onSnapshot={(value) => {
+              latestValue = value;
+            }}
+          />,
+        );
+      });
+      await flushEffects();
+
+      (
+        subscriber as
+          | (AgentSubscriber & {
+              onCustomEvent?: (payload: {
+                input?: { threadId?: string };
+                name?: string;
+                value?: unknown;
+              }) => void;
+            })
+          | undefined
+      )?.onCustomEvent?.({
+        input: { threadId: 'thread-1' },
+        name: 'shared-state.control',
+        value: {
+          kind: 'hydration',
+          reason: 'bootstrap',
+          revision: 'shared-rev-1',
+        },
+      });
+      await flushEffects();
+
+      expect(latestValue?.settings.amount).toBe(100);
+
+      latestValue?.saveSettings({ amount: 250 });
+      await flushEffects();
+      expect(latestValue?.settings.amount).toBe(250);
+      expect(latestValue?.isSyncing).toBe(true);
+
+      const forwardedCommand = mocks.runAgent.mock.calls.at(-1)?.[0] as
+        | {
+            forwardedProps?: {
+              command?: {
+                update?: {
+                  clientMutationId?: string;
+                };
+              };
+            };
+          }
+        | undefined;
+      const clientMutationId = forwardedCommand?.forwardedProps?.command?.update?.clientMutationId;
+      expect(typeof clientMutationId).toBe('string');
+
+      (
+        subscriber as
+          | (AgentSubscriber & {
+              onCustomEvent?: (payload: {
+                input?: { threadId?: string };
+                name?: string;
+                value?: unknown;
+              }) => void;
+            })
+          | undefined
+      )?.onCustomEvent?.({
+        input: { threadId: 'thread-1' },
+        name: 'shared-state.control',
+        value: {
+          kind: 'update-ack',
+          clientMutationId,
+          status: 'rejected',
+          code,
+          resultingRevision: 'shared-rev-2',
+          baseRevision: 'shared-rev-1',
+        },
+      });
+      await flushEffects();
+      await flushEffects();
+
+      expect(latestValue?.settings.amount).toBe(100);
+      expect(latestValue?.isSyncing).toBe(false);
+    },
+  );
+
   it('ignores stale run lifecycle events that do not match the active thread', async () => {
     let subscriber: AgentSubscriber | undefined;
 

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -1045,6 +1045,85 @@ describe('useAgentConnection integration', () => {
     expect(mocks.runAgent).not.toHaveBeenCalled();
   });
 
+  it('restores the last authoritative PI-runtime settings when a forwarded update run fails before any ack arrives', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.state = {
+      settings: {
+        amount: 100,
+      },
+      thread: {},
+    };
+    mocks.runAgent.mockRejectedValueOnce(new Error('update transport failed'));
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    (
+      subscriber as
+        | (AgentSubscriber & {
+            onCustomEvent?: (payload: {
+              input?: { threadId?: string };
+              name?: string;
+              value?: unknown;
+            }) => void;
+          })
+        | undefined
+    )?.onCustomEvent?.({
+      input: { threadId: 'thread-1' },
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'bootstrap',
+        revision: 'shared-rev-1',
+      },
+    });
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(100);
+
+    latestValue?.saveSettings({ amount: 250 });
+    await flushEffects();
+
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: mocks.agent,
+        threadId: 'thread-1',
+        forwardedProps: {
+          command: {
+            update: expect.objectContaining({
+              baseRevision: 'shared-rev-1',
+            }),
+          },
+        },
+      }),
+    );
+
+    await flushEffects();
+    await flushEffects();
+
+    expect(latestValue?.settings.amount).toBe(100);
+    expect(latestValue?.isSyncing).toBe(false);
+    expect(latestValue?.uiError).toBe("Agent command 'update' failed: update transport failed");
+  });
+
   it('applies authoritative PI STATE_DELTA settings updates to the visible detail state', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     let subscriber: AgentSubscriber | undefined;

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -452,6 +452,83 @@ describe('useAgentConnection integration', () => {
     );
   });
 
+  it('dispatches PI-runtime settings saves through forwardedProps.command.update instead of a JSON sync message', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    (
+      subscriber as
+        | (AgentSubscriber & {
+            onCustomEvent?: (payload: {
+              input?: { threadId?: string };
+              name?: string;
+              value?: unknown;
+            }) => void;
+          })
+        | undefined
+    )?.onCustomEvent?.({
+      input: { threadId: 'thread-1' },
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'bootstrap',
+        revision: 'shared-rev-1',
+      },
+    });
+    await flushEffects();
+
+    mocks.agent.addMessage.mockClear();
+    mocks.runAgent.mockClear();
+
+    latestValue?.saveSettings({ amount: 250 });
+    await flushEffects();
+
+    expect(mocks.agent.setState).toHaveBeenCalled();
+    expect(mocks.agent.addMessage).not.toHaveBeenCalled();
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: mocks.agent,
+        threadId: 'thread-1',
+        forwardedProps: {
+          command: {
+            update: {
+              clientMutationId: expect.any(String),
+              baseRevision: 'shared-rev-1',
+              patch: [
+                {
+                  op: 'add',
+                  path: '/shared/settings',
+                  value: {
+                    amount: 250,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+  });
+
   it('applies returned domain projection to the current thread snapshot', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
 
@@ -696,6 +773,98 @@ describe('useAgentConnection integration', () => {
         thread: {
           lastAppliedClientMutationId: clientMutationId,
         },
+      },
+    });
+    await flushEffects();
+    await flushEffects();
+
+    expect(latestValue?.isSyncing).toBe(false);
+  });
+
+  it('clears PI-runtime sync pending when shared-state.control acknowledges the mutation', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    (
+      subscriber as
+        | (AgentSubscriber & {
+            onCustomEvent?: (payload: {
+              input?: { threadId?: string };
+              name?: string;
+              value?: unknown;
+            }) => void;
+          })
+        | undefined
+    )?.onCustomEvent?.({
+      input: { threadId: 'thread-1' },
+      name: 'shared-state.control',
+      value: {
+        kind: 'hydration',
+        reason: 'bootstrap',
+        revision: 'shared-rev-1',
+      },
+    });
+    await flushEffects();
+
+    latestValue?.saveSettings({ amount: 250 });
+    await flushEffects();
+    expect(latestValue?.isSyncing).toBe(true);
+
+    const forwardedCommand = mocks.runAgent.mock.calls.at(-1)?.[0] as
+      | {
+          forwardedProps?: {
+            command?: {
+              update?: {
+                clientMutationId?: string;
+              };
+            };
+          };
+        }
+      | undefined;
+    const clientMutationId = forwardedCommand?.forwardedProps?.command?.update?.clientMutationId;
+    expect(typeof clientMutationId).toBe('string');
+
+    subscriber?.onRunFinishedEvent?.({ input: { threadId: 'thread-1' } });
+    await flushEffects();
+    expect(latestValue?.isSyncing).toBe(true);
+
+    (
+      subscriber as
+        | (AgentSubscriber & {
+            onCustomEvent?: (payload: {
+              input?: { threadId?: string };
+              name?: string;
+              value?: unknown;
+            }) => void;
+          })
+        | undefined
+    )?.onCustomEvent?.({
+      input: { threadId: 'thread-1' },
+      name: 'shared-state.control',
+      value: {
+        kind: 'update-ack',
+        clientMutationId,
+        status: 'accepted',
+        resultingRevision: 'shared-rev-2',
       },
     });
     await flushEffects();

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -230,6 +230,13 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     threadId: undefined,
     clientMutationId: null,
   });
+  const [sharedStateRevisionByThread, setSharedStateRevisionByThread] = useState<{
+    threadId: string | undefined;
+    revision: string | null;
+  }>({
+    threadId: undefined,
+    revision: null,
+  });
   const [connectRetryTick, setConnectRetryTick] = useState(0);
   const pendingSyncMutationRef = useRef<{
     threadId: string | undefined;
@@ -493,6 +500,63 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     return typeof mutationId === 'string' && mutationId.length > 0 ? mutationId : null;
   }, []);
 
+  const clearPendingSyncMutation = useCallback((clientMutationId: string | null) => {
+    if (!clientMutationId) return;
+    const pendingSyncMutation = pendingSyncMutationRef.current;
+    if (
+      pendingSyncMutation.clientMutationId !== null &&
+      pendingSyncMutation.threadId === threadIdRef.current &&
+      clientMutationId === pendingSyncMutation.clientMutationId
+    ) {
+      setPendingSyncMutationByThread({
+        threadId: threadIdRef.current,
+        clientMutationId: null,
+      });
+    }
+  }, []);
+
+  const extractSharedStateControlAckMutationId = useCallback((payload: unknown): string | null => {
+    if (typeof payload !== 'object' || payload === null) return null;
+    const eventEnvelope =
+      'event' in payload &&
+      typeof (payload as { event?: unknown }).event === 'object' &&
+      (payload as { event?: unknown }).event !== null
+        ? ((payload as { event: unknown }).event as { name?: unknown; value?: unknown })
+        : (payload as { name?: unknown; value?: unknown });
+
+    if (eventEnvelope.name !== 'shared-state.control') return null;
+    const value = eventEnvelope.value;
+    if (typeof value !== 'object' || value === null) return null;
+    if ((value as { kind?: unknown }).kind !== 'update-ack') return null;
+    const clientMutationId = (value as { clientMutationId?: unknown }).clientMutationId;
+    return typeof clientMutationId === 'string' && clientMutationId.length > 0
+      ? clientMutationId
+      : null;
+  }, []);
+
+  const extractSharedStateControlRevision = useCallback((payload: unknown): string | null => {
+    if (typeof payload !== 'object' || payload === null) return null;
+    const eventEnvelope =
+      'event' in payload &&
+      typeof (payload as { event?: unknown }).event === 'object' &&
+      (payload as { event?: unknown }).event !== null
+        ? ((payload as { event: unknown }).event as { name?: unknown; value?: unknown })
+        : (payload as { name?: unknown; value?: unknown });
+
+    if (eventEnvelope.name !== 'shared-state.control') return null;
+    const value = eventEnvelope.value;
+    if (typeof value !== 'object' || value === null) return null;
+
+    const revision =
+      (value as { kind?: unknown; revision?: unknown; resultingRevision?: unknown }).kind === 'hydration'
+        ? (value as { revision?: unknown }).revision
+        : (value as { kind?: unknown; resultingRevision?: unknown }).kind === 'update-ack'
+          ? (value as { resultingRevision?: unknown }).resultingRevision
+          : null;
+
+    return typeof revision === 'string' && revision.length > 0 ? revision : null;
+  }, []);
+
   useEffect(() => {
     pendingSyncMutationRef.current = pendingSyncMutationByThread;
   }, [pendingSyncMutationByThread]);
@@ -661,18 +725,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
             : null,
       });
       const appliedMutationId = extractAppliedMutationId(statePayload);
-      const pendingSyncMutation = pendingSyncMutationRef.current;
-      if (
-        appliedMutationId &&
-        pendingSyncMutation.clientMutationId !== null &&
-        pendingSyncMutation.threadId === threadIdRef.current &&
-        appliedMutationId === pendingSyncMutation.clientMutationId
-      ) {
-        setPendingSyncMutationByThread({
-          threadId: threadIdRef.current,
-          clientMutationId: null,
-        });
-      }
+      clearPendingSyncMutation(appliedMutationId);
       const previousState = hasStateValues(agent.state) ? (agent.state as ThreadSnapshot) : null;
       const projectedState = projectDetailStateFromPayload(statePayload, previousState);
       if (projectedState) {
@@ -793,14 +846,28 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         if (!isCurrentThreadEvent(payload)) return;
         applyMessages(payload.messages);
       },
+      onCustomEvent: (payload) => {
+        if (!isCurrentThreadEvent(payload)) return;
+        const revision = extractSharedStateControlRevision(payload);
+        if (revision) {
+          setSharedStateRevisionByThread({
+            threadId: threadIdRef.current,
+            revision,
+          });
+        }
+        clearPendingSyncMutation(extractSharedStateControlAckMutationId(payload));
+      },
     });
 
     return () => subscription.unsubscribe();
   }, [
     agent,
     agentId,
+    clearPendingSyncMutation,
     emitConnectTrace,
     extractAppliedMutationId,
+    extractSharedStateControlAckMutationId,
+    extractSharedStateControlRevision,
     hasStateValues,
     logConnectEvent,
     setRunInFlight,
@@ -876,7 +943,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         commandSchedulerRef.current = null;
       }
     };
-  }, [agentId, copilotkit, setRunInFlight]);
+  }, [agentId, runAgentOnCurrentThread, setRunInFlight]);
 
   useEffect(() => {
     const ownerId = streamOwnerIdRef.current;
@@ -1469,11 +1536,73 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     (updates: Partial<AgentSettings>) => {
       setUiError(null);
       const clientMutationId = v7();
+      const sharedStateRevision =
+        sharedStateRevisionByThread.threadId === threadId ? sharedStateRevisionByThread.revision : null;
       setPendingSyncMutationByThread({
         threadId,
         clientMutationId,
       });
       updateSettings(updates);
+
+      if (config.imperativeCommandTransport === 'forwarded-props') {
+        const scheduler = commandSchedulerRef.current;
+        if (!scheduler || !sharedStateRevision) {
+          setPendingSyncMutationByThread({
+            threadId,
+            clientMutationId: null,
+          });
+          setUiError(
+            sharedStateRevision
+              ? 'Unable to sync settings right now. Please retry.'
+              : 'Unable to sync settings until shared state is hydrated.',
+          );
+          return;
+        }
+
+        const accepted = scheduler.dispatchCustom({
+          command: 'update',
+          run: async (currentAgent) => {
+            const nextState =
+              hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
+            const nextSettings = {
+              ...(nextState.settings ?? defaultSettings),
+              ...updates,
+            };
+            for (const [key, value] of Object.entries(nextSettings)) {
+              if (value === undefined) {
+                delete nextSettings[key as keyof AgentSettings];
+              }
+            }
+            await runAgentOnCurrentThread(currentAgent, {
+              forwardedProps: {
+                command: {
+                  update: {
+                    clientMutationId,
+                    baseRevision: sharedStateRevision,
+                    patch: [
+                      {
+                        op: 'add',
+                        path: '/shared/settings',
+                        value: nextSettings,
+                      },
+                    ],
+                  },
+                },
+              },
+            });
+          },
+        });
+
+        if (!accepted) {
+          setPendingSyncMutationByThread({
+            threadId,
+            clientMutationId: null,
+          });
+          setUiError('Unable to sync settings right now. Please retry.');
+        }
+        return;
+      }
+
       const accepted = dispatchCommand('sync', {
         allowSyncCoalesce: true,
         messagePayload: {
@@ -1488,7 +1617,16 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         setUiError('Unable to sync settings right now. Please retry.');
       }
     },
-    [dispatchCommand, threadId, updateSettings],
+    [
+      config.imperativeCommandTransport,
+      dispatchCommand,
+      hasStateValues,
+      runAgentOnCurrentThread,
+      sharedStateRevisionByThread.revision,
+      sharedStateRevisionByThread.threadId,
+      threadId,
+      updateSettings,
+    ],
   );
 
   const applyDomainProjection = useCallback((projection: Record<string, unknown>) => {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -3,11 +3,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo, type ReactNode } from 'react';
 import type { Message } from '@ag-ui/core';
 import { useCopilotContext } from '@copilotkit/react-core';
-import {
-  useAgent,
-  useCopilotKit,
-  CopilotKitCoreRuntimeConnectionStatus,
-} from '@copilotkit/react-core/v2';
+import { useAgent, useCopilotKit, CopilotKitCoreRuntimeConnectionStatus } from '@copilotkit/react-core/v2';
 import { v7 } from 'uuid';
 import { useLangGraphInterruptCustomUI } from '../app/hooks/useLangGraphInterruptCustomUI';
 import { getAgentConfig, type AgentConfig } from '../config/agents';
@@ -574,6 +570,20 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     pendingSyncMutationRef.current = pendingSyncMutationByThread;
   }, [pendingSyncMutationByThread]);
 
+  const restoreSettingsSnapshot = useCallback((rollbackSettings: AgentSettings | null) => {
+    const currentAgent = agentRef.current;
+    if (!currentAgent || !rollbackSettings) return;
+
+    const nextState =
+      hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
+    currentAgent.setState({
+      ...nextState,
+      settings: {
+        ...rollbackSettings,
+      },
+    });
+  }, [hasStateValues]);
+
   const reconcileSharedStateControlAck = useCallback(
     (ack: SharedStateControlAck | null) => {
       if (!ack) return;
@@ -588,17 +598,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       }
 
       if (ack.status === 'rejected') {
-        const currentAgent = agentRef.current;
-        if (currentAgent && pendingSyncMutation.rollbackSettings) {
-          const nextState =
-            hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
-          currentAgent.setState({
-            ...nextState,
-            settings: {
-              ...pendingSyncMutation.rollbackSettings,
-            },
-          });
-        }
+        restoreSettingsSnapshot(pendingSyncMutation.rollbackSettings);
 
         setUiError(
           ack.code === 'stale_revision'
@@ -615,7 +615,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         rollbackSettings: null,
       });
     },
-    [hasStateValues],
+    [restoreSettingsSnapshot],
   );
 
   const needsSync = useCallback((value: unknown): boolean => {
@@ -889,6 +889,20 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           return;
         }
         applyProjectedState(snapshotState);
+      },
+      onStateDeltaEvent: (payload) => {
+        const accepted = shouldApplyRunScopedState(payload);
+        emitConnectTrace('state-delta-event', {
+          accepted,
+          inputThreadId: getInputThreadId(payload),
+          inputRunId: getInputRunId(payload),
+          currentThreadId: threadIdRef.current ?? null,
+          activeRunThreadId: activeRunRef.current.threadId ?? null,
+          activeRunId: activeRunRef.current.runId ?? null,
+        });
+        if (!accepted) return;
+        rememberActiveRun(payload);
+        applyProjectedState(payload.state);
       },
       onMessagesSnapshotEvent: (payload) => {
         if (!isCurrentThreadEvent(payload)) return;
@@ -1535,7 +1549,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           });
           const resumed = await resumeInterruptViaAgent({
             agent: currentAgent,
-            resumePayload: serializedInput,
+            resumePayload: input,
             runResume: ({ agent: resumeAgent, payload }) =>
               runAgentOnCurrentThread(resumeAgent, {
                 forwardedProps: payload.forwardedProps,
@@ -1615,6 +1629,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       if (config.imperativeCommandTransport === 'forwarded-props') {
         const scheduler = commandSchedulerRef.current;
         if (!scheduler || !sharedStateRevision) {
+          restoreSettingsSnapshot(rollbackSettings);
           setPendingSyncMutationByThread({
             threadId,
             clientMutationId: null,
@@ -1663,6 +1678,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         });
 
         if (!accepted) {
+          restoreSettingsSnapshot(rollbackSettings);
           setPendingSyncMutationByThread({
             threadId,
             clientMutationId: null,
@@ -1680,6 +1696,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         },
       });
       if (!accepted) {
+        restoreSettingsSnapshot(rollbackSettings);
         setPendingSyncMutationByThread({
           threadId,
           clientMutationId: null,
@@ -1693,6 +1710,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       dispatchCommand,
       hasStateValues,
       runAgentOnCurrentThread,
+      restoreSettingsSnapshot,
       sharedStateRevisionByThread.revision,
       sharedStateRevisionByThread.threadId,
       threadId,

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -213,6 +213,16 @@ export interface UseAgentConnectionResult {
 
 export function useAgentConnection(agentId: string): UseAgentConnectionResult {
   type HookAgent = NonNullable<ReturnType<typeof useAgent>['agent']>;
+  type PendingSyncMutationState = {
+    threadId: string | undefined;
+    clientMutationId: string | null;
+    rollbackSettings: AgentSettings | null;
+  };
+  type SharedStateControlAck = {
+    clientMutationId: string;
+    status: 'accepted' | 'noop' | 'rejected';
+    code: string | null;
+  };
 
   const [isHiring, setIsHiring] = useState(false);
   const [isFiring, setIsFiring] = useState(false);
@@ -223,12 +233,10 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     threadId: undefined,
     isSyncing: false,
   });
-  const [pendingSyncMutationByThread, setPendingSyncMutationByThread] = useState<{
-    threadId: string | undefined;
-    clientMutationId: string | null;
-  }>({
+  const [pendingSyncMutationByThread, setPendingSyncMutationByThread] = useState<PendingSyncMutationState>({
     threadId: undefined,
     clientMutationId: null,
+    rollbackSettings: null,
   });
   const [sharedStateRevisionByThread, setSharedStateRevisionByThread] = useState<{
     threadId: string | undefined;
@@ -238,12 +246,10 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     revision: null,
   });
   const [connectRetryTick, setConnectRetryTick] = useState(0);
-  const pendingSyncMutationRef = useRef<{
-    threadId: string | undefined;
-    clientMutationId: string | null;
-  }>({
+  const pendingSyncMutationRef = useRef<PendingSyncMutationState>({
     threadId: undefined,
     clientMutationId: null,
+    rollbackSettings: null,
   });
   const [uiError, setUiError] = useState<string | null>(null);
   const [messageSnapshotEpoch, setMessageSnapshotEpoch] = useState(0);
@@ -509,13 +515,14 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       clientMutationId === pendingSyncMutation.clientMutationId
     ) {
       setPendingSyncMutationByThread({
-        threadId: threadIdRef.current,
+        threadId: pendingSyncMutation.threadId,
         clientMutationId: null,
+        rollbackSettings: null,
       });
     }
   }, []);
 
-  const extractSharedStateControlAckMutationId = useCallback((payload: unknown): string | null => {
+  const extractSharedStateControlAck = useCallback((payload: unknown): SharedStateControlAck | null => {
     if (typeof payload !== 'object' || payload === null) return null;
     const eventEnvelope =
       'event' in payload &&
@@ -529,9 +536,15 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     if (typeof value !== 'object' || value === null) return null;
     if ((value as { kind?: unknown }).kind !== 'update-ack') return null;
     const clientMutationId = (value as { clientMutationId?: unknown }).clientMutationId;
-    return typeof clientMutationId === 'string' && clientMutationId.length > 0
-      ? clientMutationId
-      : null;
+    const status = (value as { status?: unknown }).status;
+    const code = (value as { code?: unknown }).code;
+    if (typeof clientMutationId !== 'string' || clientMutationId.length === 0) return null;
+    if (status !== 'accepted' && status !== 'noop' && status !== 'rejected') return null;
+    return {
+      clientMutationId,
+      status,
+      code: typeof code === 'string' && code.length > 0 ? code : null,
+    };
   }, []);
 
   const extractSharedStateControlRevision = useCallback((payload: unknown): string | null => {
@@ -560,6 +573,50 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
   useEffect(() => {
     pendingSyncMutationRef.current = pendingSyncMutationByThread;
   }, [pendingSyncMutationByThread]);
+
+  const reconcileSharedStateControlAck = useCallback(
+    (ack: SharedStateControlAck | null) => {
+      if (!ack) return;
+
+      const pendingSyncMutation = pendingSyncMutationRef.current;
+      if (
+        pendingSyncMutation.clientMutationId === null ||
+        pendingSyncMutation.threadId !== threadIdRef.current ||
+        ack.clientMutationId !== pendingSyncMutation.clientMutationId
+      ) {
+        return;
+      }
+
+      if (ack.status === 'rejected') {
+        const currentAgent = agentRef.current;
+        if (currentAgent && pendingSyncMutation.rollbackSettings) {
+          const nextState =
+            hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
+          currentAgent.setState({
+            ...nextState,
+            settings: {
+              ...pendingSyncMutation.rollbackSettings,
+            },
+          });
+        }
+
+        setUiError(
+          ack.code === 'stale_revision'
+            ? 'Shared settings changed elsewhere. Restored the last saved values; please retry.'
+            : ack.code === 'missing_base_revision'
+              ? 'Unable to sync settings until shared state is hydrated.'
+              : 'Unable to apply those settings. Restored the last saved values.',
+        );
+      }
+
+      setPendingSyncMutationByThread({
+        threadId: pendingSyncMutation.threadId,
+        clientMutationId: null,
+        rollbackSettings: null,
+      });
+    },
+    [hasStateValues],
+  );
 
   const needsSync = useCallback((value: unknown): boolean => {
     if (!value || typeof value !== 'object') return true;
@@ -855,7 +912,9 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
             revision,
           });
         }
-        clearPendingSyncMutation(extractSharedStateControlAckMutationId(payload));
+        const sharedStateControlAck = extractSharedStateControlAck(payload);
+        reconcileSharedStateControlAck(sharedStateControlAck);
+        clearPendingSyncMutation(sharedStateControlAck?.clientMutationId ?? null);
       },
     });
 
@@ -866,10 +925,11 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     clearPendingSyncMutation,
     emitConnectTrace,
     extractAppliedMutationId,
-    extractSharedStateControlAckMutationId,
+    extractSharedStateControlAck,
     extractSharedStateControlRevision,
     hasStateValues,
     logConnectEvent,
+    reconcileSharedStateControlAck,
     setRunInFlight,
   ]);
 
@@ -905,6 +965,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           setPendingSyncMutationByThread({
             threadId: threadIdRef.current,
             clientMutationId: null,
+            rollbackSettings: null,
           });
         }
         setUiError(`Agent run is busy while processing '${command}'. Please retry in a moment.`);
@@ -921,6 +982,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           setPendingSyncMutationByThread({
             threadId: threadIdRef.current,
             clientMutationId: null,
+            rollbackSettings: null,
           });
         }
         const detail = error instanceof Error ? error.message : String(error);
@@ -1536,11 +1598,17 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     (updates: Partial<AgentSettings>) => {
       setUiError(null);
       const clientMutationId = v7();
+      const rollbackSettings = {
+        ...((hasStateValues(agentRef.current?.state)
+          ? ((agentRef.current?.state as ThreadSnapshot).settings ?? defaultSettings)
+          : defaultSettings) as AgentSettings),
+      };
       const sharedStateRevision =
         sharedStateRevisionByThread.threadId === threadId ? sharedStateRevisionByThread.revision : null;
       setPendingSyncMutationByThread({
         threadId,
         clientMutationId,
+        rollbackSettings,
       });
       updateSettings(updates);
 
@@ -1550,6 +1618,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           setPendingSyncMutationByThread({
             threadId,
             clientMutationId: null,
+            rollbackSettings: null,
           });
           setUiError(
             sharedStateRevision
@@ -1597,6 +1666,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           setPendingSyncMutationByThread({
             threadId,
             clientMutationId: null,
+            rollbackSettings: null,
           });
           setUiError('Unable to sync settings right now. Please retry.');
         }
@@ -1613,6 +1683,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         setPendingSyncMutationByThread({
           threadId,
           clientMutationId: null,
+          rollbackSettings: null,
         });
         setUiError('Unable to sync settings right now. Please retry.');
       }

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -491,31 +491,23 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     );
   }, []);
 
-  const extractAppliedMutationId = useCallback((value: unknown): string | null => {
-    if (typeof value !== 'object' || value === null) return null;
-    const stateEnvelope = value as { thread?: unknown };
-    const stateSlice = stateEnvelope.thread;
-    if (typeof stateSlice !== 'object' || stateSlice === null) return null;
-    if (!('lastAppliedClientMutationId' in stateSlice)) return null;
-    const mutationId = (stateSlice as { lastAppliedClientMutationId?: unknown })
-      .lastAppliedClientMutationId;
-    return typeof mutationId === 'string' && mutationId.length > 0 ? mutationId : null;
-  }, []);
-
   const clearPendingSyncMutation = useCallback((clientMutationId: string | null) => {
     if (!clientMutationId) return;
-    const pendingSyncMutation = pendingSyncMutationRef.current;
-    if (
-      pendingSyncMutation.clientMutationId !== null &&
-      pendingSyncMutation.threadId === threadIdRef.current &&
-      clientMutationId === pendingSyncMutation.clientMutationId
-    ) {
-      setPendingSyncMutationByThread({
-        threadId: pendingSyncMutation.threadId,
-        clientMutationId: null,
-        rollbackSettings: null,
-      });
-    }
+    setPendingSyncMutationByThread((pendingSyncMutation) => {
+      if (
+        pendingSyncMutation.clientMutationId !== null &&
+        pendingSyncMutation.threadId === threadIdRef.current &&
+        clientMutationId === pendingSyncMutation.clientMutationId
+      ) {
+        return {
+          threadId: pendingSyncMutation.threadId,
+          clientMutationId: null,
+          rollbackSettings: null,
+        };
+      }
+
+      return pendingSyncMutation;
+    });
   }, []);
 
   const extractSharedStateControlAck = useCallback((payload: unknown): SharedStateControlAck | null => {
@@ -765,7 +757,6 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     const applyProjectedState = (statePayload: unknown) => {
       emitConnectTrace('state-apply-attempt', {
         currentThreadId: threadIdRef.current ?? null,
-        appliedMutationId: extractAppliedMutationId(statePayload),
         stateKeys:
           typeof statePayload === 'object' && statePayload !== null
             ? Object.keys(statePayload as Record<string, unknown>).slice(0, 20)
@@ -781,8 +772,6 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
             ? (statePayload as { tasks: unknown[] }).tasks.length
             : null,
       });
-      const appliedMutationId = extractAppliedMutationId(statePayload);
-      clearPendingSyncMutation(appliedMutationId);
       const previousState = hasStateValues(agent.state) ? (agent.state as ThreadSnapshot) : null;
       const projectedState = projectDetailStateFromPayload(statePayload, previousState);
       if (projectedState) {
@@ -938,7 +927,6 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     agentId,
     clearPendingSyncMutation,
     emitConnectTrace,
-    extractAppliedMutationId,
     extractSharedStateControlAck,
     extractSharedStateControlRevision,
     hasStateValues,
@@ -972,6 +960,11 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           threadId: threadIdRef.current,
           isSyncing,
         });
+      },
+      onSyncRunTerminal: (messagePayload) => {
+        const clientMutationId =
+          typeof messagePayload?.clientMutationId === 'string' ? messagePayload.clientMutationId : null;
+        clearPendingSyncMutation(clientMutationId);
       },
       onCommandBusy: (command, error) => {
         const detail = error instanceof Error ? error.message : String(error);
@@ -1019,7 +1012,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         commandSchedulerRef.current = null;
       }
     };
-  }, [agentId, runAgentOnCurrentThread, setRunInFlight]);
+  }, [agentId, clearPendingSyncMutation, runAgentOnCurrentThread, setRunInFlight]);
 
   useEffect(() => {
     const ownerId = streamOwnerIdRef.current;

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -576,6 +576,14 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     });
   }, [hasStateValues]);
 
+  const rollbackPendingSyncMutation = useCallback(
+    (clientMutationId: string | null, rollbackSettings: AgentSettings | null) => {
+      restoreSettingsSnapshot(rollbackSettings);
+      clearPendingSyncMutation(clientMutationId);
+    },
+    [clearPendingSyncMutation, restoreSettingsSnapshot],
+  );
+
   const reconcileSharedStateControlAck = useCallback(
     (ack: SharedStateControlAck | null) => {
       if (!ack) return;
@@ -1622,12 +1630,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       if (config.imperativeCommandTransport === 'forwarded-props') {
         const scheduler = commandSchedulerRef.current;
         if (!scheduler || !sharedStateRevision) {
-          restoreSettingsSnapshot(rollbackSettings);
-          setPendingSyncMutationByThread({
-            threadId,
-            clientMutationId: null,
-            rollbackSettings: null,
-          });
+          rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
           setUiError(
             sharedStateRevision
               ? 'Unable to sync settings right now. Please retry.'
@@ -1650,33 +1653,33 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
                 delete nextSettings[key as keyof AgentSettings];
               }
             }
-            await runAgentOnCurrentThread(currentAgent, {
-              forwardedProps: {
-                command: {
-                  update: {
-                    clientMutationId,
-                    baseRevision: sharedStateRevision,
-                    patch: [
-                      {
-                        op: 'add',
-                        path: '/shared/settings',
-                        value: nextSettings,
-                      },
-                    ],
+            try {
+              await runAgentOnCurrentThread(currentAgent, {
+                forwardedProps: {
+                  command: {
+                    update: {
+                      clientMutationId,
+                      baseRevision: sharedStateRevision,
+                      patch: [
+                        {
+                          op: 'add',
+                          path: '/shared/settings',
+                          value: nextSettings,
+                        },
+                      ],
+                    },
                   },
                 },
-              },
-            });
+              });
+            } catch (error) {
+              rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
+              throw error;
+            }
           },
         });
 
         if (!accepted) {
-          restoreSettingsSnapshot(rollbackSettings);
-          setPendingSyncMutationByThread({
-            threadId,
-            clientMutationId: null,
-            rollbackSettings: null,
-          });
+          rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
           setUiError('Unable to sync settings right now. Please retry.');
         }
         return;
@@ -1689,12 +1692,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         },
       });
       if (!accepted) {
-        restoreSettingsSnapshot(rollbackSettings);
-        setPendingSyncMutationByThread({
-          threadId,
-          clientMutationId: null,
-          rollbackSettings: null,
-        });
+        rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
         setUiError('Unable to sync settings right now. Please retry.');
       }
     },
@@ -1703,7 +1701,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       dispatchCommand,
       hasStateValues,
       runAgentOnCurrentThread,
-      restoreSettingsSnapshot,
+      rollbackPendingSyncMutation,
       sharedStateRevisionByThread.revision,
       sharedStateRevisionByThread.threadId,
       threadId,

--- a/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
@@ -431,7 +431,6 @@ export interface ThreadLifecycle {
 // Domain thread state emitted by agents
 export interface ThreadState {
   lifecycle?: ThreadLifecycle;
-  lastAppliedClientMutationId?: string;
   task?: Task;
   domainProjection?: Record<string, unknown>;
   onboardingFlow?: OnboardingFlow;
@@ -578,7 +577,6 @@ export const defaultThreadState: ThreadState = {
   lifecycle: {
     phase: 'prehire',
   },
-  lastAppliedClientMutationId: undefined,
   task: undefined,
   domainProjection: {},
   onboardingFlow: undefined,

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
@@ -41,6 +41,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   isAbortLikeError?: (error: unknown) => boolean;
   isAgentRunning: (agent: TAgent) => boolean;
   onSyncingChange: (isSyncing: boolean) => void;
+  onSyncRunTerminal?: (messagePayload?: Record<string, unknown>) => void;
   onCommandError?: (command: string, error: unknown) => void;
   onCommandBusy?: (command: string, error: unknown) => void;
   syncReplayDelayMs?: number;
@@ -56,6 +57,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   let pendingSyncIntent = false;
   let pendingSyncMessagePayload: Record<string, unknown> | undefined;
   let syncRunInFlight = false;
+  let activeSyncMessagePayload: Record<string, unknown> | undefined;
   let syncBusyRetries = 0;
   let replayTimer: TimerHandle | null = null;
 
@@ -105,6 +107,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
 
     if (command === 'sync') {
       syncRunInFlight = true;
+      activeSyncMessagePayload = options?.messagePayload;
       pendingSyncIntent = false;
       pendingSyncMessagePayload = options?.messagePayload;
       if (!options?.isReplayAttempt) {
@@ -121,6 +124,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
 
       if (command === 'sync') {
         syncRunInFlight = false;
+        activeSyncMessagePayload = undefined;
 
         const busy = params.isBusyRunError(error) || params.isAgentRunning(agent);
         const aborted = params.isAbortLikeError?.(error) ?? false;
@@ -219,7 +223,10 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     params.setRunInFlight(false);
     syncBusyRetries = 0;
     if (syncRunInFlight) {
+      const completedSyncMessagePayload = activeSyncMessagePayload;
       syncRunInFlight = false;
+      activeSyncMessagePayload = undefined;
+      params.onSyncRunTerminal?.(completedSyncMessagePayload);
     }
     refreshSyncing();
     replayPendingSync();
@@ -229,6 +236,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     pendingSyncIntent = false;
     pendingSyncMessagePayload = undefined;
     syncRunInFlight = false;
+    activeSyncMessagePayload = undefined;
     syncBusyRetries = 0;
     clearReplayTimer();
   };

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
@@ -15,6 +15,7 @@ describe('agentCommandScheduler', () => {
   let onSyncingChange: ReturnType<typeof vi.fn>;
   let onCommandError: ReturnType<typeof vi.fn>;
   let onCommandBusy: ReturnType<typeof vi.fn>;
+  let onSyncRunTerminal: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     runInFlight = false;
@@ -27,6 +28,7 @@ describe('agentCommandScheduler', () => {
     onSyncingChange = vi.fn();
     onCommandError = vi.fn();
     onCommandBusy = vi.fn();
+    onSyncRunTerminal = vi.fn();
   });
 
   const createScheduler = (options?: {
@@ -49,6 +51,7 @@ describe('agentCommandScheduler', () => {
       onSyncingChange,
       onCommandError,
       onCommandBusy,
+      onSyncRunTerminal,
       syncReplayDelayMs: options?.syncReplayDelayMs ?? 25,
       syncBusyMaxRetries: options?.syncBusyMaxRetries ?? 2,
     });
@@ -110,6 +113,43 @@ describe('agentCommandScheduler', () => {
 
     expect(runAgent).toHaveBeenCalledTimes(1);
     expect(agent?.addMessage).toHaveBeenCalledTimes(1);
+
+    scheduler.dispose();
+  });
+
+  it('reports only the completed sync mutation id when a newer sync is queued behind it', async () => {
+    const scheduler = createScheduler();
+
+    scheduler.dispatch('sync', {
+      allowSyncCoalesce: true,
+      messagePayload: { clientMutationId: 'm-1' },
+    });
+
+    runInFlight = true;
+    scheduler.dispatch('sync', {
+      allowSyncCoalesce: true,
+      messagePayload: { clientMutationId: 'm-2' },
+    });
+
+    runInFlight = false;
+    scheduler.handleRunTerminal();
+    await Promise.resolve();
+
+    expect(onSyncRunTerminal).toHaveBeenCalledTimes(1);
+    expect(onSyncRunTerminal).toHaveBeenCalledWith({
+      clientMutationId: 'm-1',
+    });
+
+    const replayMessage = agent?.addMessage.mock.calls.at(-1)?.[0] as { content?: string } | undefined;
+    const parsedReplay =
+      typeof replayMessage?.content === 'string'
+        ? (JSON.parse(replayMessage.content) as { command?: string; clientMutationId?: string })
+        : null;
+
+    expect(parsedReplay).toEqual({
+      command: 'sync',
+      clientMutationId: 'm-2',
+    });
 
     scheduler.dispose();
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/interruptResolution.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/interruptResolution.ts
@@ -3,7 +3,7 @@ import { isAbortLikeError, isBusyRunError } from './runConcurrency';
 type ResumeRunPayload = {
   forwardedProps: {
     command: {
-      resume: string;
+      resume: unknown;
     };
   };
 };
@@ -15,7 +15,7 @@ type ResumeRunner<TAgent> = (params: {
 
 export async function resumeInterruptViaAgent<TAgent>(params: {
   agent: TAgent | null;
-  resumePayload: string;
+  resumePayload: unknown;
   runResume?: ResumeRunner<TAgent>;
   maxRetries?: number;
   retryDelayMs?: number;

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/interruptResolution.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/interruptResolution.unit.test.ts
@@ -15,11 +15,19 @@ describe('resumeInterruptViaAgent', () => {
   it('calls the injected resume runner with resume command payload', async () => {
     const runResume = vi.fn().mockResolvedValue(undefined);
     const agent = {};
+    const resumePayload = {
+      outcome: 'signed',
+      signedDelegations: [
+        {
+          signature: '0x1234',
+        },
+      ],
+    };
 
     await expect(
       resumeInterruptViaAgent({
         agent,
-        resumePayload: '{"outcome":"signed"}',
+        resumePayload,
         runResume,
       }),
     ).resolves.toBe(true);
@@ -29,7 +37,7 @@ describe('resumeInterruptViaAgent', () => {
       payload: {
         forwardedProps: {
           command: {
-            resume: '{"outcome":"signed"}',
+            resume: resumePayload,
           },
         },
       },

--- a/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
@@ -22,7 +22,7 @@ Adopt AG-UI protocol operations (`connect`, `run`, `stop`) as the exclusive cont
 - Detail-page stream attachment is focus-scoped and must close on unfocus/navigation.
 - Agent-side lifecycle transitions should converge toward a shared kernel contract across `apps/agent*`.
 - Agent-specific metrics UI must be decomposed via a registry-driven renderer model, not centralized branching in a single detail component.
-- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, authoritative `STATE_SNAPSHOT`/`STATE_DELTA` hydration, `shared-state.control` acknowledgments for correlated writes, boundary rejection of malformed `command.update` requests that omit `clientMutationId`, unchanged structured `command.resume` payloads, and `fire` preemptive behavior.
+- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, authoritative `STATE_SNAPSHOT`/`STATE_DELTA` hydration, `shared-state.control` acknowledgments for correlated writes, rollback on rejected or pre-ack-failed optimistic shared-state writes, boundary rejection of malformed `command.update` requests that omit `clientMutationId`, unchanged structured `command.resume` payloads, and `fire` preemptive behavior.
 - Local patch exception is allowed for `@ag-ui/langgraph` `connect` behavior until upstream parity is available.
 
 ## Rationale

--- a/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
@@ -22,7 +22,7 @@ Adopt AG-UI protocol operations (`connect`, `run`, `stop`) as the exclusive cont
 - Detail-page stream attachment is focus-scoped and must close on unfocus/navigation.
 - Agent-side lifecycle transitions should converge toward a shared kernel contract across `apps/agent*`.
 - Agent-specific metrics UI must be decomposed via a registry-driven renderer model, not centralized branching in a single detail component.
-- Web command concurrency and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including `sync` coalescing and `fire` preemptive behavior.
+- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, `shared-state.control` acknowledgments, and `fire` preemptive behavior.
 - Local patch exception is allowed for `@ag-ui/langgraph` `connect` behavior until upstream parity is available.
 
 ## Rationale

--- a/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
@@ -22,7 +22,7 @@ Adopt AG-UI protocol operations (`connect`, `run`, `stop`) as the exclusive cont
 - Detail-page stream attachment is focus-scoped and must close on unfocus/navigation.
 - Agent-side lifecycle transitions should converge toward a shared kernel contract across `apps/agent*`.
 - Agent-specific metrics UI must be decomposed via a registry-driven renderer model, not centralized branching in a single detail component.
-- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, authoritative `STATE_SNAPSHOT`/`STATE_DELTA` hydration, `shared-state.control` acknowledgments, unchanged structured `command.resume` payloads, and `fire` preemptive behavior.
+- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, authoritative `STATE_SNAPSHOT`/`STATE_DELTA` hydration, `shared-state.control` acknowledgments for correlated writes, boundary rejection of malformed `command.update` requests that omit `clientMutationId`, unchanged structured `command.resume` payloads, and `fire` preemptive behavior.
 - Local patch exception is allowed for `@ag-ui/langgraph` `connect` behavior until upstream parity is available.
 
 ## Rationale

--- a/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0001-ag-ui-only-agent-communication-and-state-boundaries.md
@@ -22,7 +22,7 @@ Adopt AG-UI protocol operations (`connect`, `run`, `stop`) as the exclusive cont
 - Detail-page stream attachment is focus-scoped and must close on unfocus/navigation.
 - Agent-side lifecycle transitions should converge toward a shared kernel contract across `apps/agent*`.
 - Agent-specific metrics UI must be decomposed via a registry-driven renderer model, not centralized branching in a single detail component.
-- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, `shared-state.control` acknowledgments, and `fire` preemptive behavior.
+- Web command concurrency, optimistic shared-state writes, and stream authority rules are governed by explicit client runtime invariants (`docs/ag-ui-client-runtime-invariants.md`), including named commands plus `command.update`, writable `/shared`, runtime-owned `/projected`, authoritative `STATE_SNAPSHOT`/`STATE_DELTA` hydration, `shared-state.control` acknowledgments, unchanged structured `command.resume` payloads, and `fire` preemptive behavior.
 - Local patch exception is allowed for `@ag-ui/langgraph` `connect` behavior until upstream parity is available.
 
 ## Rationale

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -13,9 +13,9 @@ Portfolio-manager onboarding exposed a separate contract gap on the command path
 - `agent-runtime` already supports a direct AG-UI control lane via `forwardedProps.command`
 - interrupt resumes already use that direct lane
 - some imperative web actions historically still traveled as JSON user messages and relied on the model to call `agent_runtime_domain_command`
-- LangGraph currently uses `forwardedProps.command` only for interrupt resume, not for imperative `hire`/`fire`/`sync` actions
+- LangGraph currently uses `forwardedProps.command` only for interrupt resume, not for imperative named commands or `command.update` state-write actions
 
-That split is architecturally wrong for imperative controls. Commands such as `hire`, `fire`, `sync`, and interrupt resume are not natural-language inputs that need interpretation. They are control-plane requests from the client to the runtime. Routing them through inference adds nondeterminism, couples business flow to prompt/tool behavior, and creates live regressions where the direct runtime path already exists and is better tested.
+That split is architecturally wrong for imperative controls. Commands such as `hire`, `fire`, `command.update`, and interrupt resume are not natural-language inputs that need interpretation. They are control-plane requests from the client to the runtime. Routing them through inference adds nondeterminism, couples business flow to prompt/tool behavior, and creates live regressions where the direct runtime path already exists and is better tested.
 
 ## Decision
 
@@ -24,7 +24,8 @@ Adopt `forwardedProps.command` as the canonical direct command lane for `agent-r
 The rules are:
 - when an AG-UI `run` request includes `forwardedProps.command`, `agent-runtime` must evaluate that command before any inference or model/tool routing
 - `forwardedProps.command` is an out-of-band control-plane input, not conversational message content
-- imperative client actions for `agent-runtime`, including `hire`, `fire`, `sync`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
+- imperative client actions for `agent-runtime`, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
+- `command.update` is the canonical shared-state mutation lane: the client writes writable `/shared` paths with revision-guarded JSON Patch, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas
 - conversational turns remain message-driven and may use inference normally
 - if a direct command is present, the runtime must not require the model to rediscover that intent via `agent_runtime_domain_command`
 
@@ -66,5 +67,5 @@ Compatibility rule:
 - Follow-on work:
   - update web command dispatch so PI-runtime imperative actions use `forwardedProps.command`
   - keep LangGraph compatibility isolated until it gains an equivalent direct command lane for imperative actions
-  - add regression coverage that proves direct command forwarding is used for `agent-runtime` `hire`, `fire`, and `sync`
+  - add regression coverage that proves direct command forwarding is used for `agent-runtime` named commands and `command.update`
   - when LangGraph is retired or replaced, remove the remaining message-driven imperative-command compatibility path rather than preserving it as a permanent dual-mode convention

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -27,6 +27,7 @@ The rules are:
 - imperative client actions for `agent-runtime`, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
 - interrupt `resume` payloads may be structured objects and should traverse the direct command lane unchanged; only text-only runtime fallbacks may serialize them later
 - `command.update` is the canonical shared-state mutation lane: the client writes writable `/shared` paths with revision-guarded JSON Patch, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas
+- malformed `command.update` requests that omit `clientMutationId` are boundary-invalid and must be rejected before the `update-ack` lane rather than synthesizing an uncorrelatable acknowledgment
 - accepted `command.update` writes must update the visible client model from the authoritative `STATE_DELTA` before the matching `shared-state.control` `update-ack` clears optimistic pending state
 - conversational turns remain message-driven and may use inference normally
 - if a direct command is present, the runtime must not require the model to rediscover that intent via `agent_runtime_domain_command`

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -25,7 +25,9 @@ The rules are:
 - when an AG-UI `run` request includes `forwardedProps.command`, `agent-runtime` must evaluate that command before any inference or model/tool routing
 - `forwardedProps.command` is an out-of-band control-plane input, not conversational message content
 - imperative client actions for `agent-runtime`, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
+- interrupt `resume` payloads may be structured objects and should traverse the direct command lane unchanged; only text-only runtime fallbacks may serialize them later
 - `command.update` is the canonical shared-state mutation lane: the client writes writable `/shared` paths with revision-guarded JSON Patch, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas
+- accepted `command.update` writes must update the visible client model from the authoritative `STATE_DELTA` before the matching `shared-state.control` `update-ack` clears optimistic pending state
 - conversational turns remain message-driven and may use inference normally
 - if a direct command is present, the runtime must not require the model to rediscover that intent via `agent_runtime_domain_command`
 

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -30,6 +30,7 @@ The rules are:
 - in v1, `/shared` versus `/projected` is the editability model; `command.update` does not add extra field-level mutability metadata or a second allowlist inside `/shared`
 - malformed `command.update` requests that omit `clientMutationId` are boundary-invalid and must be rejected before the `update-ack` lane rather than synthesizing an uncorrelatable acknowledgment
 - accepted `command.update` writes must update the visible client model from the authoritative `STATE_DELTA` before the matching `shared-state.control` `update-ack` clears optimistic pending state
+- if a forwarded `command.update` run fails locally before any matching `shared-state.control` acknowledgment arrives, the web must roll back the optimistic writable-state view and clear the pending mutation instead of leaving optimistic settings stranded
 - conversational turns remain message-driven and may use inference normally
 - if a direct command is present, the runtime must not require the model to rediscover that intent via `agent_runtime_domain_command`
 

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -26,7 +26,8 @@ The rules are:
 - `forwardedProps.command` is an out-of-band control-plane input, not conversational message content
 - imperative client actions for `agent-runtime`, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
 - interrupt `resume` payloads may be structured objects and should traverse the direct command lane unchanged; only text-only runtime fallbacks may serialize them later
-- `command.update` is the canonical shared-state mutation lane: the client writes writable `/shared` paths with revision-guarded JSON Patch, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas
+- `command.update` is the canonical shared-state mutation lane: the client writes revision-guarded JSON Patch against the writable public-state slice rooted at `/shared`, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas
+- in v1, `/shared` versus `/projected` is the editability model; `command.update` does not add extra field-level mutability metadata or a second allowlist inside `/shared`
 - malformed `command.update` requests that omit `clientMutationId` are boundary-invalid and must be rejected before the `update-ack` lane rather than synthesizing an uncorrelatable acknowledgment
 - accepted `command.update` writes must update the visible client model from the authoritative `STATE_DELTA` before the matching `shared-state.control` `update-ack` clears optimistic pending state
 - conversational turns remain message-driven and may use inference normally

--- a/typescript/clients/web-ag-ui/docs/adr/0016-ag-ui-state-message-and-control-plane-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0016-ag-ui-state-message-and-control-plane-boundaries.md
@@ -1,0 +1,138 @@
+# ADR 0016: ag-ui state, message, and control-plane boundaries
+
+Status: Accepted
+Date: 2026-04-12
+
+## Context
+
+ADR 0001 established AG-UI as the only web-to-agent communication boundary.
+ADR 0012 established a runtime-family-neutral `thread` contract for the fields the web uses to make hired/onboarding/active render decisions.
+ADR 0013 established the direct command lane and the writable `/shared` versus runtime-owned `/projected` editability model.
+
+That architecture direction still left one important public-contract gap underspecified at the exact AG-UI payload shape:
+
+- some runtime payloads still duplicate domain projection under `thread.domainProjection`
+- some web/runtime types still treat `settings` as a top-level convenience shape even though writable state is supposed to live under `/shared`
+- some runtime payloads still duplicate messages inside state snapshots as `thread.messages` even though AG-UI already has a distinct message plane
+- the public wire contract does not yet state clearly whether `thread` is a reserved cross-runtime envelope or just another bucket for arbitrary runtime/domain data
+
+That ambiguity is dangerous because it encourages accidental compatibility mirrors, state/message duplication, and contract drift between runtime families and web consumers.
+
+The intended migration end-state is a full migration, not a permanent compatibility layer.
+`agent-runtime` should not preserve legacy mirrors on the public wire once the canonical contract is settled.
+
+## Decision
+
+Adopt one explicit three-plane AG-UI contract for the public web-facing payload:
+
+1. State plane
+   - `STATE_SNAPSHOT` and `STATE_DELTA` carry only the public state document rooted at:
+     - `/thread`
+     - `/shared`
+     - `/projected`
+
+2. Message plane
+   - transcript data lives only on AG-UI message events such as:
+     - `MESSAGES_SNAPSHOT`
+     - `TEXT_MESSAGE_START`
+     - `TEXT_MESSAGE_CONTENT`
+     - `TEXT_MESSAGE_END`
+     - other AG-UI message/tool events as applicable
+
+3. Control plane
+   - hydration metadata, shared-state revisions, and mutation acknowledgments live only on control-plane events such as:
+     - `shared-state.control`
+
+### State plane ownership
+
+#### `/thread`
+
+- `/thread` is a reserved, read-only, cross-runtime workflow/execution envelope.
+- `/thread` exists so the web can depend on one runtime-family-neutral contract for core render and execution state.
+- The required `thread` contract from ADR 0012 remains canonical:
+  - `thread.id`
+  - `thread.lifecycle.phase`
+  - `thread.task.taskStatus.state`
+  - `thread.task.taskStatus.message` uses `{ content: string }` when present
+- Fields such as `thread.lifecycle` and `thread.task` are domain-produced but contract-reserved:
+  - the domain/runtime decides when those values change and how internal execution state maps onto them
+  - the public wire location, presence requirements, and coarse shared semantics remain standardized for the web contract
+- Additional fields may live under `/thread` only when they are intentionally standardized as part of the shared cross-runtime contract.
+- Domain-specific public schema must not be placed under `/thread` just because a runtime happens to know how to emit it.
+- Existing runtime output is not grandfathered into `/thread` merely because it was emitted historically.
+  - For example, legacy `thread.domainProjection` and `thread.messages` remain invalid contract shapes even if older runtime implementations produced them.
+- Clients must not patch `/thread` through `command.update`.
+
+#### `/shared`
+
+- `/shared` is the only client-writable public state subtree.
+- `/shared` schema is domain-owned and optional.
+- `agent-runtime` provides generic shared-state transport, validation, revisioning, and patch application, but it does not own the business meaning of keys inside `/shared`.
+- `settings` is not an `agent-runtime` primitive.
+  - If a domain chooses to expose writable settings, they may live at `/shared/settings`.
+  - If a domain does not define settings, `/shared/settings` need not exist.
+
+#### `/projected`
+
+- `/projected` is the runtime-written, domain-owned public read model.
+- `/projected` holds domain projection data and other domain-specific derived state that is public but not client-writable.
+- Former `domainProjection`-style public data belongs in `/projected`, not under `/thread`.
+- Clients must not patch `/projected` through `command.update`.
+
+### Message plane rule
+
+- Messages must not be duplicated into the state plane.
+- Public state snapshots and deltas must not include transcript fields such as `thread.messages`.
+- The authoritative transcript snapshot is `MESSAGES_SNAPSHOT`, and the authoritative incremental transcript updates are the AG-UI message events.
+
+### Control plane rule
+
+- Shared-state hydration metadata, revision metadata, and mutation acknowledgments must not be embedded into `/shared`, `/projected`, or `/thread`.
+- Those values belong on the control plane, currently via `shared-state.control`.
+
+### No compatibility mirrors on the public wire
+
+- `agent-runtime` and its Pi gateway adapters must not preserve legacy compatibility mirrors once the canonical contract is in place.
+- Disallowed public-wire compatibility shapes include:
+  - `thread.domainProjection`
+  - top-level `settings`
+  - `thread.messages`
+  - fallback interpretation of legacy `domainProjection` as `/projected`
+- If older snapshots need temporary defensive handling, that handling is a migration fallback in consumers and not part of the supported runtime contract.
+
+## Rationale
+
+- Keeps ownership boundaries explicit:
+  - `/thread` for shared cross-runtime workflow/execution contract
+  - `/shared` for domain-owned writable state
+  - `/projected` for domain-owned read model
+- Prevents `agent-runtime` from turning historical web conveniences into permanent protocol surface area.
+- Preserves ADR 0012's runtime-family-neutral render contract without forcing every domain-specific read model into the reserved `thread` envelope.
+- Keeps transcript authority on the AG-UI message plane instead of duplicating it into state.
+- Makes the full-migration rule executable and reviewable rather than relying on issue-thread memory.
+
+## Alternatives Considered
+
+- Remove `/thread` entirely and place all public state under `/shared` or `/projected`:
+  - Rejected because the web still needs one reserved runtime-family-neutral envelope for lifecycle/task/render truth and execution metadata that is not domain-writable state.
+- Keep emitting compatibility mirrors such as `thread.domainProjection` and `thread.messages`:
+  - Rejected because the intended end-state is a full migration, not a permanent alias layer, and mirrors create split authority plus future drift.
+- Treat `settings` as a framework-owned primitive:
+  - Rejected because writable shared-state schema belongs to the domain layer, not to `agent-runtime`.
+- Allow runtime-specific ad hoc top-level keys in the state document:
+  - Rejected because it weakens the public contract and reintroduces runtime-family branching into the web layer.
+
+## Consequences
+
+- Positive:
+  - The AG-UI wire contract becomes easier to reason about and test.
+  - Domain-owned schema can evolve under `/shared` and `/projected` without redefining the reserved cross-runtime envelope.
+  - Message/state/control responsibilities become unambiguous.
+- Tradeoffs:
+  - This is a breaking contract cleanup for any code that still reads legacy mirrors such as `thread.domainProjection`, top-level `settings`, or `thread.messages`.
+  - Runtime and web tests must be updated in the same slice when the old mirrors are removed.
+- Follow-on work:
+  - update issue `#589` and parent feature `#588` wording so the execution contract matches this ADR exactly
+  - remove legacy compatibility mirrors from `agent-runtime` and Pi runtime emission paths
+  - remove web-side projection fallbacks that hydrate legacy top-level `settings` or `thread.domainProjection` from canonical `/shared` and `/projected`
+  - add shared contract tests proving snapshots/deltas never emit the disallowed legacy shapes

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -17,3 +17,4 @@
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
 | [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |
 | [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-03 |
+| [0016](./0016-ag-ui-state-message-and-control-plane-boundaries.md) | AG-UI state, message, and control-plane boundaries | Accepted | 2026-04-12 |

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -87,7 +87,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Current handshake for Pi-backed shared-state writes: client sends `forwardedProps.command.update` with `clientMutationId` and `baseRevision`; runtime emits `shared-state.control` `update-ack`; UI clears pending state only when ids match.
    - Malformed Pi `command.update` requests that omit `clientMutationId` are boundary-invalid and must be rejected before `update-ack`; the acknowledgment lane is reserved for writes that already have a real correlation key.
    - Accepted Pi-backed writes must reconcile the visible state from the authoritative `STATE_DELTA` payload that arrives before the matching `shared-state.control` `update-ack`.
-   - Optimistic UI is allowed but must reconcile against streamed state, including rollback on rejected acknowledgments and on local pre-dispatch failures that never reach the runtime.
+  - Optimistic UI is allowed but must reconcile against streamed state, including rollback on rejected acknowledgments and on local pre-ack run failures before any matching `shared-state.control` arrives.
 
 12. Intent/state boundary:
    - Command intent is transport/control-plane input, not shared render truth.

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -105,6 +105,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
   - other commands: explicit policy (reject-on-busy or constrained retry)
 - `AgentStatusPoller`:
   - dispatch one-shot poll `run` per non-active-detail agent on configured cadence
+  - express poll intent on the real command lane via `forwardedProps.command.name = 'sync'` so observability does not need to parse synthetic user-message JSON
   - avoid persistent `connect` ownership in polling codepaths
 - central `AgentProjectionReducer`:
   - dedupe by run/event identity

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -10,7 +10,7 @@ Define non-negotiable client invariants for:
 
 - concurrent `connect` and `run` flows on the same `agentId+threadId`
 - server-reported busy run conditions
-- command-specific behavior (`sync` vs `fire`)
+- command-specific behavior (shared-state `update` vs `fire`)
 
 These rules complement the C4 target architecture and make runtime behavior deterministic under race conditions.
 
@@ -61,9 +61,9 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Server busy is normalized to a deterministic concurrency outcome (not an unknown failure).
    - Client transitions to observe/retry policy instead of dead-ending.
 
-8. `sync` command policy (coalescing intent):
-   - `sync` represents “latest desired mutation/state refresh intent,” not an unbounded queue item.
-   - Keep a single pending `sync` intent per `agentId+threadId` (last-write-wins).
+8. Shared-state update policy (coalescing intent):
+   - `command.update` represents the latest desired writable `/shared` document intent, not an unbounded queue item.
+   - Keep a single pending shared-state mutation intent per `agentId+threadId` (last-write-wins).
    - If current run is active, defer dispatch; replay once terminal state is observed.
    - If replay hits busy, keep pending and retry with bounded policy.
 
@@ -76,13 +76,13 @@ These rules complement the C4 target architecture and make runtime behavior dete
 10. Imperative command transport policy:
    - Conversational user input belongs in AG-UI messages.
    - Imperative client controls belong in `forwardedProps.command` whenever the target runtime supports a direct command lane.
-   - Current preferred direct-command set is `hire`, `fire`, `sync`, and interrupt resume.
+   - Current preferred direct-command set is named commands such as `hire` and `fire`, shared-state `update`, and interrupt resume.
    - Compatibility note: LangGraph currently uses `forwardedProps.command` for resume only; imperative `hire`/`fire` remain message-driven there until an equivalent direct lane exists.
 
 11. Confirmation semantics:
    - “Saved/synced” UX should complete only when AG-UI state confirms application (e.g., task state, version, or acknowledged projection).
-   - Current handshake: client sends `clientMutationId` in `sync` command payload; agent projects `lastAppliedClientMutationId` acknowledgment state; UI clears pending sync only when ids match.
-   - Optimistic UI is allowed but must reconcile against streamed state.
+   - Current handshake for Pi-backed shared-state writes: client sends `forwardedProps.command.update` with `clientMutationId` and `baseRevision`; runtime emits `shared-state.control` `update-ack`; UI clears pending state only when ids match.
+   - Optimistic UI is allowed but must reconcile against streamed state, including rollback on rejected acknowledgments.
 
 12. Intent/state boundary:
    - Command intent is transport/control-plane input, not shared render truth.
@@ -98,7 +98,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
 
 - `AgentCommandScheduler` per `agentId+threadId`:
   - `fire`: preemptive lane
-  - `sync`: coalescing lane (single pending intent)
+  - shared-state `update`: coalescing lane (single pending intent)
   - other commands: explicit policy (reject-on-busy or constrained retry)
 - `AgentStatusPoller`:
   - dispatch one-shot poll `run` per non-active-detail agent on configured cadence
@@ -111,10 +111,10 @@ These rules complement the C4 target architecture and make runtime behavior dete
 ## 5. Open Design Decisions
 
 1. Confirmation payload:
-   - `clientMutationId`/`lastAppliedClientMutationId` is the current explicit mutation acknowledgment path.
+   - `shared-state.control` `update-ack` with `clientMutationId`, `status`, `resultingRevision`, and optional `code` is the current explicit mutation acknowledgment path.
    - A future `settingsVersion` contract can supersede this if agents move to versioned settings documents.
 2. Retry backoff tuning:
-   - Current implementation uses bounded `sync` replay retries (`3`) and replay delay (`500ms`) in `apps/web/src/utils/agentCommandScheduler.ts`.
+   - Current implementation uses bounded shared-state replay retries (`3`) and replay delay (`500ms`) in `apps/web/src/utils/agentCommandScheduler.ts`.
    - Remaining decision is whether these should become environment-tunable policy values.
 3. Telemetry:
    - Emit metrics for busy events, replay count, dropped stale events, and command latency.

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -63,7 +63,8 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Client transitions to observe/retry policy instead of dead-ending.
 
 8. Shared-state update policy (coalescing intent):
-   - `command.update` represents the latest desired writable `/shared` document intent, not an unbounded queue item.
+   - `command.update` represents the latest desired writable public-state intent rooted at `/shared`, not an unbounded queue item.
+   - In v1, `/shared` versus `/projected` is the editability model: any patch path rooted at `/shared` is writable, and `/projected` remains runtime-owned and non-patchable.
    - Keep a single pending shared-state mutation intent per `agentId+threadId` (last-write-wins).
    - If current run is active, defer dispatch; replay once terminal state is observed.
    - If replay hits busy, keep pending and retry with bounded policy.

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -36,6 +36,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Client-to-agent state mutation must flow through AG-UI `run` input (`RunAgentInput.state`).
    - `connect` is attach/replay for projection continuity and is not a mutation write channel.
    - Practical client pattern: update local agent state/message model, then dispatch `run`.
+   - For Pi-backed flows, the visible writable-state model must rehydrate from authoritative `STATE_SNAPSHOT` and `STATE_DELTA` events, not from acknowledgments alone.
 
 3. Stream ownership:
    - At most one long-lived detail-page `connect` stream per web client runtime instance (for example, a browser tab) while an agent detail page is active.
@@ -77,12 +78,14 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Conversational user input belongs in AG-UI messages.
    - Imperative client controls belong in `forwardedProps.command` whenever the target runtime supports a direct command lane.
    - Current preferred direct-command set is named commands such as `hire` and `fire`, shared-state `update`, and interrupt resume.
+   - Interrupt `resume` payloads may be structured objects and should flow through the direct command lane unchanged until a text-only runtime boundary explicitly needs serialization.
    - Compatibility note: LangGraph currently uses `forwardedProps.command` for resume only; imperative `hire`/`fire` remain message-driven there until an equivalent direct lane exists.
 
 11. Confirmation semantics:
    - “Saved/synced” UX should complete only when AG-UI state confirms application (e.g., task state, version, or acknowledged projection).
    - Current handshake for Pi-backed shared-state writes: client sends `forwardedProps.command.update` with `clientMutationId` and `baseRevision`; runtime emits `shared-state.control` `update-ack`; UI clears pending state only when ids match.
-   - Optimistic UI is allowed but must reconcile against streamed state, including rollback on rejected acknowledgments.
+   - Accepted Pi-backed writes must reconcile the visible state from the authoritative `STATE_DELTA` payload that arrives before the matching `shared-state.control` `update-ack`.
+   - Optimistic UI is allowed but must reconcile against streamed state, including rollback on rejected acknowledgments and on local pre-dispatch failures that never reach the runtime.
 
 12. Intent/state boundary:
    - Command intent is transport/control-plane input, not shared render truth.
@@ -112,6 +115,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
 
 1. Confirmation payload:
    - `shared-state.control` `update-ack` with `clientMutationId`, `status`, `resultingRevision`, and optional `code` is the current explicit mutation acknowledgment path.
+   - `update-ack` confirms mutation outcome, but does not replace `STATE_SNAPSHOT`/`STATE_DELTA` as the authority for the visible writable-state document.
    - A future `settingsVersion` contract can supersede this if agents move to versioned settings documents.
 2. Retry backoff tuning:
    - Current implementation uses bounded shared-state replay retries (`3`) and replay delay (`500ms`) in `apps/web/src/utils/agentCommandScheduler.ts`.

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -84,6 +84,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
 11. Confirmation semantics:
    - “Saved/synced” UX should complete only when AG-UI state confirms application (e.g., task state, version, or acknowledged projection).
    - Current handshake for Pi-backed shared-state writes: client sends `forwardedProps.command.update` with `clientMutationId` and `baseRevision`; runtime emits `shared-state.control` `update-ack`; UI clears pending state only when ids match.
+   - Malformed Pi `command.update` requests that omit `clientMutationId` are boundary-invalid and must be rejected before `update-ack`; the acknowledgment lane is reserved for writes that already have a real correlation key.
    - Accepted Pi-backed writes must reconcile the visible state from the authoritative `STATE_DELTA` payload that arrives before the matching `shared-state.control` `update-ack`.
    - Optimistic UI is allowed but must reconcile against streamed state, including rollback on rejected acknowledgments and on local pre-dispatch failures that never reach the runtime.
 
@@ -123,3 +124,4 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Remaining decision is whether these should become environment-tunable policy values.
 3. Telemetry:
    - Emit metrics for busy events, replay count, dropped stale events, and command latency.
+   - Copilot route debug metadata for structured interrupt resumes should report the full serialized `resumePayloadLength` separately from the truncated `resumePayloadPreview`.

--- a/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
@@ -35,7 +35,7 @@ Use one-way MVVM/MVI-lite rules:
 
 ### 3.1 Control Plane (intent)
 
-- User/system intents are ephemeral command events (`hire`, `sync`, `fire`, `resume`, `cycle`).
+- User/system intents are ephemeral command events (`hire`, `fire`, `resume`, `cycle`) plus shared-state `command.update`.
 - Intents are not durable render state.
 - Intent metadata must not live in shared render-driving state.
 
@@ -83,7 +83,7 @@ Command must not be persisted in shared render-driving state.
 2. `thread.lifecycle.phase` is render truth source.
 3. projection merge must be undefined-safe and preserve durable fields unless explicitly replaced.
 4. out-of-band cron updates must preserve full durable lifecycle context or skip state writes.
-5. sync confirmation remains explicit (`clientMutationId -> lastAppliedClientMutationId`) until lifecycle/version ack supersedes it.
+5. shared-state confirmation remains explicit through `shared-state.control` `update-ack` (`clientMutationId`, `status`, `resultingRevision`, optional `code`) until lifecycle/version ack supersedes it.
 6. Invariants are enforced in two layers:
    - domain invariants in agents (authoritative business/workflow truth),
    - VM invariants in web reducer (stale/out-of-order event defense).

--- a/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
@@ -86,6 +86,7 @@ Command must not be persisted in shared render-driving state.
 3. projection merge must be undefined-safe and preserve durable fields unless explicitly replaced.
 4. out-of-band cron updates must preserve full durable lifecycle context or skip state writes.
 5. shared-state confirmation remains explicit through `shared-state.control` `update-ack` (`clientMutationId`, `status`, `resultingRevision`, optional `code`) until lifecycle/version ack supersedes it.
+   Malformed Pi `command.update` requests that omit `clientMutationId` are rejected at the boundary before that ack lane rather than synthesizing an uncorrelatable acknowledgment.
 6. optimistic writable-state edits must roll back to the last authoritative projection when a Pi mutation is rejected or when local dispatch fails before the runtime accepts the command.
 7. Invariants are enforced in two layers:
    - domain invariants in agents (authoritative business/workflow truth),

--- a/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
@@ -36,6 +36,7 @@ Use one-way MVVM/MVI-lite rules:
 ### 3.1 Control Plane (intent)
 
 - User/system intents are ephemeral command events (`hire`, `fire`, `resume`, `cycle`) plus shared-state `command.update`.
+- `resume` may carry a structured object payload; the control lane must preserve that payload unchanged across web and runtime boundaries.
 - Intents are not durable render state.
 - Intent metadata must not live in shared render-driving state.
 
@@ -55,6 +56,7 @@ Monotonic requirements:
 ### 3.3 Projection Plane (web VM/read model)
 
 - A single projection reducer in the ViewModel applies AG-UI snapshots/events and builds `UiState`.
+- For Pi-backed flows, both `STATE_SNAPSHOT` and `STATE_DELTA` are authoritative inputs for the visible `/shared` plus `/projected` model.
 - source authority is explicit per agent/thread:
   - active detail route: `connect` stream authority,
   - non-active detail: poll run authority,
@@ -84,7 +86,8 @@ Command must not be persisted in shared render-driving state.
 3. projection merge must be undefined-safe and preserve durable fields unless explicitly replaced.
 4. out-of-band cron updates must preserve full durable lifecycle context or skip state writes.
 5. shared-state confirmation remains explicit through `shared-state.control` `update-ack` (`clientMutationId`, `status`, `resultingRevision`, optional `code`) until lifecycle/version ack supersedes it.
-6. Invariants are enforced in two layers:
+6. optimistic writable-state edits must roll back to the last authoritative projection when a Pi mutation is rejected or when local dispatch fails before the runtime accepts the command.
+7. Invariants are enforced in two layers:
    - domain invariants in agents (authoritative business/workflow truth),
    - VM invariants in web reducer (stale/out-of-order event defense).
 

--- a/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
@@ -88,7 +88,7 @@ Command must not be persisted in shared render-driving state.
 4. out-of-band cron updates must preserve full durable lifecycle context or skip state writes.
 5. shared-state confirmation remains explicit through `shared-state.control` `update-ack` (`clientMutationId`, `status`, `resultingRevision`, optional `code`) until lifecycle/version ack supersedes it.
    Malformed Pi `command.update` requests that omit `clientMutationId` are rejected at the boundary before that ack lane rather than synthesizing an uncorrelatable acknowledgment.
-6. optimistic writable-state edits must roll back to the last authoritative projection when a Pi mutation is rejected or when local dispatch fails before the runtime accepts the command.
+6. optimistic writable-state edits must roll back to the last authoritative projection when a Pi mutation is rejected or when the local `command.update` run fails before any matching `shared-state.control` acknowledgment arrives.
 7. Invariants are enforced in two layers:
    - domain invariants in agents (authoritative business/workflow truth),
    - VM invariants in web reducer (stale/out-of-order event defense).

--- a/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-frontend-backend-contract-ui-stability.md
@@ -57,6 +57,7 @@ Monotonic requirements:
 
 - A single projection reducer in the ViewModel applies AG-UI snapshots/events and builds `UiState`.
 - For Pi-backed flows, both `STATE_SNAPSHOT` and `STATE_DELTA` are authoritative inputs for the visible `/shared` plus `/projected` model.
+- In v1, the writable public slice is the subtree rooted at `/shared`; `/projected` is public but runtime-owned and read-only.
 - source authority is explicit per agent/thread:
   - active detail route: `connect` stream authority,
   - non-active detail: poll run authority,

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -250,6 +250,7 @@ Every Pi-owned domain module should define one explicit SPI surface:
   - domain-aware context appended to the system prompt path
 - normalized operation handling:
   - one domain-facing operation handler that is agnostic to whether the request came from the direct command lane or the LLM tool lane
+  - direct-lane payloads such as structured interrupt `resume` objects should stay structurally intact until the domain handler or a text-only fallback boundary consumes them
 - domain outputs:
   - adapter-neutral outputs such as artifacts, interrupts, and status-bearing domain results
 - automation policy hooks:

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -298,7 +298,7 @@ sequenceDiagram
   Runtime->>Agent: validate patch, update `/shared`, recompute `/projected`
   Agent-->>Runtime: STATE_DELTA(shared + projected) then shared-state.control update-ack
   Runtime-->>Web: streamed events
-  Web->>Web: mark save complete only after matching update-ack
+  Web->>Web: apply authoritative delta, then clear pending save after matching update-ack
 ```
 
 ## 7. Data contracts
@@ -309,6 +309,7 @@ sequenceDiagram
 - `UiState` (web VM-facing): deterministic projection from AG-UI events + `ThreadState` snapshots.
 - `TaskState` enum (shared): `submitted`, `working`, `input-required`, `completed`, `failed`, `canceled`.
 - Named control-plane commands stay explicit (`hire`, `fire`, typed interrupt resolutions); shared-state writes use `command.update` against writable `/shared`.
+- Typed interrupt resolutions may carry structured `command.resume` payload objects across the direct command lane without pre-stringifying them in the web client.
 
 ### 7.2 Rules
 
@@ -411,9 +412,10 @@ Completed:
 - Web command scheduling now uses a dedicated `AgentCommandScheduler` (`apps/web/src/utils/agentCommandScheduler.ts`) with bounded busy-retry handling for coalesced shared-state writes.
 - Integration coverage now verifies key lifecycle invariants:
   - `apps/web/src/contexts/AgentListContext.int.test.tsx` asserts bounded non-active-detail polling fan-out and periodic no-overlap behavior.
-  - `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts detail-page connect and deterministic detach on unmount.
-  - `apps/web/src/utils/agentCommandScheduler.unit.test.ts` asserts coalescing, terminal replay, bounded busy retries, and non-update in-flight rejection.
-- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts `shared-state.control` confirmation and rejected-ack reconciliation semantics for optimistic shared-state writes.
+- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts detail-page connect and deterministic detach on unmount.
+- `apps/web/src/utils/agentCommandScheduler.unit.test.ts` asserts coalescing, terminal replay, bounded busy retries, and non-update in-flight rejection.
+- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts authoritative Pi `STATE_DELTA` hydration, `shared-state.control` confirmation, rejected-ack reconciliation, and rollback on local Pi dispatch failures for optimistic shared-state writes.
+- `apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts` and `agent-runtime/src/index.int.test.ts` assert object `command.resume` payload passthrough across the web, transport, and Pi runtime layers.
 
 Remaining gaps:
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -118,6 +118,7 @@ Explicit non-goal container:
 - `AgentStatusPoller` (refactored list polling):
   - Every 15s, performs one-shot AG-UI `run` status sync for agents whose detail page is not currently active.
   - Poll runs are bounded lifecycle invocations (`run` start -> snapshot/events -> terminal), not persistent `connect` loops.
+  - Poll intent stays on `forwardedProps.command` for route tracing and runtime observability instead of synthetic JSON user messages.
   - Uses protocol-compliant calls only; no direct thread endpoints.
   - Writes normalized status to shared projection store.
 
@@ -152,6 +153,7 @@ Explicit non-goal container:
 - `CopilotKit Runtime Route` (`/api/copilotkit`):
   - The only server route used by web for agent communication.
   - Exposes AG-UI `connect`, `run`, and `stop` semantics used by web.
+  - Request metadata and debug traces should read command intent from `forwardedProps.command` and related control-lane fields, not by parsing the last chat message.
   - For standalone Pi-backed agents, imports runtime-owned transport helpers rather than defining Pi-specific transport behavior locally.
 
 - `Agent Registry`:

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -298,7 +298,7 @@ sequenceDiagram
   User->>Web: Trigger shared-state save
   Web->>Web: optimistically update local writable `/shared` view
   Web->>Runtime: run(agentId, threadId, forwardedProps.command.update)
-  Runtime->>Agent: validate command.update boundary, update `/shared`, recompute `/projected`
+  Runtime->>Agent: validate that every patch path stays rooted at `/shared`, update `/shared`, recompute `/projected`
   Agent-->>Runtime: STATE_DELTA(shared + projected) then shared-state.control update-ack
   Runtime-->>Web: streamed events
   Web->>Web: apply authoritative delta, then clear pending save after matching update-ack
@@ -313,7 +313,8 @@ sequenceDiagram
 - `ThreadState@vN` (versioned, domain-facing): profile, metrics, activity, task, interrupts, onboarding.
 - `UiState` (web VM-facing): deterministic projection from AG-UI events + `ThreadState` snapshots.
 - `TaskState` enum (shared): `submitted`, `working`, `input-required`, `completed`, `failed`, `canceled`.
-- Named control-plane commands stay explicit (`hire`, `fire`, typed interrupt resolutions); shared-state writes use `command.update` against writable `/shared`.
+- Named control-plane commands stay explicit (`hire`, `fire`, typed interrupt resolutions); shared-state writes use `command.update` against the writable public-state slice rooted at `/shared`.
+- In v1, `/shared` versus `/projected` is the editability model: `/shared` is writable, while `/projected` remains runtime-owned and non-patchable.
 - Typed interrupt resolutions may carry structured `command.resume` payload objects across the direct command lane without pre-stringifying them in the web client.
 
 ### 7.2 Rules

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -130,14 +130,14 @@ Explicit non-goal container:
   - Removes split-brain between stream state and sync endpoint state.
 
 - `AgentCommandBus`:
-  - Sends `hire`, `sync`, `fire`, interrupt responses, and client mutation intents via AG-UI `run` payloads.
+  - Sends named commands such as `hire`/`fire`, interrupt responses, and shared-state `command.update` intents via AG-UI `run` payloads.
   - `fire` may invoke AG-UI `stop` as a pre-dispatch preemption control.
   - No out-of-band command mutation.
 
 - `AgentCommandScheduler` (new):
   - Enforces command concurrency policy by `agentId+threadId`.
   - `fire` is preemptive for backend and local ownership (`stop` then detach, wait terminal/timeout, then dispatch).
-  - `sync` uses coalescing intent policy (single pending intent, last-write-wins).
+  - Shared-state `command.update` uses coalescing intent policy (single pending intent, last-write-wins).
   - Normalizes server busy responses into deterministic observe/retry behavior.
 
 - `AgentMetricsRendererRegistry` (new):
@@ -276,7 +276,7 @@ sequenceDiagram
   participant Agent
 
   loop every 15s
-    Poller->>Runtime: bounded AG-UI run(agentId, threadId, status/sync)
+    Poller->>Runtime: bounded AG-UI run(agentId, threadId, status refresh)
     Runtime->>Agent: execute one-shot run
     Agent-->>Runtime: projection events + terminal
     Runtime-->>Poller: reduced status payload
@@ -292,13 +292,13 @@ sequenceDiagram
   participant Runtime as /api/copilotkit
   participant Agent
 
-  User->>Web: Trigger save/sync
-  Web->>Web: set local agent state/messages
-  Web->>Runtime: run(agentId, threadId, input.state/messages)
-  Runtime->>Agent: apply run input state/messages, execute run
-  Agent-->>Runtime: AG-UI state/message events + terminal event
+  User->>Web: Trigger shared-state save
+  Web->>Web: optimistically update local writable `/shared` view
+  Web->>Runtime: run(agentId, threadId, forwardedProps.command.update)
+  Runtime->>Agent: validate patch, update `/shared`, recompute `/projected`
+  Agent-->>Runtime: STATE_DELTA(shared + projected) then shared-state.control update-ack
   Runtime-->>Web: streamed events
-  Web->>Web: mark sync complete only after projected confirmation
+  Web->>Web: mark save complete only after matching update-ack
 ```
 
 ## 7. Data contracts
@@ -308,7 +308,7 @@ sequenceDiagram
 - `ThreadState@vN` (versioned, domain-facing): profile, metrics, activity, task, interrupts, onboarding.
 - `UiState` (web VM-facing): deterministic projection from AG-UI events + `ThreadState` snapshots.
 - `TaskState` enum (shared): `submitted`, `working`, `input-required`, `completed`, `failed`, `canceled`.
-- `AgentCommand` enum (shared control-plane intent): `hire`, `sync`, `fire`, plus typed interrupt resolutions.
+- Named control-plane commands stay explicit (`hire`, `fire`, typed interrupt resolutions); shared-state writes use `command.update` against writable `/shared`.
 
 ### 7.2 Rules
 
@@ -331,7 +331,7 @@ sequenceDiagram
    - non-active-detail agents -> polling snapshots projected from one-shot poll `run`,
    - fallback without either -> active `run` stream for that command lifecycle.
 7. Local run-in-flight gating is advisory; server busy responses are authoritative for global concurrency.
-8. `sync` uses coalescing intent semantics (single pending intent per `agentId+threadId`, last-write-wins).
+8. Shared-state `command.update` uses coalescing intent semantics (single pending intent per `agentId+threadId`, last-write-wins).
 9. `fire` is the only preemptive stop command: issue `stop`, detach local stream, wait terminal/timeout, then dispatch `fire`.
 10. Terminal run handling is idempotent: client converges on one terminal outcome even if terminal callbacks are duplicated.
 11. On detail-page route leave/unmount, stream teardown is deterministic.
@@ -342,7 +342,7 @@ sequenceDiagram
 ### Slice 1: Protocol boundary cleanup
 
 - Remove `apps/web/src/app/api/agents/sync/route.ts` and consumers.
-- Replace `useAgentConnection` sync fallback with AG-UI-only projection path.
+- Replace `useAgentConnection` mutation fallback with AG-UI-only direct-command projection path.
 - Keep behavior parity via tests before deletion.
 
 ### Slice 2: Detail-route stream governance
@@ -408,12 +408,12 @@ Completed:
 - Non-metrics blockers/onboarding branch helpers are extracted from `AgentDetailPage` into specialized modules:
   - `apps/web/src/components/agentBlockersBehavior.ts`,
   - `apps/web/src/components/agentBlockersInterrupt.ts`.
-- Web command scheduling now uses a dedicated `AgentCommandScheduler` (`apps/web/src/utils/agentCommandScheduler.ts`) with bounded busy-retry handling for `sync` and coalescing intent semantics.
+- Web command scheduling now uses a dedicated `AgentCommandScheduler` (`apps/web/src/utils/agentCommandScheduler.ts`) with bounded busy-retry handling for coalesced shared-state writes.
 - Integration coverage now verifies key lifecycle invariants:
   - `apps/web/src/contexts/AgentListContext.int.test.tsx` asserts bounded non-active-detail polling fan-out and periodic no-overlap behavior.
   - `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts detail-page connect and deterministic detach on unmount.
-  - `apps/web/src/utils/agentCommandScheduler.unit.test.ts` asserts `sync` coalescing, terminal replay, bounded busy retries, and non-sync in-flight rejection.
-- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts sync confirmation semantics via client mutation id handshake between command dispatch and projected state acknowledgement.
+  - `apps/web/src/utils/agentCommandScheduler.unit.test.ts` asserts coalescing, terminal replay, bounded busy retries, and non-update in-flight rejection.
+- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts `shared-state.control` confirmation and rejected-ack reconciliation semantics for optimistic shared-state writes.
 
 Remaining gaps:
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -154,6 +154,7 @@ Explicit non-goal container:
   - The only server route used by web for agent communication.
   - Exposes AG-UI `connect`, `run`, and `stop` semantics used by web.
   - Request metadata and debug traces should read command intent from `forwardedProps.command` and related control-lane fields, not by parsing the last chat message.
+  - Structured interrupt-resume tracing should log full serialized `resumePayloadLength` separately from the truncated `resumePayloadPreview`.
   - For standalone Pi-backed agents, imports runtime-owned transport helpers rather than defining Pi-specific transport behavior locally.
 
 - `Agent Registry`:
@@ -297,11 +298,13 @@ sequenceDiagram
   User->>Web: Trigger shared-state save
   Web->>Web: optimistically update local writable `/shared` view
   Web->>Runtime: run(agentId, threadId, forwardedProps.command.update)
-  Runtime->>Agent: validate patch, update `/shared`, recompute `/projected`
+  Runtime->>Agent: validate command.update boundary, update `/shared`, recompute `/projected`
   Agent-->>Runtime: STATE_DELTA(shared + projected) then shared-state.control update-ack
   Runtime-->>Web: streamed events
   Web->>Web: apply authoritative delta, then clear pending save after matching update-ack
 ```
+
+- Malformed Pi `command.update` requests that omit `clientMutationId` are rejected at the runtime boundary before `shared-state.control` `update-ack`, because `clientMutationId` is the acknowledgment correlation key.
 
 ## 7. Data contracts
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -305,6 +305,7 @@ sequenceDiagram
 ```
 
 - Malformed Pi `command.update` requests that omit `clientMutationId` are rejected at the runtime boundary before `shared-state.control` `update-ack`, because `clientMutationId` is the acknowledgment correlation key.
+- If the local forwarded `command.update` run fails before any matching `shared-state.control` arrives, the web must roll back the optimistic `/shared` view immediately and clear the pending mutation locally.
 
 ## 7. Data contracts
 
@@ -420,7 +421,7 @@ Completed:
   - `apps/web/src/contexts/AgentListContext.int.test.tsx` asserts bounded non-active-detail polling fan-out and periodic no-overlap behavior.
 - `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts detail-page connect and deterministic detach on unmount.
 - `apps/web/src/utils/agentCommandScheduler.unit.test.ts` asserts coalescing, terminal replay, bounded busy retries, and non-update in-flight rejection.
-- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts authoritative Pi `STATE_DELTA` hydration, `shared-state.control` confirmation, rejected-ack reconciliation, and rollback on local Pi dispatch failures for optimistic shared-state writes.
+- `apps/web/src/hooks/useAgentConnection.int.test.tsx` asserts authoritative Pi `STATE_DELTA` hydration, `shared-state.control` confirmation, rejected-ack reconciliation, and rollback on local pre-ack Pi run failures for optimistic shared-state writes.
 - `apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts` and `agent-runtime/src/index.int.test.ts` assert object `command.resume` payload passthrough across the web, transport, and Pi runtime layers.
 
 Remaining gaps:

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.viewer.html
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.viewer.html
@@ -424,7 +424,7 @@ sequenceDiagram
 
     User->>Web: Submit connected wallet
     Web->>Web: buildPortfolioManagerSetupInput(walletAddress)
-    Web->>CK: AG-UI run(command.resume=setup JSON)
+    Web->>CK: AG-UI run(command.resume=setup object payload)
     CK->>PM: resume setup interrupt
     PM->>PM: save phase=onboarding + activeWalletAddress + pendingOnboardingWalletAddress + pendingApprovedMandateEnvelope
     PM-->>CK: input-required "portfolio-manager-delegation-signing-request"
@@ -432,7 +432,7 @@ sequenceDiagram
 
     User->>Wallet: Sign delegation(s)
     Wallet-->>Web: signedDelegations[]
-    Web->>CK: AG-UI run(command.resume=signed JSON)
+    Web->>CK: AG-UI run(command.resume=signed object payload)
     CK->>PM: resume signing interrupt
     PM->>PM: build onboarding bootstrap + root-delegation handoff
 

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -273,19 +273,19 @@ importers:
         version: 0.0.47
       '@mariozechner/pi-agent-core':
         specifier: 0.64.0
-        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
+        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-ai':
         specifier: 0.64.0
-        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
+        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@open-wallet-standard/core':
         specifier: ^1.2.0
         version: 1.2.0
       agent-runtime-pi:
         specifier: workspace:^
-        version: file:agent-runtime/lib/pi(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
+        version: file:agent-runtime/lib/pi(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       viem:
         specifier: 'catalog:'
-        version: 2.38.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.38.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     dependenciesMeta:
       agent-runtime-pi:
         injected: false
@@ -298,7 +298,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   agent-runtime/lib/pi:
     dependencies:
@@ -313,10 +313,10 @@ importers:
         version: 0.0.47
       '@mariozechner/pi-agent-core':
         specifier: 0.64.0
-        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
       '@mariozechner/pi-ai':
         specifier: 0.64.0
-        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
       agent-runtime-postgres:
         specifier: workspace:^
         version: link:../postgres
@@ -344,7 +344,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-a2a:
     dependencies:
@@ -574,7 +574,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.0.8
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -586,7 +586,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -601,7 +601,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-clmm:
     dependencies:
@@ -674,7 +674,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.0.8
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -686,7 +686,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -701,7 +701,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-ember-lending:
     dependencies:
@@ -735,7 +735,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-gmx-allora:
     dependencies:
@@ -808,7 +808,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.0.8
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -820,7 +820,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       msw:
         specifier: ^2.12.8
         version: 2.12.8(@types/node@22.19.2)(typescript@5.9.3)
@@ -838,7 +838,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-pendle:
     dependencies:
@@ -911,7 +911,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^4.0.8
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -923,7 +923,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       msw:
         specifier: ^2.12.8
         version: 2.12.8(@types/node@22.19.2)(typescript@5.9.3)
@@ -941,7 +941,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.8
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-pi-example:
     dependencies:
@@ -950,7 +950,7 @@ importers:
         version: 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
       agent-runtime:
         specifier: workspace:^
-        version: link:../../../../agent-runtime
+        version: file:agent-runtime(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(express@5.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
     dependenciesMeta:
       agent-runtime:
         injected: false
@@ -966,7 +966,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-portfolio-manager:
     dependencies:
@@ -997,7 +997,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-runtime-langgraph:
     dependencies:
@@ -1013,7 +1013,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/agent-workflow-core:
     dependencies:
@@ -1032,7 +1032,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-ag-ui/apps/web:
     dependencies:
@@ -1125,7 +1125,7 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       agent-pi-example:
         specifier: workspace:^
         version: file:clients/web-ag-ui/apps/agent-pi-example(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(bufferutil@4.0.9)(express@5.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
@@ -1152,7 +1152,7 @@ importers:
         version: 6.0.5(typescript@5.9.3)(vite@7.1.7(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   clients/web-legacy:
     dependencies:
@@ -1536,7 +1536,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.2.0
-        version: 1.6.1(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.0)
+        version: 1.6.1(@types/node@20.19.21)(@vitest/ui@3.2.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.0)
 
   community/agents/gmx-allora-agent: {}
 
@@ -2185,7 +2185,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.2.0
-        version: 1.6.1(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.0)
+        version: 1.6.1(@types/node@20.19.21)(@vitest/ui@3.2.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.0)
 
   community/mcp-tools/tatum-mcp-server:
     dependencies:
@@ -20513,8 +20513,8 @@ snapshots:
 
   '@coinbase/cdp-sdk@1.40.1(bufferutil@4.0.9)(debug@4.4.3)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
@@ -20536,8 +20536,8 @@ snapshots:
 
   '@coinbase/cdp-sdk@1.40.1(bufferutil@4.0.9)(debug@4.4.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
@@ -20619,26 +20619,6 @@ snapshots:
       - zod
 
   '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
-      preact: 10.24.2
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zustand: 5.0.3(@types/react@19.2.2)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
-  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
@@ -25903,7 +25883,7 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.3)
       viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
@@ -25938,7 +25918,7 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(react@19.2.3)
       viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
@@ -26780,7 +26760,7 @@ snapshots:
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.3)
       viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
@@ -26818,7 +26798,7 @@ snapshots:
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(react@19.2.3)
       viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
@@ -27046,7 +27026,7 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.2)(react@19.2.3))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.3)
       viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -27089,7 +27069,7 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(react@19.2.3)
       viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -27945,7 +27925,7 @@ snapshots:
     dependencies:
       '@solana/kit': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
@@ -27962,7 +27942,7 @@ snapshots:
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/system@0.8.1(@solana/kit@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
@@ -27981,7 +27961,7 @@ snapshots:
       '@solana/kit': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/sysvars': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
-  '@solana-program/token@0.5.1(@solana/kit@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
@@ -27989,7 +27969,7 @@ snapshots:
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/token@0.6.0(@solana/kit@3.0.3(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
@@ -30269,7 +30249,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -30281,9 +30261,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -30295,7 +30275,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -30697,7 +30677,7 @@ snapshots:
   '@wagmi/connectors@6.2.0(@wagmi/core@2.22.1(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)))(bufferutil@4.0.9)(debug@4.4.3)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(wagmi@2.19.5(bufferutil@4.0.9)(debug@4.4.3)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 2.4.0(bufferutil@4.0.9)(debug@4.4.3)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@gemini-wallet/core': 0.3.2(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -30924,50 +30904,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/window-getters': 1.0.1
-      es-toolkit: 1.33.0
-      events: 3.3.0
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/core@2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
@@ -31027,50 +30963,6 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1(@vercel/blob@0.24.1)
       '@walletconnect/utils': 2.21.1(@vercel/blob@0.24.1)(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@walletconnect/window-getters': 1.0.1
-      es-toolkit: 1.33.0
-      events: 3.3.0
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/core@2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -31282,10 +31174,10 @@ snapshots:
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -31323,10 +31215,10 @@ snapshots:
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -31637,42 +31529,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/sign-client@2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/core': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -31719,42 +31575,6 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1(@vercel/blob@0.24.1)
       '@walletconnect/utils': 2.21.1(@vercel/blob@0.24.1)(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -32111,46 +31931,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      es-toolkit: 1.33.0
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/universal-provider@2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
@@ -32203,46 +31983,6 @@ snapshots:
       '@walletconnect/sign-client': 2.21.1(@vercel/blob@0.24.1)(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
       '@walletconnect/types': 2.21.1(@vercel/blob@0.24.1)
       '@walletconnect/utils': 2.21.1(@vercel/blob@0.24.1)(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-      es-toolkit: 1.33.0
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -32439,50 +32179,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@noble/ciphers': 1.2.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      bs58: 6.0.0
-      detect-browser: 5.3.0
-      query-string: 7.1.3
-      uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/utils@2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
@@ -32546,50 +32242,6 @@ snapshots:
       query-string: 7.1.3
       uint8arrays: 3.1.0
       viem: 2.23.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.12)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/utils@2.21.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@noble/ciphers': 1.2.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@2.2.0(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      bs58: 6.0.0
-      detect-browser: 5.3.0
-      query-string: 7.1.3
-      uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -32859,6 +32511,28 @@ snapshots:
       - zod
       - zod-to-json-schema
 
+  agent-runtime-pi@file:agent-runtime/lib/pi(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+    dependencies:
+      '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(express@5.1.0)
+      '@ag-ui/client': 0.0.47
+      '@ag-ui/core': 0.0.47
+      '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      agent-runtime-postgres: file:agent-runtime/lib/postgres
+      fast-json-patch: 3.1.1(patch_hash=5a36c993e7d9da965b642d6d0e2860c03aaa57b26a71c6f517c9fd070416a7f5)
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@grpc/grpc-js'
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - express
+      - pg-native
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   agent-runtime-pi@file:agent-runtime/lib/pi(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(express@5.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5):
     dependencies:
       '@a2a-js/sdk': 0.3.13(@bufbuild/protobuf@2.10.2)(@grpc/grpc-js@1.14.3)(express@5.1.0)
@@ -32867,6 +32541,7 @@ snapshots:
       '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
       '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.25.3(@cfworker/json-schema@4.1.1)(hono@4.12.9)(zod@4.3.5))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.5)
       agent-runtime-postgres: file:agent-runtime/lib/postgres
+      fast-json-patch: 3.1.1(patch_hash=5a36c993e7d9da965b642d6d0e2860c03aaa57b26a71c6f517c9fd070416a7f5)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
       - '@grpc/grpc-js'
@@ -32888,6 +32563,7 @@ snapshots:
       '@mariozechner/pi-agent-core': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-ai': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       agent-runtime-postgres: file:agent-runtime/lib/postgres
+      fast-json-patch: 3.1.1(patch_hash=5a36c993e7d9da965b642d6d0e2860c03aaa57b26a71c6f517c9fd070416a7f5)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
       - '@grpc/grpc-js'
@@ -32909,6 +32585,7 @@ snapshots:
       '@mariozechner/pi-agent-core': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
       '@mariozechner/pi-ai': 0.64.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
       agent-runtime-postgres: file:agent-runtime/lib/postgres
+      fast-json-patch: 3.1.1(patch_hash=5a36c993e7d9da965b642d6d0e2860c03aaa57b26a71c6f517c9fd070416a7f5)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
       - '@grpc/grpc-js'
@@ -35110,8 +34787,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.8
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -35153,21 +34830,6 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -35227,18 +34889,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -35264,17 +34926,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
@@ -35286,7 +34937,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.36.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -35295,9 +34946,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.36.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.36.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -35315,7 +34966,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.36.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -35324,9 +34975,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.36.0(jiti@2.6.1)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.36.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -35374,35 +35025,6 @@ snapshots:
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -44122,7 +43744,7 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest@1.6.1(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.0):
+  vitest@1.6.1(@types/node@20.19.21)(@vitest/ui@3.2.4)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.44.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -44246,7 +43868,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.8(@types/node@20.19.21)(typescript@5.9.3))(vite@7.1.7(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
@@ -44286,7 +43908,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4(vitest@3.2.4))(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.8(@types/node@22.19.2)(typescript@5.9.3))(vite@7.1.7(@types/node@22.19.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
@@ -44820,8 +44442,8 @@ snapshots:
   x402@0.6.6(@solana/sysvars@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.2)(bufferutil@4.0.9)(debug@4.4.3)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.0(@babel/core@7.28.5)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -44870,8 +44492,8 @@ snapshots:
   x402@0.6.6(bufferutil@4.0.9)(debug@4.4.3)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))


### PR DESCRIPTION
## Summary
- cut web and Pi runtime over to the canonical direct command/control contract
- reconcile rejected `shared-state.control` acknowledgments so optimistic Pi settings writes roll back on `stale_revision` and `invalid_patch`
- recompute runtime-owned `/projected` state during accepted `/shared` updates and align durable docs, diagrams, and ADRs with `command.update`

## Test Plan
- pnpm test:unit -- src/contexts/agentProjection.unit.test.ts in `typescript/clients/web-ag-ui/apps/web`
- pnpm test:int -- src/hooks/useAgentConnection.int.test.tsx in `typescript/clients/web-ag-ui/apps/web`
- pnpm test:int -- src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts in `typescript/clients/web-ag-ui/apps/web`
- pnpm test:int -- src/gatewayService.int.test.ts in `typescript/agent-runtime/lib/pi`
- pnpm test:unit -- src/index.unit.test.ts in `typescript/agent-runtime`
- pnpm test:int -- src/index.int.test.ts in `typescript/agent-runtime`
- pnpm test:int -- src/agUiServer.int.test.ts in `typescript/clients/web-ag-ui/apps/agent-pi-example`
- pnpm lint in `typescript/clients/web-ag-ui/apps/web`
- pnpm build in `typescript/clients/web-ag-ui/apps/web`
- pnpm lint in `typescript/agent-runtime`
- pnpm lint in `typescript/agent-runtime/lib/pi`
- pnpm build in `typescript/agent-runtime/lib/pi`
- pnpm lint in `typescript/clients/web-ag-ui/apps/agent-pi-example`
- pnpm build in `typescript/clients/web-ag-ui/apps/agent-pi-example`
- pnpm install --lockfile-only in `typescript/`

Closes #589
Related to #588
Related to #489
