### PR TITLE
fix(web-ag-ui): retire fake-message command routing

### DIFF
--- a/typescript/agent-runtime/lib/pi/src/fast-json-patch-modules.d.ts
+++ b/typescript/agent-runtime/lib/pi/src/fast-json-patch-modules.d.ts
@@ -1,0 +1,19 @@
+declare module 'fast-json-patch/module/core.mjs' {
+  export function applyPatch<T>(
+    document: T,
+    patch: ReadonlyArray<Record<string, unknown>>,
+    validateOperation?: boolean,
+    mutateDocument?: boolean,
+    banPrototypeModifications?: boolean,
+  ): {
+    newDocument: T;
+  };
+}
+
+declare module 'fast-json-patch/module/duplex.mjs' {
+  export function compare(
+    tree1: unknown,
+    tree2: unknown,
+    invertible?: boolean,
+  ): Array<Record<string, unknown>>;
+}

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -263,22 +263,6 @@ const EMPTY_USAGE = {
   },
 } as const;
 
-type JsonPatchCompare = (
-  left: object,
-  right: object,
-  invertible?: boolean,
-) => Array<Record<string, unknown>>;
-
-type JsonPatchApply = <T>(
-  document: T,
-  patch: ReadonlyArray<Record<string, unknown>>,
-  validateOperation?: boolean,
-  mutateDocument?: boolean,
-  banPrototypeModifications?: boolean,
-) => {
-  newDocument: T;
-};
-
 type PiRuntimeGatewaySharedStateHydrationReason = 'bootstrap' | 'reconnect';
 type PiRuntimeGatewaySharedStateUpdateAckStatus = 'accepted' | 'noop' | 'rejected';
 type PiRuntimeGatewaySharedStateUpdateAckCode =

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -34,7 +34,8 @@ import {
   type PiThreadRecord,
   type PostgresBootstrapPlan,
 } from 'agent-runtime-postgres';
-import * as jsonPatch from 'fast-json-patch';
+import { applyPatch as jsonPatchApply } from 'fast-json-patch/module/core.mjs';
+import { compare as jsonPatchCompare } from 'fast-json-patch/module/duplex.mjs';
 
 import { type TaskState } from './taskState.js';
 import { mergeThreadPatchForEmit } from './threadEmission.js';
@@ -277,14 +278,6 @@ type JsonPatchApply = <T>(
 ) => {
   newDocument: T;
 };
-
-const jsonPatchCompare =
-  (jsonPatch as unknown as { compare?: JsonPatchCompare; default?: { compare?: JsonPatchCompare } }).compare ??
-  (jsonPatch as unknown as { default?: { compare?: JsonPatchCompare } }).default?.compare;
-const jsonPatchApply =
-  (jsonPatch as unknown as { applyPatch?: JsonPatchApply; default?: { applyPatch?: JsonPatchApply } })
-    .applyPatch ??
-  (jsonPatch as unknown as { default?: { applyPatch?: JsonPatchApply } }).default?.applyPatch;
 
 type PiRuntimeGatewaySharedStateHydrationReason = 'bootstrap' | 'reconnect';
 type PiRuntimeGatewaySharedStateUpdateAckStatus = 'accepted' | 'noop' | 'rejected';

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/accounting/types.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/accounting/types.ts
@@ -1,4 +1,4 @@
-export type NavSnapshotTrigger = 'cycle' | 'transaction' | 'sync';
+export type NavSnapshotTrigger = 'cycle' | 'transaction' | 'refresh';
 
 export type PriceSource = 'ember' | 'coingecko';
 export type PriceSourceSummary = 'ember' | 'coingecko' | 'mixed' | 'unknown';

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/agent.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from 'node:url';
 
 import { END, InMemoryStore, START, StateGraph } from '@langchain/langgraph';
 import { restorePersistedCronSchedulesWithRunReconciliation } from 'agent-runtime-langgraph';
+import { buildRunCommandStateUpdate } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
 import { privateKeyToAccount } from 'viem/accounts';
 import { z } from 'zod';
@@ -140,14 +141,15 @@ async function ensureThread(baseUrl: string, threadId: string, graphId: string) 
   await parseJsonResponse(patchResponse, ThreadResponseSchema);
 }
 
-async function updateCycleState(baseUrl: string, threadId: string, runMessage: { id: string; role: 'user'; content: string }) {
+async function updateCycleState(
+  baseUrl: string,
+  threadId: string,
+  cycleCommand: { command: 'cycle'; clientMutationId?: string },
+) {
   const response = await fetch(`${baseUrl}/threads/${threadId}/state`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      values: { messages: [runMessage] },
-      as_node: 'runCommand',
-    }),
+    body: JSON.stringify(buildRunCommandStateUpdate(cycleCommand)),
   });
   await parseJsonResponse(response, ThreadStateUpdateResponseSchema);
 }
@@ -229,10 +231,9 @@ export async function runGraphOnce(threadId: string, options?: { durability?: La
   console.info(`[cron] Starting CLMM graph run via API (thread=${threadId})`);
 
   const clientMutationId = uuidv7();
-  const runMessage = {
-    id: uuidv7(),
-    role: 'user' as const,
-    content: JSON.stringify({ command: 'cycle', clientMutationId }),
+  const cycleCommand = {
+    command: 'cycle' as const,
+    clientMutationId,
   };
 
   const baseUrl = resolveLangGraphDeploymentUrl();
@@ -241,7 +242,7 @@ export async function runGraphOnce(threadId: string, options?: { durability?: La
 
   try {
     await ensureThread(baseUrl, threadId, graphId);
-    await updateCycleState(baseUrl, threadId, runMessage);
+    await updateCycleState(baseUrl, threadId, cycleCommand);
     const runId = await createRun({ baseUrl, threadId, graphId, durability });
     if (!runId) {
       return;

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/agentCron.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/agentCron.unit.test.ts
@@ -46,9 +46,15 @@ describe('runGraphOnce cron state update payload', () => {
     expect(stateUpdateBody).toMatchObject({
       as_node: 'runCommand',
       values: {
-        messages: [expect.objectContaining({ role: 'user' })],
+        private: {
+          pendingCommand: {
+            command: 'cycle',
+            clientMutationId: expect.any(String),
+          },
+        },
       },
     });
+    expect((stateUpdateBody?.['values'] as Record<string, unknown>) ?? {}).not.toHaveProperty('messages');
     expect((stateUpdateBody?.['values'] as Record<string, unknown>) ?? {}).not.toHaveProperty('thread');
 
     const calledUrls = fetchMock.mock.calls

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/hire.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/hire.ts
@@ -1,5 +1,6 @@
 import { pathToFileURL } from 'node:url';
 
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
 
 import { clmmGraph } from './agent.js';
@@ -85,17 +86,15 @@ export async function startClmmHire(
   options?: { durability?: LangGraphDurability },
 ) {
   const clientMutationId = uuidv7();
-  const hireMessage = {
-    id: uuidv7(),
-    role: 'user' as const,
-    content: JSON.stringify({ command: 'hire', clientMutationId }),
-  };
 
   type ClmmInvokeInput = Parameters<typeof clmmGraph.invoke>[0];
   type ClmmInvokeOutput = Awaited<ReturnType<typeof clmmGraph.invoke>>;
   type ClmmInvokeConfig = Parameters<typeof clmmGraph.invoke>[1];
 
-  const initialInput: ClmmInvokeInput = { messages: [hireMessage] } as ClmmInvokeInput;
+  const initialInput: ClmmInvokeInput = buildPendingCommandStateValues({
+    command: 'hire',
+    clientMutationId,
+  }) as ClmmInvokeInput;
   const invokeConfig: ClmmInvokeConfig = {
     configurable: { thread_id: threadId },
     durability: resolveLangGraphDurability(options?.durability),

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/accounting.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/accounting.unit.test.ts
@@ -128,4 +128,48 @@ describe('createCamelotAccountingSnapshot', () => {
       }),
     );
   });
+
+  it('forwards refresh as the accounting trigger for hydration-driven snapshots', async () => {
+    const { createCamelotAccountingSnapshot } = await import('./accounting.js');
+
+    createCamelotNavSnapshot.mockResolvedValue({
+      contextId: 'thread-1',
+      trigger: 'refresh',
+      timestamp: '2026-02-20T00:00:00.000Z',
+      protocolId: 'camelot-clmm',
+      walletAddress: '0x1111111111111111111111111111111111111111',
+      chainId: 42161,
+      totalUsd: 1,
+      positions: [],
+      priceSource: 'unknown',
+    });
+
+    const state = {
+      thread: {
+        operatorConfig: {
+          walletAddress: '0x1111111111111111111111111111111111111111',
+        },
+        metrics: {
+          lastSnapshot: undefined,
+          latestSnapshot: undefined,
+        },
+        accounting: {
+          flowLog: [],
+        },
+      },
+    } as unknown as ClmmState;
+
+    await createCamelotAccountingSnapshot({
+      state,
+      camelotClient: {} as never,
+      trigger: 'refresh',
+      threadId: 'thread-1',
+    });
+
+    expect(createCamelotNavSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: 'refresh',
+      }),
+    );
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/context.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/context.ts
@@ -5,6 +5,8 @@ import type { AIMessage as CopilotKitAIMessage } from '@copilotkit/shared';
 import { type Artifact } from '@emberai/agent-node/workflow';
 import { Annotation } from '@langchain/langgraph';
 import {
+  type AgentCommand,
+  type CommandEnvelope,
   createMessageHistoryReducer,
   isTaskActiveState,
   isTaskTerminalState,
@@ -56,6 +58,8 @@ export type ClmmPrivateState = {
   streamLimit: number;
   cronScheduled: boolean;
   bootstrapped: boolean;
+  pendingCommand?: CommandEnvelope<AgentCommand> | null;
+  activeCommand?: AgentCommand | null;
   suppressDuplicateCommand?: boolean;
   lastAppliedCommandMutationId?: string;
 };
@@ -252,6 +256,8 @@ const defaultPrivateState = (): ClmmPrivateState => ({
   streamLimit: resolveStreamLimit(),
   cronScheduled: false,
   bootstrapped: false,
+  pendingCommand: null,
+  activeCommand: null,
   suppressDuplicateCommand: false,
   lastAppliedCommandMutationId: undefined,
 });
@@ -336,6 +342,14 @@ const mergePrivateState = (
   streamLimit: right?.streamLimit ?? left.streamLimit ?? resolveStreamLimit(),
   cronScheduled: right?.cronScheduled ?? left.cronScheduled ?? false,
   bootstrapped: right?.bootstrapped ?? left.bootstrapped ?? false,
+  pendingCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'pendingCommand')
+      ? right.pendingCommand ?? null
+      : left.pendingCommand ?? null,
+  activeCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'activeCommand')
+      ? right.activeCommand ?? null
+      : left.activeCommand ?? null,
   suppressDuplicateCommand: right?.suppressDuplicateCommand ?? left.suppressDuplicateCommand ?? false,
   lastAppliedCommandMutationId:
     right?.lastAppliedCommandMutationId ?? left.lastAppliedCommandMutationId,

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/graphRouting.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/graphRouting.ts
@@ -12,7 +12,7 @@ export function resolvePostBootstrap(
   | 'prepareOperator'
   | 'syncState' {
   const command = extractCommand(state.private.activeCommand);
-  if (command === 'sync') {
+  if (command === 'refresh') {
     return 'syncState';
   }
   return resolveNextOnboardingNode(state);

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/graphRouting.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/graphRouting.ts
@@ -11,7 +11,7 @@ export function resolvePostBootstrap(
   | 'collectDelegations'
   | 'prepareOperator'
   | 'syncState' {
-  const command = extractCommand(state.messages);
+  const command = extractCommand(state.private.activeCommand);
   if (command === 'sync') {
     return 'syncState';
   }

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.ts
@@ -32,7 +32,7 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
     lastAppliedCommandMutationId: state.private.lastAppliedCommandMutationId,
   });
   const lastAppliedClientMutationId =
-    parsedCommand === 'sync'
+    parsedCommand === 'refresh'
       ? commandEnvelope?.clientMutationId ?? state.thread.lastAppliedClientMutationId
       : state.thread.lastAppliedClientMutationId;
 

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.ts
@@ -1,6 +1,5 @@
 import {
-  extractCommandEnvelopeFromMessages,
-  extractCommandFromMessages,
+  extractCommandEnvelope as extractWorkflowCommandEnvelope,
   resolveCommandReplayGuardState,
   resolveCycleCommandTarget,
   resolveCommandTargetForBootstrappedFlow,
@@ -14,16 +13,18 @@ import { resolveNextOnboardingNode } from '../onboardingRouting.js';
 
 type CommandTarget = CommandRoutingTarget;
 
-export function extractCommandEnvelope(messages: ClmmState['messages']): CommandEnvelope<AgentCommand> | null {
-  return extractCommandEnvelopeFromMessages(messages);
+export function extractCommandEnvelope(
+  pendingCommand: ClmmState['private']['pendingCommand'],
+): CommandEnvelope<AgentCommand> | null {
+  return extractWorkflowCommandEnvelope(pendingCommand);
 }
 
-export function extractCommand(messages: ClmmState['messages']): AgentCommand | null {
-  return extractCommandFromMessages(messages);
+export function extractCommand(activeCommand: ClmmState['private']['activeCommand']): AgentCommand | null {
+  return activeCommand ?? null;
 }
 
 export function runCommandNode(state: ClmmState): ClmmUpdate {
-  const commandEnvelope = extractCommandEnvelope(state.messages);
+  const commandEnvelope = extractCommandEnvelope(state.private.pendingCommand);
   const parsedCommand = commandEnvelope?.command ?? null;
   const replayGuardState = resolveCommandReplayGuardState({
     parsedCommand,
@@ -37,6 +38,8 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
 
   return {
     private: {
+      pendingCommand: null,
+      activeCommand: parsedCommand,
       suppressDuplicateCommand: replayGuardState.suppressDuplicateCommand,
       lastAppliedCommandMutationId: replayGuardState.lastAppliedCommandMutationId,
     },
@@ -51,7 +54,7 @@ export function resolveCommandTarget(state: ClmmState): CommandTarget {
     return '__end__';
   }
 
-  const resolvedCommand = extractCommand(state.messages);
+  const resolvedCommand = extractCommand(state.private.activeCommand);
   if (resolvedCommand === 'cycle') {
     return resolveCycleCommandTarget({
       bootstrapped: state.private.bootstrapped,

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.unit.test.ts
@@ -4,7 +4,7 @@ import { createDefaultClmmThreadState, type ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-function createState(commandEnvelope: { command: 'hire' | 'fire' | 'cycle' | 'sync'; clientMutationId?: string }): ClmmState {
+function createState(commandEnvelope: { command: 'hire' | 'fire' | 'cycle' | 'refresh'; clientMutationId?: string }): ClmmState {
   return {
     messages: [],
     copilotkit: { actions: [], context: [] },
@@ -38,8 +38,8 @@ function applyRunCommandUpdate(state: ClmmState): ClmmState {
 }
 
 describe('runCommandNode', () => {
-  it('records sync mutation acknowledgements in thread state envelope', () => {
-    const state = createState({ command: 'sync', clientMutationId: 'cmid-1' });
+  it('records refresh mutation acknowledgements in thread state envelope', () => {
+    const state = createState({ command: 'refresh', clientMutationId: 'cmid-1' });
 
     const result = runCommandNode(state) as unknown as {
       thread?: { lastAppliedClientMutationId?: string };

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/runCommand.unit.test.ts
@@ -4,9 +4,9 @@ import { createDefaultClmmThreadState, type ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-function createState(messageContent: string): ClmmState {
+function createState(commandEnvelope: { command: 'hire' | 'fire' | 'cycle' | 'sync'; clientMutationId?: string }): ClmmState {
   return {
-    messages: [{ role: 'user', content: messageContent }],
+    messages: [],
     copilotkit: { actions: [], context: [] },
     settings: {},
     private: {
@@ -15,6 +15,8 @@ function createState(messageContent: string): ClmmState {
       streamLimit: -1,
       cronScheduled: false,
       bootstrapped: true,
+      pendingCommand: commandEnvelope,
+      activeCommand: null,
     },
     thread: createDefaultClmmThreadState(),
   };
@@ -37,7 +39,7 @@ function applyRunCommandUpdate(state: ClmmState): ClmmState {
 
 describe('runCommandNode', () => {
   it('records sync mutation acknowledgements in thread state envelope', () => {
-    const state = createState(JSON.stringify({ command: 'sync', clientMutationId: 'cmid-1' }));
+    const state = createState({ command: 'sync', clientMutationId: 'cmid-1' });
 
     const result = runCommandNode(state) as unknown as {
       thread?: { lastAppliedClientMutationId?: string };
@@ -49,7 +51,7 @@ describe('runCommandNode', () => {
   });
 
   it('returns a minimal thread patch so stale snapshots cannot overwrite onboarding state', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
     state.thread.task = {
       id: 'task-1',
       taskStatus: {
@@ -69,13 +71,14 @@ describe('runCommandNode', () => {
   });
 
   it('suppresses cycle commands while onboarding is incomplete', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle commands once onboarding is complete', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
     state.thread.poolArtifact = {
       artifactId: 'camelot-pools',
       parts: [],
@@ -115,12 +118,13 @@ describe('runCommandNode', () => {
       },
       tickSpacing: 10,
     };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('runCycleCommand');
+    expect(resolveCommandTarget(next)).toBe('runCycleCommand');
   });
 
   it('suppresses replayed non-sync command envelopes with the same clientMutationId', () => {
-    const state = createState(JSON.stringify({ command: 'cycle', clientMutationId: 'cycle-1' }));
+    const state = createState({ command: 'cycle', clientMutationId: 'cycle-1' });
     state.thread.poolArtifact = {
       artifactId: 'camelot-pools',
       parts: [],
@@ -162,6 +166,8 @@ describe('runCommandNode', () => {
     };
 
     const first = applyRunCommandUpdate(state);
+    expect(first.private.activeCommand).toBe('cycle');
+    expect(first.private.pendingCommand).toBeNull();
     expect(resolveCommandTarget(first)).toBe('runCycleCommand');
 
     const second = applyRunCommandUpdate(first);

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/syncState.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/src/workflow/nodes/syncState.ts
@@ -6,7 +6,7 @@ import { buildLoggedStateUpdate } from '../stateUpdateFactory.js';
 import { applyAccountingToView } from '../viewMapping.js';
 
 /**
- * No-op sync node.
+ * No-op refresh node.
  *
  * Returns the current LangGraph state snapshot without any mutations.
  * Used by the frontend to fetch current state without triggering any actions.
@@ -23,7 +23,7 @@ export async function syncStateNode(
   const camelotClient = getCamelotClient();
   const threadId = config?.configurable?.thread_id;
   if (!threadId) {
-    logInfo('Accounting sync skipped: missing threadId', {});
+    logInfo('Accounting refresh skipped: missing threadId', {});
     return {};
   }
 
@@ -31,7 +31,7 @@ export async function syncStateNode(
     const snapshot = await createCamelotAccountingSnapshot({
       state,
       camelotClient,
-      trigger: 'sync',
+      trigger: 'refresh',
       threadId,
     });
     if (!snapshot) {
@@ -50,7 +50,7 @@ export async function syncStateNode(
   } catch (error: unknown) {
     const message =
       error instanceof Error ? error.message : typeof error === 'string' ? error : 'Unknown error';
-    logInfo('Accounting sync failed', { error: message });
+    logInfo('Accounting refresh failed', { error: message });
     return {};
   }
 }

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/tests/runGraphOnceBusy.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/tests/runGraphOnceBusy.int.test.ts
@@ -59,9 +59,20 @@ describe('runGraphOnce busy handling integration (CLMM)', () => {
           throw new Error('Expected string request body');
         }
         const body = JSON.parse(bodyText) as {
-          values?: { thread?: unknown; messages?: unknown[] };
+          values?: {
+            thread?: unknown;
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+                clientMutationId?: string;
+              };
+            };
+          };
         };
-        expect(body.values?.messages).toBeDefined();
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.private?.pendingCommand?.clientMutationId).toEqual(expect.any(String));
+        expect(body.values?.messages).toBeUndefined();
         expect(body.values?.thread).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }

--- a/typescript/clients/web-ag-ui/apps/agent-clmm/tests/workflow/agent-clmm.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-clmm/tests/workflow/agent-clmm.e2e.test.ts
@@ -1,3 +1,4 @@
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
 import { describe, expect, it } from 'vitest';
 
@@ -36,15 +37,9 @@ const createRun = async (params: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       assistant_id: params.graphId,
-      input: {
-        messages: [
-          {
-            id: uuidv7(),
-            role: 'user',
-            content: JSON.stringify({ command: params.command }),
-          },
-        ],
-      },
+      input: buildPendingCommandStateValues({
+        command: params.command,
+      }),
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'e2e' },
       stream_mode: ['events', 'values', 'messages'],

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
@@ -9,6 +9,7 @@ import {
 } from 'agent-runtime-langgraph';
 import {
   analyzeCycleProjectionThread,
+  buildRunCommandStateUpdate,
   projectCycleCommandThread,
 } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
@@ -63,7 +64,7 @@ function resolvePostBootstrap(
   | 'collectDelegations'
   | 'prepareOperator'
   | 'syncState' {
-  const command = extractCommand(state.messages);
+  const command = extractCommand(state.private.activeCommand);
   const target = command === 'sync' ? 'syncState' : resolveNextOnboardingNode(state);
   logRouteDecision('bootstrap', target, {
     command,
@@ -382,7 +383,7 @@ async function ensureThread(baseUrl: string, threadId: string, graphId: string) 
 async function updateCycleState(
   baseUrl: string,
   threadId: string,
-  runMessage: { id: string; role: 'user'; content: string },
+  cycleCommand: { command: 'cycle'; clientMutationId?: string },
 ): Promise<boolean> {
   let existingThread: Record<string, unknown> | null = null;
   try {
@@ -425,10 +426,12 @@ async function updateCycleState(
   const response = await fetch(`${baseUrl}/threads/${threadId}/state`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      values: { messages: [runMessage], thread },
-      as_node: 'runCommand',
-    }),
+    body: JSON.stringify(
+      buildRunCommandStateUpdate({
+        ...cycleCommand,
+        thread,
+      }),
+    ),
   });
   if (isLangGraphBusyStatus(response.status)) {
     const payloadText = await response.text();
@@ -565,10 +568,8 @@ export async function runGraphOnce(
   const startedAt = Date.now();
   console.info(`[cron] Starting GMX Allora graph run via API (thread=${threadId})`);
 
-  const runMessage = {
-    id: uuidv7(),
-    role: 'user' as const,
-    content: JSON.stringify({ command: 'cycle' }),
+  const cycleCommand = {
+    command: 'cycle' as const,
   };
 
   const baseUrl = resolveLangGraphDeploymentUrl();
@@ -578,7 +579,7 @@ export async function runGraphOnce(
 
   try {
     await ensureThread(baseUrl, threadId, graphId);
-    const stateUpdated = await updateCycleState(baseUrl, threadId, runMessage);
+    const stateUpdated = await updateCycleState(baseUrl, threadId, cycleCommand);
     if (!stateUpdated) {
       return;
     }

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/agent.ts
@@ -65,7 +65,7 @@ function resolvePostBootstrap(
   | 'prepareOperator'
   | 'syncState' {
   const command = extractCommand(state.private.activeCommand);
-  const target = command === 'sync' ? 'syncState' : resolveNextOnboardingNode(state);
+  const target = command === 'refresh' ? 'syncState' : resolveNextOnboardingNode(state);
   logRouteDecision('bootstrap', target, {
     command,
     onboardingStatus: state.thread.onboardingFlow?.status,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/cronApiRunner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/cronApiRunner.ts
@@ -1,20 +1,13 @@
 import { pathToFileURL } from 'node:url';
 
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import cron from 'node-cron';
 import { v7 as uuidv7 } from 'uuid';
 import { z } from 'zod';
 
-type MessageInput = {
-  id: string;
-  role: 'user';
-  content: string;
-};
-
 type RunCreatePayload = {
   assistant_id: string;
-  input?: {
-    messages: MessageInput[];
-  };
+  input?: Record<string, unknown>;
   config?: {
     configurable?: {
       thread_id?: string;
@@ -91,17 +84,11 @@ const resolveThreadId = () => process.env.STARTER_THREAD_ID ?? uuidv7();
 const resolveIntervalMs = () =>
   parseNumber(process.env.STARTER_CRON_INTERVAL_MS) ?? DEFAULT_INTERVAL_MS;
 
-const buildCycleMessage = (): MessageInput => ({
-  id: uuidv7(),
-  role: 'user',
-  content: JSON.stringify({ command: 'cycle' }),
-});
-
 const buildRunPayload = (params: { graphId: string; threadId: string }): RunCreatePayload => ({
   assistant_id: params.graphId,
-  input: {
-    messages: [buildCycleMessage()],
-  },
+  input: buildPendingCommandStateValues({
+    command: 'cycle',
+  }),
   config: {
     configurable: {
       thread_id: params.threadId,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/context.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/context.ts
@@ -4,6 +4,8 @@ import type { AIMessage as CopilotKitAIMessage } from '@copilotkit/shared';
 import { type Artifact } from '@emberai/agent-node/workflow';
 import { Annotation } from '@langchain/langgraph';
 import {
+  type AgentCommand,
+  type CommandEnvelope,
   createMessageHistoryReducer,
   isTaskActiveState,
   isTaskTerminalState,
@@ -52,6 +54,8 @@ export type ClmmPrivateState = {
   streamLimit: number;
   cronScheduled: boolean;
   bootstrapped: boolean;
+  pendingCommand?: CommandEnvelope<AgentCommand> | null;
+  activeCommand?: AgentCommand | null;
   suppressDuplicateCommand?: boolean;
   lastAppliedCommandMutationId?: string;
 };
@@ -264,6 +268,8 @@ const defaultPrivateState = (): ClmmPrivateState => ({
   streamLimit: resolveStreamLimit(),
   cronScheduled: false,
   bootstrapped: false,
+  pendingCommand: null,
+  activeCommand: null,
   suppressDuplicateCommand: false,
   lastAppliedCommandMutationId: undefined,
 });
@@ -334,6 +340,14 @@ const mergePrivateState = (
   streamLimit: right?.streamLimit ?? left.streamLimit ?? resolveStreamLimit(),
   cronScheduled: right?.cronScheduled ?? left.cronScheduled ?? false,
   bootstrapped: right?.bootstrapped ?? left.bootstrapped ?? false,
+  pendingCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'pendingCommand')
+      ? right.pendingCommand ?? null
+      : left.pendingCommand ?? null,
+  activeCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'activeCommand')
+      ? right.activeCommand ?? null
+      : left.activeCommand ?? null,
   suppressDuplicateCommand: right?.suppressDuplicateCommand ?? left.suppressDuplicateCommand ?? false,
   lastAppliedCommandMutationId:
     right?.lastAppliedCommandMutationId ?? left.lastAppliedCommandMutationId,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.ts
@@ -37,7 +37,7 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
     lastAppliedCommandMutationId: state.private.lastAppliedCommandMutationId,
   });
   const lastAppliedClientMutationId =
-    parsedCommand === 'sync'
+    parsedCommand === 'refresh'
       ? commandEnvelope?.clientMutationId ?? state.thread.lastAppliedClientMutationId
       : state.thread.lastAppliedClientMutationId;
 

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.ts
@@ -1,6 +1,5 @@
 import {
-  extractCommandEnvelopeFromMessages,
-  extractCommandFromMessages,
+  extractCommandEnvelope as extractWorkflowCommandEnvelope,
   resolveCommandReplayGuardState,
   resolveCycleCommandTarget,
   resolveCommandTargetForBootstrappedFlow,
@@ -19,16 +18,18 @@ function shouldTraceCommand(command: AgentCommand | null | undefined): command i
   return command !== null && command !== undefined && TRACEABLE_COMMANDS.includes(command);
 }
 
-export function extractCommandEnvelope(messages: ClmmState['messages']): CommandEnvelope<AgentCommand> | null {
-  return extractCommandEnvelopeFromMessages(messages);
+export function extractCommandEnvelope(
+  pendingCommand: ClmmState['private']['pendingCommand'],
+): CommandEnvelope<AgentCommand> | null {
+  return extractWorkflowCommandEnvelope(pendingCommand);
 }
 
-export function extractCommand(messages: ClmmState['messages']): AgentCommand | null {
-  return extractCommandFromMessages(messages);
+export function extractCommand(activeCommand: ClmmState['private']['activeCommand']): AgentCommand | null {
+  return activeCommand ?? null;
 }
 
 export function runCommandNode(state: ClmmState): ClmmUpdate {
-  const commandEnvelope = extractCommandEnvelope(state.messages);
+  const commandEnvelope = extractCommandEnvelope(state.private.pendingCommand);
   const parsedCommand = commandEnvelope?.command ?? null;
   const replayGuardState = resolveCommandReplayGuardState({
     parsedCommand,
@@ -54,6 +55,8 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
 
   return {
     private: {
+      pendingCommand: null,
+      activeCommand: parsedCommand,
       suppressDuplicateCommand: replayGuardState.suppressDuplicateCommand,
       lastAppliedCommandMutationId: replayGuardState.lastAppliedCommandMutationId,
     },
@@ -68,7 +71,7 @@ export function resolveCommandTarget(state: ClmmState): CommandTarget {
     return '__end__';
   }
 
-  const resolvedCommand = extractCommand(state.messages);
+  const resolvedCommand = extractCommand(state.private.activeCommand);
   if (resolvedCommand === 'cycle') {
     const target = resolveCycleCommandTarget({
       bootstrapped: state.private.bootstrapped,

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.unit.test.ts
@@ -4,7 +4,7 @@ import type { ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-function createState(commandEnvelope: { command: 'hire' | 'fire' | 'cycle' | 'sync'; clientMutationId?: string }): ClmmState {
+function createState(commandEnvelope: { command: 'hire' | 'fire' | 'cycle' | 'refresh'; clientMutationId?: string }): ClmmState {
   return {
     messages: [],
     copilotkit: { actions: [], context: [] },
@@ -47,8 +47,8 @@ function applyRunCommandUpdate(state: ClmmState): ClmmState {
 }
 
 describe('runCommandNode (gmx-allora)', () => {
-  it('records sync mutation acknowledgements in thread state envelope', () => {
-    const state = createState({ command: 'sync', clientMutationId: 'cmid-1' });
+  it('records refresh mutation acknowledgements in thread state envelope', () => {
+    const state = createState({ command: 'refresh', clientMutationId: 'cmid-1' });
 
     const result = runCommandNode(state) as unknown as {
       thread?: { lastAppliedClientMutationId?: string };

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/src/workflow/nodes/runCommand.unit.test.ts
@@ -4,9 +4,9 @@ import type { ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-function createState(messageContent: string): ClmmState {
+function createState(commandEnvelope: { command: 'hire' | 'fire' | 'cycle' | 'sync'; clientMutationId?: string }): ClmmState {
   return {
-    messages: [{ role: 'user', content: messageContent }],
+    messages: [],
     copilotkit: { actions: [], context: [] },
     settings: {},
     private: {
@@ -15,6 +15,8 @@ function createState(messageContent: string): ClmmState {
       streamLimit: -1,
       cronScheduled: false,
       bootstrapped: true,
+      pendingCommand: commandEnvelope,
+      activeCommand: null,
     },
     thread: {
       lastAppliedClientMutationId: undefined,
@@ -46,7 +48,7 @@ function applyRunCommandUpdate(state: ClmmState): ClmmState {
 
 describe('runCommandNode (gmx-allora)', () => {
   it('records sync mutation acknowledgements in thread state envelope', () => {
-    const state = createState(JSON.stringify({ command: 'sync', clientMutationId: 'cmid-1' }));
+    const state = createState({ command: 'sync', clientMutationId: 'cmid-1' });
 
     const result = runCommandNode(state) as unknown as {
       thread?: { lastAppliedClientMutationId?: string };
@@ -56,13 +58,14 @@ describe('runCommandNode (gmx-allora)', () => {
   });
 
   it('suppresses cycle commands while onboarding is incomplete', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle commands once onboarding is complete', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
     state.thread.operatorInput = {
       delegatorWalletAddress: '0x8aF45a2C60aBE9172D93aCddB40473DCc66AA9B9',
       targetMarketAddress: '0x1111111111111111111111111111111111111111',
@@ -92,19 +95,21 @@ describe('runCommandNode (gmx-allora)', () => {
         shortToken: 'USDC',
       },
     };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('runCycleCommand');
+    expect(resolveCommandTarget(next)).toBe('runCycleCommand');
   });
 
   it('routes cycle to bootstrap when thread is not bootstrapped', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
     state.private.bootstrapped = false;
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('bootstrap');
+    expect(resolveCommandTarget(next)).toBe('bootstrap');
   });
 
   it('suppresses replayed non-sync command envelopes with the same clientMutationId', () => {
-    const state = createState(JSON.stringify({ command: 'cycle', clientMutationId: 'cycle-1' }));
+    const state = createState({ command: 'cycle', clientMutationId: 'cycle-1' });
     state.thread.operatorInput = {
       delegatorWalletAddress: '0x8aF45a2C60aBE9172D93aCddB40473DCc66AA9B9',
       targetMarketAddress: '0x1111111111111111111111111111111111111111',
@@ -136,6 +141,8 @@ describe('runCommandNode (gmx-allora)', () => {
     };
 
     const first = applyRunCommandUpdate(state);
+    expect(first.private.activeCommand).toBe('cycle');
+    expect(first.private.pendingCommand).toBeNull();
     expect(resolveCommandTarget(first)).toBe('runCycleCommand');
 
     const second = applyRunCommandUpdate(first);

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/runGraphOnceBusy.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/runGraphOnceBusy.int.test.ts
@@ -50,6 +50,25 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return new Response('busy', { status: 409 });
       }
       throw new Error(`Unexpected fetch call: ${method} ${url}`);
@@ -81,6 +100,25 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -145,8 +183,18 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
           throw new Error('Expected string request body');
         }
         const body = JSON.parse(bodyText) as {
-          values?: { thread?: { task?: { taskStatus?: { state?: string } } } };
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+            thread?: { task?: { taskStatus?: { state?: string } } };
+          };
         };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         expect(body.values?.thread?.task?.taskStatus?.state).toBe('working');
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
@@ -177,6 +225,25 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -228,6 +295,25 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -413,8 +499,18 @@ describe('runGraphOnce busy handling integration (GMX Allora)', () => {
           throw new Error('Expected string request body');
         }
         const body = JSON.parse(bodyText) as {
-          values?: { thread?: { lifecycle?: { phase?: string }; task?: { taskStatus?: { state?: string } } } };
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+            thread?: { lifecycle?: { phase?: string }; task?: { taskStatus?: { state?: string } } };
+          };
         };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         expect(body.values?.thread?.lifecycle?.phase).toBe('inactive');
         expect(body.values?.thread?.task?.taskStatus?.state).toBe('completed');
         return jsonResponse({ checkpoint_id: 'cp-1' });

--- a/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/workflow/agent-gmx-allora.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-gmx-allora/tests/workflow/agent-gmx-allora.e2e.test.ts
@@ -1,3 +1,4 @@
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import { describe, expect, it } from 'vitest';
 import { v7 as uuidv7 } from 'uuid';
 
@@ -36,15 +37,9 @@ const createRun = async (params: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       assistant_id: params.graphId,
-      input: {
-        messages: [
-          {
-            id: uuidv7(),
-            role: 'user',
-            content: JSON.stringify({ command: params.command }),
-          },
-        ],
-      },
+      input: buildPendingCommandStateValues({
+        command: params.command,
+      }),
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'e2e' },
       stream_mode: ['events', 'values', 'messages'],

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/scripts/smoke/pendle-fire-smoke.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/scripts/smoke/pendle-fire-smoke.ts
@@ -1,3 +1,4 @@
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -155,15 +156,9 @@ const createRun = async (params: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       assistant_id: params.graphId,
-      input: {
-        messages: [
-          {
-            id: uuidv7(),
-            role: 'user',
-            content: JSON.stringify({ command: params.command }),
-          },
-        ],
-      },
+      input: buildPendingCommandStateValues({
+        command: params.command,
+      }),
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'smoke' },
       stream_mode: ['events', 'values', 'messages'],

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/agent.ts
@@ -8,6 +8,7 @@ import {
 } from 'agent-runtime-langgraph';
 import {
   analyzeCycleProjectionThread,
+  buildRunCommandStateUpdate,
   projectCycleCommandThread,
 } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
@@ -182,7 +183,7 @@ async function ensureThread(baseUrl: string, threadId: string, graphId: string) 
 async function updateCycleState(
   baseUrl: string,
   threadId: string,
-  runMessage: { id: string; role: 'user'; content: string },
+  cycleCommand: { command: 'cycle'; clientMutationId?: string },
 ): Promise<boolean> {
   let existingThread: Record<string, unknown> | null = null;
   try {
@@ -230,10 +231,12 @@ async function updateCycleState(
   const response = await fetchRequest(`${baseUrl}/threads/${threadId}/state`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      values: { messages: [runMessage], thread },
-      as_node: 'runCommand',
-    }),
+    body: JSON.stringify(
+      buildRunCommandStateUpdate({
+        ...cycleCommand,
+        thread,
+      }),
+    ),
   });
   if (isLangGraphBusyStatus(response.status)) {
     const payloadText = await response.text();
@@ -327,10 +330,8 @@ export async function runGraphOnce(
   const startedAt = Date.now();
   console.info(`[cron] Starting Pendle graph run via API (thread=${threadId})`);
 
-  const runMessage = {
-    id: uuidv7(),
-    role: 'user' as const,
-    content: JSON.stringify({ command: 'cycle' }),
+  const cycleCommand = {
+    command: 'cycle' as const,
   };
 
   const baseUrl = resolveLangGraphDeploymentUrl();
@@ -340,7 +341,7 @@ export async function runGraphOnce(
 
   try {
     await ensureThread(baseUrl, threadId, graphId);
-    const stateUpdated = await updateCycleState(baseUrl, threadId, runMessage);
+    const stateUpdated = await updateCycleState(baseUrl, threadId, cycleCommand);
     if (!stateUpdated) {
       return;
     }

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/cronApiRunner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/cronApiRunner.ts
@@ -1,20 +1,13 @@
 import { pathToFileURL } from 'node:url';
 
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import cron from 'node-cron';
 import { v7 as uuidv7 } from 'uuid';
 import { z } from 'zod';
 
-type MessageInput = {
-  id: string;
-  role: 'user';
-  content: string;
-};
-
 type RunCreatePayload = {
   assistant_id: string;
-  input?: {
-    messages: MessageInput[];
-  };
+  input?: Record<string, unknown>;
   config?: {
     configurable?: {
       thread_id?: string;
@@ -91,20 +84,14 @@ const resolveThreadId = () => process.env.STARTER_THREAD_ID ?? uuidv7();
 const resolveIntervalMs = () =>
   parseNumber(process.env.STARTER_CRON_INTERVAL_MS) ?? DEFAULT_INTERVAL_MS;
 
-const buildCycleMessage = (): MessageInput => ({
-  id: uuidv7(),
-  role: 'user',
-  content: JSON.stringify({ command: 'cycle' }),
-});
-
 const buildRunPayload = (params: {
   graphId: string;
   threadId: string;
 }): RunCreatePayload => ({
   assistant_id: params.graphId,
-  input: {
-    messages: [buildCycleMessage()],
-  },
+  input: buildPendingCommandStateValues({
+    command: 'cycle',
+  }),
   config: {
     configurable: {
       thread_id: params.threadId,

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/runGraphOnceBusy.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/runGraphOnceBusy.int.test.ts
@@ -70,6 +70,25 @@ describe('runGraphOnce busy handling integration (Pendle)', () => {
         return jsonResponse({ values: { thread: READY_THREAD } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return new Response('busy', { status: 409 });
       }
       throw new Error(`Unexpected fetch call: ${method} ${url}`);
@@ -104,6 +123,25 @@ describe('runGraphOnce busy handling integration (Pendle)', () => {
         return jsonResponse({ values: { thread: READY_THREAD } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -146,6 +184,25 @@ describe('runGraphOnce busy handling integration (Pendle)', () => {
         return jsonResponse({ values: { thread: READY_THREAD } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -231,8 +288,18 @@ describe('runGraphOnce busy handling integration (Pendle)', () => {
           throw new Error('Expected string request body');
         }
         const body = JSON.parse(bodyText) as {
-          values?: { thread?: { task?: { taskStatus?: { state?: string } } } };
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+            thread?: { task?: { taskStatus?: { state?: string } } };
+          };
         };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         expect(body.values?.thread?.task?.taskStatus?.state).toBe('working');
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
@@ -294,8 +361,18 @@ describe('runGraphOnce busy handling integration (Pendle)', () => {
           throw new Error('Expected string request body');
         }
         const body = JSON.parse(bodyText) as {
-          values?: { thread?: { lifecycle?: { phase?: string }; task?: { taskStatus?: { state?: string } } } };
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+            thread?: { lifecycle?: { phase?: string }; task?: { taskStatus?: { state?: string } } };
+          };
         };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         expect(body.values?.thread?.lifecycle?.phase).toBe('inactive');
         expect(body.values?.thread?.task?.taskStatus?.state).toBe('completed');
         return jsonResponse({ checkpoint_id: 'cp-1' });

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/context.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/context.ts
@@ -2,6 +2,8 @@ import type { AIMessage as CopilotKitAIMessage } from '@copilotkit/shared';
 import { type Artifact } from '@emberai/agent-node/workflow';
 import { Annotation } from '@langchain/langgraph';
 import {
+  type AgentCommand,
+  type CommandEnvelope,
   createMessageHistoryReducer,
   isTaskActiveState,
   isTaskTerminalState,
@@ -50,6 +52,8 @@ export type ClmmPrivateState = {
   streamLimit: number;
   cronScheduled: boolean;
   bootstrapped: boolean;
+  pendingCommand?: CommandEnvelope<AgentCommand> | null;
+  activeCommand?: AgentCommand | null;
   suppressDuplicateCommand?: boolean;
   lastAppliedCommandMutationId?: string;
 };
@@ -294,6 +298,8 @@ const defaultPrivateState = (): ClmmPrivateState => ({
   streamLimit: resolveStreamLimit(),
   cronScheduled: false,
   bootstrapped: false,
+  pendingCommand: null,
+  activeCommand: null,
   suppressDuplicateCommand: false,
   lastAppliedCommandMutationId: undefined,
 });
@@ -362,6 +368,14 @@ const mergePrivateState = (
   streamLimit: right?.streamLimit ?? left.streamLimit ?? resolveStreamLimit(),
   cronScheduled: right?.cronScheduled ?? left.cronScheduled ?? false,
   bootstrapped: right?.bootstrapped ?? left.bootstrapped ?? false,
+  pendingCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'pendingCommand')
+      ? right.pendingCommand ?? null
+      : left.pendingCommand ?? null,
+  activeCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'activeCommand')
+      ? right.activeCommand ?? null
+      : left.activeCommand ?? null,
   suppressDuplicateCommand: right?.suppressDuplicateCommand ?? left.suppressDuplicateCommand ?? false,
   lastAppliedCommandMutationId:
     right?.lastAppliedCommandMutationId ?? left.lastAppliedCommandMutationId,

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.ts
@@ -35,7 +35,7 @@ function resolveNextOnboardingNode(state: ClmmState): OnboardingNodeTarget {
 }
 
 export function resolvePostBootstrap(state: ClmmState): OnboardingNodeTarget {
-  const command = extractCommand(state.messages);
+  const command = extractCommand(state.private.activeCommand);
   if (command === 'sync') {
     return 'syncState';
   }

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.ts
@@ -36,7 +36,7 @@ function resolveNextOnboardingNode(state: ClmmState): OnboardingNodeTarget {
 
 export function resolvePostBootstrap(state: ClmmState): OnboardingNodeTarget {
   const command = extractCommand(state.private.activeCommand);
-  if (command === 'sync') {
+  if (command === 'refresh') {
     return 'syncState';
   }
   return resolveNextOnboardingNode(state);

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.unit.test.ts
@@ -13,6 +13,9 @@ import {
 const createState = (): ClmmState =>
   ({
     messages: [],
+    private: {
+      activeCommand: null,
+    },
     thread: {
       operatorInput: undefined,
       fundingTokenInput: undefined,
@@ -66,7 +69,7 @@ const makeReadyState = (): ClmmState => {
 describe('graphRouting', () => {
   it('routes bootstrap to syncState for explicit sync command', () => {
     const state = createState();
-    state.messages = [{ id: 'msg-1', role: 'user', content: JSON.stringify({ command: 'sync' }) }];
+    state.private.activeCommand = 'sync';
 
     expect(resolvePostBootstrap(state)).toBe('syncState');
   });

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/graphRouting.unit.test.ts
@@ -67,9 +67,9 @@ const makeReadyState = (): ClmmState => {
 };
 
 describe('graphRouting', () => {
-  it('routes bootstrap to syncState for explicit sync command', () => {
+  it('routes bootstrap to syncState for explicit refresh command', () => {
     const state = createState();
-    state.private.activeCommand = 'sync';
+    state.private.activeCommand = 'refresh';
 
     expect(resolvePostBootstrap(state)).toBe('syncState');
   });

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.ts
@@ -32,7 +32,7 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
     lastAppliedCommandMutationId: state.private.lastAppliedCommandMutationId,
   });
   const lastAppliedClientMutationId =
-    parsedCommand === 'sync'
+    parsedCommand === 'refresh'
       ? commandEnvelope?.clientMutationId ?? state.thread.lastAppliedClientMutationId
       : state.thread.lastAppliedClientMutationId;
 
@@ -49,7 +49,7 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
   };
 }
 
-export function resolveCommandTarget({ messages, private: priv, thread }: ClmmState): CommandTarget {
+export function resolveCommandTarget({ private: priv, thread }: ClmmState): CommandTarget {
   if (priv.suppressDuplicateCommand === true) {
     return '__end__';
   }

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.ts
@@ -1,6 +1,5 @@
 import {
-  extractCommandEnvelopeFromMessages,
-  extractCommandFromMessages,
+  extractCommandEnvelope as extractWorkflowCommandEnvelope,
   resolveCommandReplayGuardState,
   resolveCycleCommandTarget,
   resolveOnboardingPhase,
@@ -14,16 +13,18 @@ import { type ClmmState, type ClmmUpdate } from '../context.js';
 
 type CommandTarget = CommandRoutingTarget;
 
-export function extractCommandEnvelope(messages: ClmmState['messages']): CommandEnvelope<AgentCommand> | null {
-  return extractCommandEnvelopeFromMessages(messages);
+export function extractCommandEnvelope(
+  pendingCommand: ClmmState['private']['pendingCommand'],
+): CommandEnvelope<AgentCommand> | null {
+  return extractWorkflowCommandEnvelope(pendingCommand);
 }
 
-export function extractCommand(messages: ClmmState['messages']): AgentCommand | null {
-  return extractCommandFromMessages(messages);
+export function extractCommand(activeCommand: ClmmState['private']['activeCommand']): AgentCommand | null {
+  return activeCommand ?? null;
 }
 
 export function runCommandNode(state: ClmmState): ClmmUpdate {
-  const commandEnvelope = extractCommandEnvelope(state.messages);
+  const commandEnvelope = extractCommandEnvelope(state.private.pendingCommand);
   const parsedCommand = commandEnvelope?.command ?? null;
   const replayGuardState = resolveCommandReplayGuardState({
     parsedCommand,
@@ -37,6 +38,8 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
 
   return {
     private: {
+      pendingCommand: null,
+      activeCommand: parsedCommand,
       suppressDuplicateCommand: replayGuardState.suppressDuplicateCommand,
       lastAppliedCommandMutationId: replayGuardState.lastAppliedCommandMutationId,
     },
@@ -51,7 +54,7 @@ export function resolveCommandTarget({ messages, private: priv, thread }: ClmmSt
     return '__end__';
   }
 
-  const resolvedCommand = extractCommand(messages);
+  const resolvedCommand = extractCommand(priv.activeCommand);
   if (!resolvedCommand) {
     return '__end__';
   }

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.unit.test.ts
@@ -4,11 +4,6 @@ import type { ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-type PendingCommandEnvelope = {
-  command: 'hire' | 'fire' | 'cycle' | 'sync';
-  clientMutationId?: string;
-};
-
 const baseState = (): ClmmState => ({
   messages: [],
   copilotkit: { actions: [], context: [] },
@@ -76,10 +71,10 @@ const applyRunCommandUpdate = (state: ClmmState): ClmmState => {
 };
 
 describe('resolveCommandTarget', () => {
-  it('records lastAppliedClientMutationId when sync command includes one', () => {
+  it('records lastAppliedClientMutationId when refresh command includes one', () => {
     const state = baseState();
     state.private.pendingCommand = {
-      command: 'sync',
+      command: 'refresh',
       clientMutationId: 'mutation-1',
     };
 

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/src/workflow/nodes/runCommand.unit.test.ts
@@ -4,6 +4,11 @@ import type { ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
+type PendingCommandEnvelope = {
+  command: 'hire' | 'fire' | 'cycle' | 'sync';
+  clientMutationId?: string;
+};
+
 const baseState = (): ClmmState => ({
   messages: [],
   copilotkit: { actions: [], context: [] },
@@ -14,6 +19,8 @@ const baseState = (): ClmmState => ({
     streamLimit: -1,
     cronScheduled: false,
     bootstrapped: false,
+    pendingCommand: null,
+    activeCommand: null,
   },
   thread: {
     command: undefined,
@@ -53,12 +60,6 @@ const baseState = (): ClmmState => ({
   },
 });
 
-const message = (command: 'hire' | 'fire' | 'cycle' | 'sync') => ({
-  id: 'msg-1',
-  role: 'user' as const,
-  content: JSON.stringify({ command }),
-});
-
 const applyRunCommandUpdate = (state: ClmmState): ClmmState => {
   const update = runCommandNode(state);
   return {
@@ -77,13 +78,10 @@ const applyRunCommandUpdate = (state: ClmmState): ClmmState => {
 describe('resolveCommandTarget', () => {
   it('records lastAppliedClientMutationId when sync command includes one', () => {
     const state = baseState();
-    state.messages = [
-      {
-        id: 'msg-sync',
-        role: 'user',
-        content: JSON.stringify({ command: 'sync', clientMutationId: 'mutation-1' }),
-      },
-    ];
+    state.private.pendingCommand = {
+      command: 'sync',
+      clientMutationId: 'mutation-1',
+    };
 
     const next = runCommandNode(state);
 
@@ -92,26 +90,29 @@ describe('resolveCommandTarget', () => {
 
   it('routes cycle to bootstrap when not bootstrapped', () => {
     const state = baseState();
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('bootstrap');
+    expect(resolveCommandTarget(next)).toBe('bootstrap');
   });
 
   it('routes cycle to syncState when bootstrapped but onboarding is incomplete', () => {
     const state = baseState();
     state.private.bootstrapped = true;
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle to syncState when funding token selection is missing', () => {
     const state = baseState();
     state.private.bootstrapped = true;
     state.thread.operatorInput = { walletAddress: '0xabc', baseContributionUsd: 10 };
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle to syncState when delegations are required but missing', () => {
@@ -120,9 +121,10 @@ describe('resolveCommandTarget', () => {
     state.thread.operatorInput = { walletAddress: '0xabc', baseContributionUsd: 10 };
     state.thread.fundingTokenInput = { fundingTokenAddress: '0xdef' as `0x${string}` };
     state.thread.delegationsBypassActive = false;
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle to syncState when operator config is missing', () => {
@@ -131,9 +133,10 @@ describe('resolveCommandTarget', () => {
     state.thread.operatorInput = { walletAddress: '0xabc', baseContributionUsd: 10 };
     state.thread.fundingTokenInput = { fundingTokenAddress: '0xdef' as `0x${string}` };
     state.thread.delegationsBypassActive = true;
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle to syncState when setup is not complete yet', () => {
@@ -159,9 +162,10 @@ describe('resolveCommandTarget', () => {
       },
     };
     state.thread.setupComplete = false;
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(next)).toBe('syncState');
   });
 
   it('routes cycle to runCycleCommand when configured and setup complete', () => {
@@ -187,9 +191,10 @@ describe('resolveCommandTarget', () => {
       },
     };
     state.thread.setupComplete = true;
-    state.messages = [message('cycle')];
+    state.private.pendingCommand = { command: 'cycle' };
+    const next = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('runCycleCommand');
+    expect(resolveCommandTarget(next)).toBe('runCycleCommand');
   });
 
   it('suppresses replayed non-sync command envelopes with the same clientMutationId', () => {
@@ -215,15 +220,14 @@ describe('resolveCommandTarget', () => {
       },
     };
     state.thread.setupComplete = true;
-    state.messages = [
-      {
-        id: 'msg-1',
-        role: 'user',
-        content: JSON.stringify({ command: 'cycle', clientMutationId: 'cycle-1' }),
-      },
-    ];
+    state.private.pendingCommand = {
+      command: 'cycle',
+      clientMutationId: 'cycle-1',
+    };
 
     const first = applyRunCommandUpdate(state);
+    expect(first.private.activeCommand).toBe('cycle');
+    expect(first.private.pendingCommand).toBeNull();
     expect(resolveCommandTarget(first)).toBe('runCycleCommand');
 
     const second = applyRunCommandUpdate(first);

--- a/typescript/clients/web-ag-ui/apps/agent-pendle/tests/workflow/agent-pendle.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pendle/tests/workflow/agent-pendle.e2e.test.ts
@@ -1,3 +1,4 @@
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import { describe, expect, it } from 'vitest';
 import { v7 as uuidv7 } from 'uuid';
 
@@ -36,15 +37,9 @@ const createRun = async (params: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       assistant_id: params.graphId,
-      input: {
-        messages: [
-          {
-            id: uuidv7(),
-            role: 'user',
-            content: JSON.stringify({ command: params.command }),
-          },
-        ],
-      },
+      input: buildPendingCommandStateValues({
+        command: params.command,
+      }),
       config: { configurable: { thread_id: params.threadId } },
       metadata: { source: 'e2e' },
       stream_mode: ['events', 'values', 'messages'],

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/agUiServer.unit.test.ts
@@ -178,7 +178,7 @@ describe('createPiExampleAgUiHandler', () => {
           {
             id: 'message-1',
             role: 'user',
-            content: 'schedule a sync',
+            content: 'schedule a refresh',
           },
         ],
       }),

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.ts
@@ -487,8 +487,8 @@ function createPiExampleMockStream(): PiExampleGatewayStream {
         toolName: AGENT_RUNTIME_AUTOMATION_SCHEDULE_TOOL,
         toolCallId: 'pi-example-tool-schedule',
         args: {
-          title: 'Sync every 5 minutes',
-          instruction: 'sync',
+          title: 'Refresh every 5 minutes',
+          instruction: 'refresh',
           schedule: {
             kind: 'every',
             intervalMinutes: 5,

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/piExampleFoundation.unit.test.ts
@@ -217,7 +217,7 @@ describe('createPiExampleAgentConfig', () => {
       config.model!,
       {
         systemPrompt: config.systemPrompt,
-        messages: [{ role: 'user', content: 'schedule a sync' }],
+        messages: [{ role: 'user', content: 'schedule a refresh' }],
       } as never,
       {} as never,
     );

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.runtimeInterop.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.runtimeInterop.int.test.ts
@@ -1,0 +1,152 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+describe('agent-portfolio-manager runtime interop', () => {
+  it(
+    'serves the initial hire run when started through tsx package resolution',
+    async () => {
+      const packageRoot = process.cwd();
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), 'agent-portfolio-manager-runtime-interop-'));
+      const scriptPath = path.join(tempDir, 'runtime-interop.mjs');
+      const agUiServerUrl = pathToFileURL(path.join(packageRoot, 'src', 'agUiServer.ts')).href;
+      const sharedEmberAdapterUrl = pathToFileURL(
+        path.join(packageRoot, 'src', 'sharedEmberAdapter.ts'),
+      ).href;
+
+      try {
+        await writeFile(
+          scriptPath,
+          `
+import {
+  createPortfolioManagerAgUiHandler,
+  createPortfolioManagerGatewayService,
+  PORTFOLIO_MANAGER_AGENT_ID,
+} from ${JSON.stringify(agUiServerUrl)};
+import { createPortfolioManagerDomain } from ${JSON.stringify(sharedEmberAdapterUrl)};
+
+const service = await createPortfolioManagerGatewayService({
+  runtimeConfig: {
+    model: {
+      id: 'openai/gpt-5.4-mini',
+      name: 'openai/gpt-5.4-mini',
+      api: 'openai-responses',
+      provider: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      reasoning: true,
+    },
+    systemPrompt: 'Portfolio manager runtime interop test.',
+    tools: [],
+    domain: createPortfolioManagerDomain({
+      protocolHost: {
+        handleJsonRpc: async () => {
+          throw new Error('Unexpected Shared Ember JSON-RPC request during hire flow.');
+        },
+        readCommittedEventOutbox: async () => ({
+          protocol_version: 'v1',
+          revision: 0,
+          events: [],
+        }),
+        acknowledgeCommittedEventOutbox: async () => ({
+          protocol_version: 'v1',
+          revision: 0,
+          consumer_id: 'portfolio-manager',
+          acknowledged_through_sequence: 0,
+        }),
+      },
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x3b32650cefcb53bf0365058c5576d70226225fc4',
+    }),
+    agentOptions: {
+      initialState: {
+        thinkingLevel: 'low',
+      },
+      getApiKey: () => 'test-openrouter-key',
+    },
+  },
+  __internalPostgres: {
+    ensureReady: async () => ({
+      databaseUrl: 'postgresql://postgres:postgres@127.0.0.1:55432/pi_runtime',
+    }),
+    loadInspectionState: async () => ({
+      threads: [],
+      executions: [],
+      automations: [],
+      automationRuns: [],
+      interrupts: [],
+      leases: [],
+      outboxIntents: [],
+      executionEvents: [],
+      threadActivities: [],
+    }),
+    executeStatements: async () => undefined,
+    persistDirectExecution: async () => undefined,
+  },
+});
+
+const handler = createPortfolioManagerAgUiHandler({
+  agentId: PORTFOLIO_MANAGER_AGENT_ID,
+  service,
+});
+
+const response = await handler(new Request('http://127.0.0.1/ag-ui/agent/agent-portfolio-manager/run', {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+  },
+  body: JSON.stringify({
+    threadId: 'thread-runtime-interop-1',
+    runId: 'run-runtime-interop-1',
+    forwardedProps: {
+      command: {
+        name: 'hire',
+      },
+    },
+  }),
+  duplex: 'half',
+}));
+
+console.log('status', response.status);
+console.log(await response.text());
+          `,
+          'utf8',
+        );
+
+        const child = spawn(process.execPath, ['./node_modules/tsx/dist/cli.mjs', scriptPath], {
+          cwd: packageRoot,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf8');
+        child.stderr.setEncoding('utf8');
+        child.stdout.on('data', (chunk) => {
+          stdout += chunk;
+        });
+        child.stderr.on('data', (chunk) => {
+          stderr += chunk;
+        });
+
+        const [exitCode] = (await once(child, 'close')) as [number | null, NodeJS.Signals | null];
+
+        expect({
+          exitCode,
+          stdout,
+          stderr,
+        }).toMatchObject({
+          exitCode: 0,
+        });
+        expect(stdout).toContain('status 200');
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -107,7 +107,21 @@ function createOnboardingBootstrap() {
         },
       },
     ],
-    userReservePolicies: [],
+    userReservePolicies: [
+      {
+        reserve_policy_ref: 'reserve-policy-ember-lending-protocol-001',
+        summary: 'allow managed lending to admit allocable idle USDC',
+        user_reserve_rules: [
+          {
+            root_asset: 'USDC',
+            network: 'arbitrum',
+            benchmark_asset: 'USD',
+            reserved_quantity: '0',
+            reason: 'allow managed lending to admit allocable idle USDC',
+          },
+        ],
+      },
+    ],
     activation: {
       mandateRef: 'mandate-ember-lending-protocol-001',
     },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -1124,6 +1124,12 @@ function buildPortfolioManagerOnboardingBlockedMessage(input: {
   return `Portfolio manager onboarding is not complete. Shared Ember onboarding phase is ${input.onboardingDetails.onboarding.phase}.${missingProofs.length > 0 ? ` Missing proofs: ${missingProofs.join(', ')}.` : ''}`;
 }
 
+function buildManagedReservePolicySummary(input: {
+  managedMandate: ManagedMandate;
+}): string {
+  return `allow managed lending to admit allocable idle ${input.managedMandate.asset_intent.root_asset}`;
+}
+
 function buildPortfolioManagerOnboardingBootstrap(params: {
   agentId: string;
   threadId: string;
@@ -1137,6 +1143,9 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
   const firstManagedMandate = params.approvedSetup.firstManagedMandate;
   const managedAgentKeySegment = sanitizeIdentitySegment(firstManagedMandate.targetAgentKey);
   const managedAgentMandateRef = `mandate-${managedAgentKeySegment}-${identity}`;
+  const reservePolicySummary = buildManagedReservePolicySummary({
+    managedMandate: firstManagedMandate.managedMandate,
+  });
 
   return {
     occurredAt: PORTFOLIO_MANAGER_BOOTSTRAP_TIMESTAMP,
@@ -1167,7 +1176,21 @@ function buildPortfolioManagerOnboardingBootstrap(params: {
         managed_mandate: firstManagedMandate.managedMandate,
       },
     ],
-    userReservePolicies: [],
+    userReservePolicies: [
+      {
+        reserve_policy_ref: `reserve-policy-${managedAgentKeySegment}-${identity}`,
+        summary: reservePolicySummary,
+        user_reserve_rules: [
+          {
+            root_asset: firstManagedMandate.managedMandate.asset_intent.root_asset,
+            network: firstManagedMandate.managedMandate.asset_intent.network,
+            benchmark_asset: firstManagedMandate.managedMandate.asset_intent.benchmark_asset,
+            reserved_quantity: '0',
+            reason: reservePolicySummary,
+          },
+        ],
+      },
+    ],
     activation: {
       mandateRef: managedAgentMandateRef,
     },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -170,7 +170,21 @@ function createOnboardingBootstrap() {
         },
       },
     ],
-    userReservePolicies: [],
+    userReservePolicies: [
+      {
+        reserve_policy_ref: 'reserve-policy-ember-lending-protocol-001',
+        summary: 'allow managed lending to admit allocable idle USDC',
+        user_reserve_rules: [
+          {
+            root_asset: 'USDC',
+            network: 'arbitrum',
+            benchmark_asset: 'USD',
+            reserved_quantity: '0',
+            reason: 'allow managed lending to admit allocable idle USDC',
+          },
+        ],
+      },
+    ],
     activation: {
       mandateRef: 'mandate-ember-lending-protocol-001',
     },
@@ -615,7 +629,21 @@ describe('createPortfolioManagerDomain', () => {
                 },
               }),
             }),
-            userReservePolicies: [],
+            userReservePolicies: [
+              {
+                reserve_policy_ref: expect.stringContaining('reserve-policy-'),
+                summary: 'allow managed lending to admit allocable idle USDC',
+                user_reserve_rules: [
+                  {
+                    root_asset: 'USDC',
+                    network: 'arbitrum',
+                    benchmark_asset: 'USD',
+                    reserved_quantity: '0',
+                    reason: 'allow managed lending to admit allocable idle USDC',
+                  },
+                ],
+              },
+            ],
             mandates: [
               {
                 mandate_ref: expect.stringContaining('mandate-'),

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/commandEnvelope.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/commandEnvelope.ts
@@ -1,71 +1,44 @@
-type MessageRecord = {
-  content?: unknown;
-};
-
 export type CommandEnvelope<TCommand extends string = string> = {
   command: TCommand;
   clientMutationId?: string;
 };
 
-function getLastMessageContent(messages: unknown): string | null {
-  if (!messages) {
-    return null;
-  }
-
-  const list: unknown[] = Array.isArray(messages) ? messages : [messages];
-  if (list.length === 0) {
-    return null;
-  }
-
-  const lastMessage = list[list.length - 1];
-  if (typeof lastMessage === 'string') {
-    return lastMessage;
-  }
-  if (Array.isArray(lastMessage)) {
-    return null;
-  }
-  if (typeof lastMessage === 'object' && lastMessage !== null && 'content' in lastMessage) {
-    const value = (lastMessage as MessageRecord).content;
-    return typeof value === 'string' ? value : null;
-  }
-
-  return null;
-}
-
-export function extractCommandEnvelopeFromMessages<TCommand extends string>(params: {
-  messages: unknown;
+function extractCommandEnvelopeFromValue<TCommand extends string>(params: {
+  value: unknown;
   isCommand: (value: string) => value is TCommand;
 }): CommandEnvelope<TCommand> | null {
-  const content = getLastMessageContent(params.messages);
-  if (!content) {
+  if (typeof params.value !== 'object' || params.value === null || Array.isArray(params.value)) {
     return null;
   }
 
-  try {
-    const parsed = JSON.parse(content) as unknown;
-    if (typeof parsed !== 'object' || parsed === null || !('command' in parsed)) {
-      return null;
-    }
-    const command = (parsed as { command?: unknown }).command;
-    if (typeof command !== 'string' || !params.isCommand(command)) {
-      return null;
-    }
-
-    const clientMutationId = (parsed as { clientMutationId?: unknown }).clientMutationId;
-    return {
-      command,
-      ...(typeof clientMutationId === 'string' && clientMutationId.length > 0
-        ? { clientMutationId }
-        : {}),
-    };
-  } catch {
+  if (!('command' in params.value)) {
     return null;
   }
+
+  const command = (params.value as { command?: unknown }).command;
+  if (typeof command !== 'string' || !params.isCommand(command)) {
+    return null;
+  }
+
+  const clientMutationId = (params.value as { clientMutationId?: unknown }).clientMutationId;
+  return {
+    command,
+    ...(typeof clientMutationId === 'string' && clientMutationId.length > 0
+      ? { clientMutationId }
+      : {}),
+  };
 }
 
-export function extractCommandFromMessages<TCommand extends string>(params: {
-  messages: unknown;
+export function extractCommandEnvelope<TCommand extends string>(params: {
+  value: unknown;
+  isCommand: (value: string) => value is TCommand;
+}): CommandEnvelope<TCommand> | null {
+  return extractCommandEnvelopeFromValue(params);
+}
+
+export function extractCommand<TCommand extends string>(params: {
+  value: unknown;
   isCommand: (value: string) => value is TCommand;
 }): TCommand | null {
-  return extractCommandEnvelopeFromMessages(params)?.command ?? null;
+  return extractCommandEnvelopeFromValue(params)?.command ?? null;
 }

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/commandRouting.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/commandRouting.ts
@@ -32,7 +32,7 @@ export function resolveCommandReplayGuardState(input: {
   suppressDuplicateCommand: boolean;
   lastAppliedCommandMutationId?: string;
 } {
-  if (!input.parsedCommand || input.parsedCommand === 'sync') {
+  if (!input.parsedCommand || input.parsedCommand === 'refresh') {
     return {
       suppressDuplicateCommand: false,
       lastAppliedCommandMutationId: input.lastAppliedCommandMutationId,
@@ -77,7 +77,7 @@ export function resolveCommandTargetForBootstrappedFlow(input: {
         bootstrapped: input.bootstrapped,
         onboardingReady: true,
       });
-    case 'sync':
+    case 'refresh':
       return input.bootstrapped ? 'syncState' : 'bootstrap';
     default:
       return '__end__';

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/commandRouting.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/commandRouting.unit.test.ts
@@ -8,12 +8,12 @@ import {
 } from './commandRouting';
 
 describe('commandRouting', () => {
-  it('returns explicit sync command without falling back to persisted thread command', () => {
+  it('returns explicit refresh command without falling back to persisted thread command', () => {
     expect(
       resolveRunCommandForThread({
-        parsedCommand: 'sync',
+        parsedCommand: 'refresh',
       }),
-    ).toBe('sync');
+    ).toBe('refresh');
   });
 
   it('does not fall back to persisted command when no command is parsed', () => {
@@ -42,10 +42,10 @@ describe('commandRouting', () => {
     expect(resolveCommandTargetForBootstrappedFlow({ resolvedCommand: 'cycle', bootstrapped: false })).toBe(
       'bootstrap',
     );
-    expect(resolveCommandTargetForBootstrappedFlow({ resolvedCommand: 'sync', bootstrapped: false })).toBe(
+    expect(resolveCommandTargetForBootstrappedFlow({ resolvedCommand: 'refresh', bootstrapped: false })).toBe(
       'bootstrap',
     );
-    expect(resolveCommandTargetForBootstrappedFlow({ resolvedCommand: 'sync', bootstrapped: true })).toBe(
+    expect(resolveCommandTargetForBootstrappedFlow({ resolvedCommand: 'refresh', bootstrapped: true })).toBe(
       'syncState',
     );
   });
@@ -82,7 +82,7 @@ describe('commandRouting', () => {
     ).toBe('__end__');
   });
 
-  it('suppresses replayed non-sync command envelopes when clientMutationId is unchanged', () => {
+  it('suppresses replayed non-refresh command envelopes when clientMutationId is unchanged', () => {
     expect(
       resolveCommandReplayGuardState({
         parsedCommand: 'cycle',
@@ -95,7 +95,7 @@ describe('commandRouting', () => {
     });
   });
 
-  it('does not suppress first-seen non-sync command envelopes and records mutation id', () => {
+  it('does not suppress first-seen non-refresh command envelopes and records mutation id', () => {
     expect(
       resolveCommandReplayGuardState({
         parsedCommand: 'hire',
@@ -107,16 +107,16 @@ describe('commandRouting', () => {
     });
   });
 
-  it('ignores replay suppression for sync commands', () => {
+  it('ignores replay suppression for refresh commands', () => {
     expect(
       resolveCommandReplayGuardState({
-        parsedCommand: 'sync',
-        clientMutationId: 'sync-1',
-        lastAppliedCommandMutationId: 'sync-1',
+        parsedCommand: 'refresh',
+        clientMutationId: 'refresh-1',
+        lastAppliedCommandMutationId: 'refresh-1',
       }),
     ).toEqual({
       suppressDuplicateCommand: false,
-      lastAppliedCommandMutationId: 'sync-1',
+      lastAppliedCommandMutationId: 'refresh-1',
     });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/index.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/index.ts
@@ -1,7 +1,9 @@
 export {
   AGENT_COMMANDS,
-  extractCommandEnvelopeFromMessages,
-  extractCommandFromMessages,
+  buildPendingCommandStateValues,
+  buildRunCommandStateUpdate,
+  extractCommandEnvelope,
+  extractCommand,
   type AgentCommand,
   type CommandEnvelope,
 } from './taskLifecycle.js';

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.ts
@@ -1,6 +1,6 @@
 import {
-  extractCommandEnvelopeFromMessages as extractRuntimeCommandEnvelopeFromMessages,
-  extractCommandFromMessages as extractRuntimeCommandFromMessages,
+  extractCommandEnvelope as extractRuntimeCommandEnvelope,
+  extractCommand as extractRuntimeCommand,
 } from './commandEnvelope.js';
 import type { CommandEnvelope } from './commandEnvelope.js';
 
@@ -15,18 +15,55 @@ function isAgentCommand(value: string): value is AgentCommand {
   return AGENT_COMMAND_SET.has(value);
 }
 
-export function extractCommandEnvelopeFromMessages(
-  messages: unknown,
-): CommandEnvelope<AgentCommand> | null {
-  return extractRuntimeCommandEnvelopeFromMessages({
-    messages,
+export function extractCommandEnvelope(value: unknown): CommandEnvelope<AgentCommand> | null {
+  return extractRuntimeCommandEnvelope({
+    value,
     isCommand: isAgentCommand,
   });
 }
 
-export function extractCommandFromMessages(messages: unknown): AgentCommand | null {
-  return extractRuntimeCommandFromMessages({
-    messages,
+export function extractCommand(value: unknown): AgentCommand | null {
+  return extractRuntimeCommand({
+    value,
     isCommand: isAgentCommand,
   });
+}
+
+type PendingCommandStateValues<TCommand extends string> = {
+  private: {
+    pendingCommand: CommandEnvelope<TCommand>;
+  };
+  thread?: Record<string, unknown>;
+};
+
+export function buildPendingCommandStateValues<TCommand extends AgentCommand>(params: {
+  command: TCommand;
+  clientMutationId?: string;
+  thread?: Record<string, unknown>;
+}): PendingCommandStateValues<TCommand> {
+  const pendingCommand: CommandEnvelope<TCommand> = {
+    command: params.command,
+    ...(params.clientMutationId ? { clientMutationId: params.clientMutationId } : {}),
+  };
+
+  return {
+    private: {
+      pendingCommand,
+    },
+    ...(params.thread ? { thread: params.thread } : {}),
+  };
+}
+
+export function buildRunCommandStateUpdate<TCommand extends AgentCommand>(params: {
+  command: TCommand;
+  clientMutationId?: string;
+  thread?: Record<string, unknown>;
+}): {
+  as_node: 'runCommand';
+  values: PendingCommandStateValues<TCommand>;
+} {
+  return {
+    as_node: 'runCommand',
+    values: buildPendingCommandStateValues(params),
+  };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.ts
@@ -6,7 +6,7 @@ import type { CommandEnvelope } from './commandEnvelope.js';
 
 export type { CommandEnvelope } from './commandEnvelope.js';
 
-export const AGENT_COMMANDS = ['hire', 'fire', 'cycle', 'sync'] as const;
+export const AGENT_COMMANDS = ['hire', 'fire', 'cycle', 'refresh'] as const;
 export type AgentCommand = (typeof AGENT_COMMANDS)[number];
 
 const AGENT_COMMAND_SET = new Set<string>(AGENT_COMMANDS);

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.unit.test.ts
@@ -11,25 +11,25 @@ import {
 describe('taskLifecycle', () => {
   it('extracts supported commands from a normalized workflow command envelope', () => {
     const parsed = extractCommand({
-      command: 'sync',
+      command: 'refresh',
     });
-    expect(parsed).toBe('sync');
+    expect(parsed).toBe('refresh');
   });
 
   it('extracts command envelope metadata from a normalized workflow command envelope', () => {
     const parsed = extractCommandEnvelope({
-      command: 'sync',
+      command: 'refresh',
       clientMutationId: 'mutation-1',
     });
     expect(parsed).toEqual({
-      command: 'sync',
+      command: 'refresh',
       clientMutationId: 'mutation-1',
     });
   });
 
   it('returns null for unsupported or malformed normalized command envelopes', () => {
     expect(extractCommand({ command: 'oops' })).toBeNull();
-    expect(extractCommand('{"command":"sync"}')).toBeNull();
+    expect(extractCommand('{"command":"refresh"}')).toBeNull();
   });
 
   it('builds private pending-command state values for direct workflow command routing', () => {
@@ -53,16 +53,16 @@ describe('taskLifecycle', () => {
   it('builds runCommand state update payloads without legacy message input', () => {
     expect(
       buildRunCommandStateUpdate({
-        command: 'sync',
-        clientMutationId: 'sync-1',
+        command: 'refresh',
+        clientMutationId: 'refresh-1',
       }),
     ).toEqual({
       as_node: 'runCommand',
       values: {
         private: {
           pendingCommand: {
-            command: 'sync',
-            clientMutationId: 'sync-1',
+            command: 'refresh',
+            clientMutationId: 'refresh-1',
           },
         },
       },
@@ -70,6 +70,6 @@ describe('taskLifecycle', () => {
   });
 
   it('exports the canonical command vocabulary', () => {
-    expect(AGENT_COMMANDS).toEqual(['hire', 'fire', 'cycle', 'sync']);
+    expect(AGENT_COMMANDS).toEqual(['hire', 'fire', 'cycle', 'refresh']);
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/taskLifecycle.unit.test.ts
@@ -2,35 +2,71 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AGENT_COMMANDS,
-  extractCommandEnvelopeFromMessages,
-  extractCommandFromMessages,
+  buildPendingCommandStateValues,
+  buildRunCommandStateUpdate,
+  extractCommand,
+  extractCommandEnvelope,
 } from './taskLifecycle';
 
 describe('taskLifecycle', () => {
-  it('extracts supported commands from last message content', () => {
-    const parsed = extractCommandFromMessages([
-      {
-        content: JSON.stringify({ command: 'sync' }),
-      },
-    ]);
+  it('extracts supported commands from a normalized workflow command envelope', () => {
+    const parsed = extractCommand({
+      command: 'sync',
+    });
     expect(parsed).toBe('sync');
   });
 
-  it('extracts command envelope metadata from last message content', () => {
-    const parsed = extractCommandEnvelopeFromMessages([
-      {
-        content: JSON.stringify({ command: 'sync', clientMutationId: 'mutation-1' }),
-      },
-    ]);
+  it('extracts command envelope metadata from a normalized workflow command envelope', () => {
+    const parsed = extractCommandEnvelope({
+      command: 'sync',
+      clientMutationId: 'mutation-1',
+    });
     expect(parsed).toEqual({
       command: 'sync',
       clientMutationId: 'mutation-1',
     });
   });
 
-  it('returns null for unsupported or malformed commands', () => {
-    expect(extractCommandFromMessages([{ content: '{"command":"oops"}' }])).toBeNull();
-    expect(extractCommandFromMessages([{ content: '{not-json' }])).toBeNull();
+  it('returns null for unsupported or malformed normalized command envelopes', () => {
+    expect(extractCommand({ command: 'oops' })).toBeNull();
+    expect(extractCommand('{"command":"sync"}')).toBeNull();
+  });
+
+  it('builds private pending-command state values for direct workflow command routing', () => {
+    expect(
+      buildPendingCommandStateValues({
+        command: 'cycle',
+        clientMutationId: 'cycle-1',
+        thread: { lifecycle: { phase: 'active' } },
+      }),
+    ).toEqual({
+      private: {
+        pendingCommand: {
+          command: 'cycle',
+          clientMutationId: 'cycle-1',
+        },
+      },
+      thread: { lifecycle: { phase: 'active' } },
+    });
+  });
+
+  it('builds runCommand state update payloads without legacy message input', () => {
+    expect(
+      buildRunCommandStateUpdate({
+        command: 'sync',
+        clientMutationId: 'sync-1',
+      }),
+    ).toEqual({
+      as_node: 'runCommand',
+      values: {
+        private: {
+          pendingCommand: {
+            command: 'sync',
+            clientMutationId: 'sync-1',
+          },
+        },
+      },
+    });
   });
 
   it('exports the canonical command vocabulary', () => {

--- a/typescript/clients/web-ag-ui/apps/agent/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/agent.ts
@@ -5,7 +5,7 @@ import {
   configureLangGraphApiCheckpointer,
   isLangGraphBusyStatus,
 } from 'agent-runtime-langgraph';
-import { projectCycleCommandThread } from 'agent-workflow-core';
+import { buildRunCommandStateUpdate, projectCycleCommandThread } from 'agent-workflow-core';
 import { v7 as uuidv7 } from 'uuid';
 import { z } from 'zod';
 
@@ -41,7 +41,7 @@ function resolvePostBootstrap(
   | 'collectDelegations'
   | 'prepareOperator'
   | 'syncState' {
-  const command = extractCommand(state.messages);
+  const command = extractCommand(state.private.activeCommand);
   if (command === 'sync') {
     return 'syncState';
   }
@@ -187,7 +187,7 @@ async function ensureThread(baseUrl: string, threadId: string, graphId: string) 
 async function updateCycleState(
   baseUrl: string,
   threadId: string,
-  runMessage: { id: string; role: 'user'; content: string },
+  cycleCommand: { command: 'cycle'; clientMutationId?: string },
 ): Promise<boolean> {
   let existingThread: Record<string, unknown> | null = null;
   try {
@@ -205,10 +205,12 @@ async function updateCycleState(
   const response = await fetch(`${baseUrl}/threads/${threadId}/state`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      values: { messages: [runMessage], thread },
-      as_node: 'runCommand',
-    }),
+    body: JSON.stringify(
+      buildRunCommandStateUpdate({
+        ...cycleCommand,
+        thread,
+      }),
+    ),
   });
   if (isLangGraphBusyStatus(response.status)) {
     const payloadText = await response.text();
@@ -297,10 +299,8 @@ export async function runGraphOnce(
   const startedAt = Date.now();
   console.info(`[cron] Starting mock CLMM graph run via API (thread=${threadId})`);
 
-  const runMessage = {
-    id: uuidv7(),
-    role: 'user' as const,
-    content: JSON.stringify({ command: 'cycle' }),
+  const cycleCommand = {
+    command: 'cycle' as const,
   };
 
   const baseUrl = resolveLangGraphDeploymentUrl();
@@ -310,7 +310,7 @@ export async function runGraphOnce(
 
   try {
     await ensureThread(baseUrl, threadId, graphId);
-    const stateUpdated = await updateCycleState(baseUrl, threadId, runMessage);
+    const stateUpdated = await updateCycleState(baseUrl, threadId, cycleCommand);
     if (!stateUpdated) {
       return;
     }

--- a/typescript/clients/web-ag-ui/apps/agent/src/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/agent.ts
@@ -42,7 +42,7 @@ function resolvePostBootstrap(
   | 'prepareOperator'
   | 'syncState' {
   const command = extractCommand(state.private.activeCommand);
-  if (command === 'sync') {
+  if (command === 'refresh') {
     return 'syncState';
   }
   if (!state.thread.poolArtifact) {

--- a/typescript/clients/web-ag-ui/apps/agent/src/cronApiRunner.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/cronApiRunner.ts
@@ -1,20 +1,13 @@
 import { pathToFileURL } from 'node:url';
 
+import { buildPendingCommandStateValues } from 'agent-workflow-core';
 import cron from 'node-cron';
 import { v7 as uuidv7 } from 'uuid';
 import { z } from 'zod';
 
-type MessageInput = {
-  id: string;
-  role: 'user';
-  content: string;
-};
-
 type RunCreatePayload = {
   assistant_id: string;
-  input?: {
-    messages: MessageInput[];
-  };
+  input?: Record<string, unknown>;
   config?: {
     configurable?: {
       thread_id?: string;
@@ -91,20 +84,14 @@ const resolveThreadId = () => process.env.STARTER_THREAD_ID ?? uuidv7();
 const resolveIntervalMs = () =>
   parseNumber(process.env.STARTER_CRON_INTERVAL_MS) ?? DEFAULT_INTERVAL_MS;
 
-const buildCycleMessage = (): MessageInput => ({
-  id: uuidv7(),
-  role: 'user',
-  content: JSON.stringify({ command: 'cycle' }),
-});
-
 const buildRunPayload = (params: {
   graphId: string;
   threadId: string;
 }): RunCreatePayload => ({
   assistant_id: params.graphId,
-  input: {
-    messages: [buildCycleMessage()],
-  },
+  input: buildPendingCommandStateValues({
+    command: 'cycle',
+  }),
   config: {
     configurable: {
       thread_id: params.threadId,

--- a/typescript/clients/web-ag-ui/apps/agent/src/workflow/context.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/workflow/context.ts
@@ -2,6 +2,8 @@ import type { AIMessage as CopilotKitAIMessage } from '@copilotkit/shared';
 import { type Artifact } from '@emberai/agent-node/workflow';
 import { Annotation } from '@langchain/langgraph';
 import {
+  type AgentCommand,
+  type CommandEnvelope,
   createMessageHistoryReducer,
   isTaskActiveState,
   isTaskTerminalState,
@@ -50,6 +52,8 @@ export type ClmmPrivateState = {
   streamLimit: number;
   cronScheduled: boolean;
   bootstrapped: boolean;
+  pendingCommand?: CommandEnvelope<AgentCommand> | null;
+  activeCommand?: AgentCommand | null;
   suppressDuplicateCommand?: boolean;
   lastAppliedCommandMutationId?: string;
 };
@@ -215,6 +219,8 @@ const defaultPrivateState = (): ClmmPrivateState => ({
   streamLimit: resolveStreamLimit(),
   cronScheduled: false,
   bootstrapped: false,
+  pendingCommand: null,
+  activeCommand: null,
   suppressDuplicateCommand: false,
   lastAppliedCommandMutationId: undefined,
 });
@@ -277,6 +283,14 @@ const mergePrivateState = (
   streamLimit: right?.streamLimit ?? left.streamLimit ?? resolveStreamLimit(),
   cronScheduled: right?.cronScheduled ?? left.cronScheduled ?? false,
   bootstrapped: right?.bootstrapped ?? left.bootstrapped ?? false,
+  pendingCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'pendingCommand')
+      ? right.pendingCommand ?? null
+      : left.pendingCommand ?? null,
+  activeCommand:
+    right && Object.prototype.hasOwnProperty.call(right, 'activeCommand')
+      ? right.activeCommand ?? null
+      : left.activeCommand ?? null,
   suppressDuplicateCommand: right?.suppressDuplicateCommand ?? left.suppressDuplicateCommand ?? false,
   lastAppliedCommandMutationId:
     right?.lastAppliedCommandMutationId ?? left.lastAppliedCommandMutationId,

--- a/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.ts
@@ -31,7 +31,7 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
     lastAppliedCommandMutationId: state.private.lastAppliedCommandMutationId,
   });
   const lastAppliedClientMutationId =
-    parsedCommand === 'sync'
+    parsedCommand === 'refresh'
       ? commandEnvelope?.clientMutationId ?? state.thread.lastAppliedClientMutationId
       : state.thread.lastAppliedClientMutationId;
 

--- a/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.ts
@@ -1,6 +1,5 @@
 import {
-  extractCommandEnvelopeFromMessages,
-  extractCommandFromMessages,
+  extractCommandEnvelope as extractWorkflowCommandEnvelope,
   resolveCommandReplayGuardState,
   resolveCycleCommandTarget,
   resolveCommandTargetForBootstrappedFlow,
@@ -13,16 +12,18 @@ import { type ClmmState, type ClmmUpdate } from '../context.js';
 
 type CommandTarget = CommandRoutingTarget;
 
-export function extractCommandEnvelope(messages: ClmmState['messages']): CommandEnvelope<AgentCommand> | null {
-  return extractCommandEnvelopeFromMessages(messages);
+export function extractCommandEnvelope(
+  pendingCommand: ClmmState['private']['pendingCommand'],
+): CommandEnvelope<AgentCommand> | null {
+  return extractWorkflowCommandEnvelope(pendingCommand);
 }
 
-export function extractCommand(messages: ClmmState['messages']): AgentCommand | null {
-  return extractCommandFromMessages(messages);
+export function extractCommand(activeCommand: ClmmState['private']['activeCommand']): AgentCommand | null {
+  return activeCommand ?? null;
 }
 
 export function runCommandNode(state: ClmmState): ClmmUpdate {
-  const commandEnvelope = extractCommandEnvelope(state.messages);
+  const commandEnvelope = extractCommandEnvelope(state.private.pendingCommand);
   const parsedCommand = commandEnvelope?.command ?? null;
   const replayGuardState = resolveCommandReplayGuardState({
     parsedCommand,
@@ -36,6 +37,8 @@ export function runCommandNode(state: ClmmState): ClmmUpdate {
 
   return {
     private: {
+      pendingCommand: null,
+      activeCommand: parsedCommand,
       suppressDuplicateCommand: replayGuardState.suppressDuplicateCommand,
       lastAppliedCommandMutationId: replayGuardState.lastAppliedCommandMutationId,
     },
@@ -66,7 +69,7 @@ export function resolveCommandTarget(state: ClmmState): CommandTarget {
     return '__end__';
   }
 
-  const resolvedCommand = extractCommand(state.messages);
+  const resolvedCommand = extractCommand(state.private.activeCommand);
   if (resolvedCommand === 'cycle') {
     return resolveCycleCommandTarget({
       bootstrapped: state.private.bootstrapped,

--- a/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.unit.test.ts
@@ -1,11 +1,11 @@
+import { type CommandEnvelope } from 'agent-workflow-core';
 import { describe, expect, it } from 'vitest';
 
-import { type CommandEnvelope } from 'agent-workflow-core';
 import type { ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-function createState(commandEnvelope: CommandEnvelope<'hire' | 'fire' | 'cycle' | 'sync'> | null): ClmmState {
+function createState(commandEnvelope: CommandEnvelope<'hire' | 'fire' | 'cycle' | 'refresh'> | null): ClmmState {
   return {
     messages: [],
     copilotkit: { actions: [], context: [] },
@@ -47,8 +47,8 @@ function applyRunCommandUpdate(state: ClmmState): ClmmState {
 }
 
 describe('runCommandNode (starter agent)', () => {
-  it('records sync mutation acknowledgements in thread state envelope', () => {
-    const state = createState({ command: 'sync', clientMutationId: 'cmid-1' });
+  it('records refresh mutation acknowledgements in thread state envelope', () => {
+    const state = createState({ command: 'refresh', clientMutationId: 'cmid-1' });
 
     const result = runCommandNode(state) as unknown as {
       thread?: { lastAppliedClientMutationId?: string };
@@ -99,7 +99,7 @@ describe('runCommandNode (starter agent)', () => {
     expect(resolveCommandTarget(updated)).toBe('bootstrap');
   });
 
-  it('suppresses replayed non-sync command envelopes with the same clientMutationId', () => {
+  it('suppresses replayed non-refresh command envelopes with the same clientMutationId', () => {
     const state = createState({ command: 'cycle', clientMutationId: 'cycle-1' });
     state.thread.poolArtifact = {
       artifactId: 'camelot-pools',

--- a/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/src/workflow/nodes/runCommand.unit.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
+import { type CommandEnvelope } from 'agent-workflow-core';
 import type { ClmmState } from '../context.js';
 
 import { resolveCommandTarget, runCommandNode } from './runCommand.js';
 
-function createState(messageContent: string): ClmmState {
+function createState(commandEnvelope: CommandEnvelope<'hire' | 'fire' | 'cycle' | 'sync'> | null): ClmmState {
   return {
-    messages: [{ role: 'user', content: messageContent }],
+    messages: [],
     copilotkit: { actions: [], context: [] },
     settings: {},
     private: {
@@ -15,6 +16,8 @@ function createState(messageContent: string): ClmmState {
       streamLimit: -1,
       cronScheduled: false,
       bootstrapped: true,
+      pendingCommand: commandEnvelope,
+      activeCommand: null,
     },
     thread: {
       lastAppliedClientMutationId: undefined,
@@ -45,7 +48,7 @@ function applyRunCommandUpdate(state: ClmmState): ClmmState {
 
 describe('runCommandNode (starter agent)', () => {
   it('records sync mutation acknowledgements in thread state envelope', () => {
-    const state = createState(JSON.stringify({ command: 'sync', clientMutationId: 'cmid-1' }));
+    const state = createState({ command: 'sync', clientMutationId: 'cmid-1' });
 
     const result = runCommandNode(state) as unknown as {
       thread?: { lastAppliedClientMutationId?: string };
@@ -55,13 +58,14 @@ describe('runCommandNode (starter agent)', () => {
   });
 
   it('suppresses cycle commands while onboarding is incomplete', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
+    const updated = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('syncState');
+    expect(resolveCommandTarget(updated)).toBe('syncState');
   });
 
   it('routes cycle commands once onboarding is complete', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
     state.thread.poolArtifact = {
       artifactId: 'camelot-pools',
       parts: [],
@@ -82,18 +86,21 @@ describe('runCommandNode (starter agent)', () => {
       manualBandwidthBps: 125,
     };
 
-    expect(resolveCommandTarget(state)).toBe('runCycleCommand');
+    const updated = applyRunCommandUpdate(state);
+
+    expect(resolveCommandTarget(updated)).toBe('runCycleCommand');
   });
 
   it('routes cycle to bootstrap when thread is not bootstrapped', () => {
-    const state = createState(JSON.stringify({ command: 'cycle' }));
+    const state = createState({ command: 'cycle' });
     state.private.bootstrapped = false;
+    const updated = applyRunCommandUpdate(state);
 
-    expect(resolveCommandTarget(state)).toBe('bootstrap');
+    expect(resolveCommandTarget(updated)).toBe('bootstrap');
   });
 
   it('suppresses replayed non-sync command envelopes with the same clientMutationId', () => {
-    const state = createState(JSON.stringify({ command: 'cycle', clientMutationId: 'cycle-1' }));
+    const state = createState({ command: 'cycle', clientMutationId: 'cycle-1' });
     state.thread.poolArtifact = {
       artifactId: 'camelot-pools',
       parts: [],

--- a/typescript/clients/web-ag-ui/apps/agent/tests/runGraphOnce.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent/tests/runGraphOnce.int.test.ts
@@ -50,6 +50,25 @@ describe('runGraphOnce integration', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return new Response('busy', { status: 409 });
       }
       throw new Error(`Unexpected fetch call: ${method} ${url}`);
@@ -82,6 +101,25 @@ describe('runGraphOnce integration', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -118,6 +156,25 @@ describe('runGraphOnce integration', () => {
         return jsonResponse({ values: { thread: {} } });
       }
       if (url.endsWith('/threads/thread-1/state') && method === 'POST') {
+        if (!init || typeof init !== 'object' || !('body' in init)) {
+          throw new Error('Missing request body');
+        }
+        const bodyText = (init as { body?: unknown }).body;
+        if (typeof bodyText !== 'string') {
+          throw new Error('Expected string request body');
+        }
+        const body = JSON.parse(bodyText) as {
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+          };
+        };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }
       if (url.endsWith('/threads/thread-1/runs') && method === 'POST') {
@@ -203,8 +260,18 @@ describe('runGraphOnce integration', () => {
           throw new Error('Expected string request body');
         }
         const body = JSON.parse(bodyText) as {
-          values?: { thread?: { task?: { taskStatus?: { state?: string } } } };
+          values?: {
+            messages?: unknown[];
+            private?: {
+              pendingCommand?: {
+                command?: string;
+              };
+            };
+            thread?: { task?: { taskStatus?: { state?: string } } };
+          };
         };
+        expect(body.values?.private?.pendingCommand?.command).toBe('cycle');
+        expect(body.values?.messages).toBeUndefined();
         expect(body.values?.thread?.task?.taskStatus?.state).toBe('working');
         return jsonResponse({ checkpoint_id: 'cp-1' });
       }

--- a/typescript/clients/web-ag-ui/apps/web/.env.example
+++ b/typescript/clients/web-ag-ui/apps/web/.env.example
@@ -13,7 +13,7 @@ NEXT_PUBLIC_DELEGATIONS_BYPASS=false
 # Optional: enable extra mock Hire Agents rows for pagination QA.
 NEXT_PUBLIC_ENABLE_HIRE_AGENTS_PAGINATION_MOCKS=false
 
-# Optional: polling intervals (ms) for sync refresh.
+# Optional: polling intervals (ms) for refresh.
 # NEXT_PUBLIC_AGENT_LIST_SYNC_POLL_MS=15000
 # NEXT_PUBLIC_AGENT_DETAIL_SYNC_POLL_MS=5000
 

--- a/typescript/clients/web-ag-ui/apps/web/README.md
+++ b/typescript/clients/web-ag-ui/apps/web/README.md
@@ -25,7 +25,7 @@ pnpm lint:fix
 
 Optional configuration:
 
-- `NEXT_PUBLIC_AGENT_LIST_SYNC_POLL_MS` — polling interval (ms) for list-page sync refresh. Defaults to `15000`.
+- `NEXT_PUBLIC_AGENT_LIST_SYNC_POLL_MS` — polling interval (ms) for list-page refresh. Defaults to `15000`.
 
 ### E2E Profiles
 

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/langGraphInterruptSnapshotAgent.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/langGraphInterruptSnapshotAgent.ts
@@ -8,8 +8,17 @@ type PrepareStreamInput = Parameters<CopilotKitLangGraphAgent['prepareStream']>[
 type PrepareStreamMode = Parameters<CopilotKitLangGraphAgent['prepareStream']>[1];
 type PrepareStreamResult = Awaited<ReturnType<CopilotKitLangGraphAgent['prepareStream']>>;
 
+type PendingWorkflowCommandEnvelope = {
+  command: string;
+  clientMutationId?: string;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function readInterruptTypesFromState(state: LangGraphThreadState | undefined): string[] {
@@ -62,6 +71,54 @@ function readResumeShape(input: PrepareStreamInput): {
   };
 }
 
+function translateNamedWorkflowCommand(command: Record<string, unknown>): Record<string, unknown> | null {
+  const name = readString(command.name);
+  if (!name) {
+    return null;
+  }
+
+  const pendingCommand: PendingWorkflowCommandEnvelope = {
+    command: name,
+  };
+  const clientMutationId = readString(command.clientMutationId);
+  if (clientMutationId) {
+    pendingCommand.clientMutationId = clientMutationId;
+  }
+
+  return {
+    update: {
+      private: {
+        pendingCommand,
+      },
+    },
+  };
+}
+
+function translatePrepareStreamInput(input: PrepareStreamInput): PrepareStreamInput {
+  const forwardedProps = isRecord(input.forwardedProps) ? input.forwardedProps : null;
+  const command = forwardedProps && isRecord(forwardedProps.command) ? forwardedProps.command : null;
+  if (!command) {
+    return input;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(command, 'resume') || Object.prototype.hasOwnProperty.call(command, 'update')) {
+    return input;
+  }
+
+  const translatedCommand = translateNamedWorkflowCommand(command);
+  if (!translatedCommand) {
+    return input;
+  }
+
+  return {
+    ...input,
+    forwardedProps: {
+      ...forwardedProps,
+      command: translatedCommand,
+    },
+  };
+}
+
 export class LangGraphInterruptSnapshotAgent extends CopilotKitLangGraphAgent {
   constructor(config: LangGraphAgentConfig) {
     super(config);
@@ -88,8 +145,9 @@ export class LangGraphInterruptSnapshotAgent extends CopilotKitLangGraphAgent {
     input: PrepareStreamInput,
     streamMode: PrepareStreamMode,
   ): Promise<PrepareStreamResult> {
+    const translatedInput = translatePrepareStreamInput(input);
     const beforeState = input.threadId ? await this.client.threads.getState(input.threadId).catch(() => undefined) : undefined;
-    const resumeShape = readResumeShape(input);
+    const resumeShape = readResumeShape(translatedInput);
 
     console.warn('[langgraph-resume-trace] prepareStream start', {
       agentName: this.agentName,
@@ -104,7 +162,7 @@ export class LangGraphInterruptSnapshotAgent extends CopilotKitLangGraphAgent {
       persistedInterruptTypes: readInterruptTypesFromState(beforeState),
     });
 
-    const result = await super.prepareStream(input, streamMode);
+    const result = await super.prepareStream(translatedInput, streamMode);
 
     console.warn('[langgraph-resume-trace] prepareStream result', {
       agentName: this.agentName,

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/langGraphInterruptSnapshotAgent.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/langGraphInterruptSnapshotAgent.unit.test.ts
@@ -1,7 +1,7 @@
 import type { State } from '@ag-ui/langgraph';
 import { EventType, verifyEvents, type RunAgentInput } from '@ag-ui/client';
 import { Subject, lastValueFrom, toArray } from 'rxjs';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { LangGraphInterruptSnapshotAgent } from './langGraphInterruptSnapshotAgent';
 import { assertSharedThreadSnapshotContract } from './sharedThreadSnapshotContract.test-support';
@@ -9,6 +9,90 @@ import { assertSharedThreadSnapshotContract } from './sharedThreadSnapshotContra
 type LangGraphThreadState = Parameters<LangGraphInterruptSnapshotAgent['getStateSnapshot']>[0];
 
 describe('LangGraphInterruptSnapshotAgent', () => {
+  it('translates named workflow commands into native LangGraph command updates before streaming', async () => {
+    const streamMock = vi.fn(async function* () {});
+    const agent = new LangGraphInterruptSnapshotAgent({
+      deploymentUrl: 'http://langgraph-gmx:8126',
+      graphId: 'agent-gmx-allora',
+    });
+
+    Reflect.set(agent, 'assistant', {
+      assistant_id: 'assistant-1',
+    });
+    Reflect.set(agent, 'activeRun', {
+      id: 'run-1',
+      threadId: 'thread-1',
+      hasFunctionStreaming: false,
+      hasPredictState: false,
+      manuallyEmittedState: null,
+    });
+    Reflect.set(agent, 'client', {
+      threads: {
+        getState: async () =>
+          ({
+            values: {
+              messages: [],
+              thread: {},
+              private: {},
+            },
+            tasks: [],
+            next: [],
+            metadata: { writes: {} },
+          }) as LangGraphThreadState,
+      },
+      assistants: {
+        getGraph: async () => ({ edges: [] }),
+      },
+      runs: {
+        stream: streamMock,
+      },
+    });
+
+    Reflect.set(agent, 'getOrCreateThread', vi.fn(async () => ({ thread_id: 'thread-1' })));
+    Reflect.set(agent, 'getSchemaKeys', vi.fn(async () => ({
+      config: [],
+      context: [],
+      input: ['thread', 'messages', 'copilotkit', 'tools'],
+      output: ['thread', 'messages', 'copilotkit', 'tools'],
+    })));
+
+    await agent.prepareStream(
+      {
+        threadId: 'thread-1',
+        runId: 'run-1',
+        messages: [],
+        state: {},
+        tools: [],
+        context: [],
+        forwardedProps: {
+          command: {
+            name: 'hire',
+            clientMutationId: 'hire-1',
+            source: 'detail-page',
+          },
+        },
+      },
+      ['events'],
+    );
+
+    expect(streamMock).toHaveBeenCalledWith(
+      'thread-1',
+      'assistant-1',
+      expect.objectContaining({
+        command: {
+          update: {
+            private: {
+              pendingCommand: {
+                command: 'hire',
+                clientMutationId: 'hire-1',
+              },
+            },
+          },
+        },
+      }),
+    );
+  });
+
   it('preserves top-level persisted task interrupts in projected snapshots', () => {
     const agent = new LangGraphInterruptSnapshotAgent({
       deploymentUrl: 'http://langgraph-gmx:8126',

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts
@@ -408,7 +408,7 @@ describe('agent-runtime HTTP agent integration', () => {
 
     const runEvents = await collectEvents(
       agent
-        .run(createPromptRunInput('Please schedule sync automation.', { runId: 'run-schedule' }))
+        .run(createPromptRunInput('Please schedule refresh automation.', { runId: 'run-schedule' }))
         .pipe(verifyEvents()),
     );
 
@@ -439,7 +439,7 @@ describe('agent-runtime HTTP agent integration', () => {
         matchesArtifactData(operation.value, {
           type: 'automation-status',
           status: 'scheduled',
-          command: 'sync',
+          command: 'refresh',
         }),
     );
     expectStateDeltaOperation(

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.ts
@@ -24,12 +24,12 @@ installCopilotRuntimeDebugFilter({ enabled: shouldLogCopilotRuntimeDebug });
 
 const shouldLogCopilotRouteRequests =
   process.env.NODE_ENV !== 'production' || process.env.COPILOTKIT_ROUTE_DEBUG === 'true';
-const shouldLogCopilotRouteSyncPolls =
+const shouldLogCopilotRouteRefreshPolls =
   process.env.COPILOTKIT_ROUTE_DEBUG === 'true' || process.env.COPILOTKIT_ROUTE_LOG_SYNC === 'true';
 const shouldTraceAllRunCommands =
   process.env.COPILOTKIT_ROUTE_TRACE_RUN_ALL === 'true' ||
   process.env.COPILOTKIT_ROUTE_DEBUG === 'true';
-const shouldWarnOnSlowSyncPolls = process.env.COPILOTKIT_ROUTE_WARN_SYNC_SLOW !== 'false';
+const shouldWarnOnSlowRefreshPolls = process.env.COPILOTKIT_ROUTE_WARN_SYNC_SLOW !== 'false';
 const shouldLogUnmatchedRequests =
   process.env.COPILOTKIT_ROUTE_LOG_UNMATCHED === 'true' || process.env.COPILOTKIT_ROUTE_DEBUG === 'true';
 const slowCopilotRouteWarnThresholdMs = (() => {
@@ -57,10 +57,10 @@ async function appendCopilotRouteTrace(entry: Record<string, unknown>): Promise<
 function monitorCopilotResponseStream(params: {
   requestId: string;
   requestMetadata: CopilotRouteRequestMetadata;
-  isAgentListSyncPoll: boolean;
+  isAgentListRefreshPoll: boolean;
   shouldTraceRequest: boolean;
   shouldLogCopilotRouteRequests: boolean;
-  shouldWarnOnSlowSyncPolls: boolean;
+  shouldWarnOnSlowRefreshPolls: boolean;
   slowCopilotRouteWarnThresholdMs: number;
   startedAt: number;
   stream: ReadableStream<Uint8Array>;
@@ -84,14 +84,14 @@ function monitorCopilotResponseStream(params: {
       const streamDurationMs = Date.now() - streamStartedAt;
       const shouldWarnSlowStream =
         params.shouldLogCopilotRouteRequests &&
-        (params.shouldWarnOnSlowSyncPolls || !params.isAgentListSyncPoll) &&
+        (params.shouldWarnOnSlowRefreshPolls || !params.isAgentListRefreshPoll) &&
         totalDurationMs >= params.slowCopilotRouteWarnThresholdMs;
 
       if (params.shouldTraceRequest || shouldWarnSlowStream) {
         const payload = {
           requestId: params.requestId,
           ...params.requestMetadata,
-          isAgentListSyncPoll: params.isAgentListSyncPoll,
+          isAgentListRefreshPoll: params.isAgentListRefreshPoll,
           totalDurationMs,
           streamDurationMs,
           chunkCount,
@@ -138,9 +138,9 @@ async function readCopilotRouteMetadata(req: NextRequest): Promise<CopilotRouteR
 export const POST = async (req: NextRequest) => {
   const requestId = randomUUID();
   const requestMetadata = await readCopilotRouteMetadata(req);
-  const isAgentListSyncPoll =
+  const isAgentListRefreshPoll =
     requestMetadata.method === 'agent/run' &&
-    requestMetadata.command === 'sync' &&
+    requestMetadata.command === 'refresh' &&
     requestMetadata.source === 'agent-list-poll';
   const isFireRun = requestMetadata.method === 'agent/run' && requestMetadata.command === 'fire';
   const shouldTraceRunCommand =
@@ -152,7 +152,7 @@ export const POST = async (req: NextRequest) => {
   const shouldTraceRequest =
     shouldLogCopilotRouteRequests &&
     shouldTraceMethod &&
-    (!isAgentListSyncPoll || shouldLogCopilotRouteSyncPolls);
+    (!isAgentListRefreshPoll || shouldLogCopilotRouteRefreshPolls);
   const startedAt = Date.now();
   const metadataParsedAt = Date.now();
 
@@ -222,16 +222,16 @@ export const POST = async (req: NextRequest) => {
   }
   if (
     shouldLogCopilotRouteRequests &&
-    (shouldWarnOnSlowSyncPolls || !isAgentListSyncPoll) &&
+    (shouldWarnOnSlowRefreshPolls || !isAgentListRefreshPoll) &&
     durationMs >= slowCopilotRouteWarnThresholdMs
   ) {
     console.warn('[copilotkit-route] slow request', {
       requestId,
       ...requestMetadata,
-      isAgentListSyncPoll,
+      isAgentListRefreshPoll,
       status: response.status,
       durationMs,
-      shouldWarnOnSlowSyncPolls,
+      shouldWarnOnSlowRefreshPolls,
       phaseDurationsMs: {
         metadataParse: metadataParseDurationMs,
         handlerInit: handlerInitDurationMs,
@@ -275,10 +275,10 @@ export const POST = async (req: NextRequest) => {
   monitorCopilotResponseStream({
     requestId,
     requestMetadata,
-    isAgentListSyncPoll,
+    isAgentListRefreshPoll,
     shouldTraceRequest,
     shouldLogCopilotRouteRequests,
-    shouldWarnOnSlowSyncPolls,
+    shouldWarnOnSlowRefreshPolls,
     slowCopilotRouteWarnThresholdMs,
     startedAt,
     stream: bodyForMonitor,

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
@@ -19,9 +19,9 @@ describe('parseCopilotRouteMetadata', () => {
             },
           ],
           forwardedProps: {
+            source: 'agent-list-poll',
             command: {
               name: 'refresh',
-              source: 'agent-list-poll',
             },
           },
         },

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/route.unit.test.ts
@@ -15,12 +15,12 @@ describe('parseCopilotRouteMetadata', () => {
           messages: [
             {
               role: 'user',
-              content: '{"command":"sync","source":"legacy-message"}',
+              content: '{"command":"refresh","source":"legacy-message"}',
             },
           ],
           forwardedProps: {
             command: {
-              name: 'sync',
+              name: 'refresh',
               source: 'agent-list-poll',
             },
           },
@@ -30,7 +30,7 @@ describe('parseCopilotRouteMetadata', () => {
       method: 'agent/run',
       agentId: 'agent-clmm',
       threadId: 'thread-1',
-      command: 'sync',
+      command: 'refresh',
       source: 'agent-list-poll',
       metadataMatched: true,
     });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/routeMetadata.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/routeMetadata.ts
@@ -84,7 +84,7 @@ function readCommandMetadata(payloadBody: Record<string, unknown>): {
 
   return {
     command: namedCommand ?? (update ? 'update' : undefined),
-    source: readString(command.source),
+    source: readString(forwardedProps.source),
     clientMutationId: update ? readString(update.clientMutationId) : readString(command.clientMutationId),
   };
 }

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
@@ -126,22 +126,31 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const routeHasRegisteredAgent = isRegisteredAgentId(routeAgentId);
   const selectedAgentId = routeHasRegisteredAgent ? routeAgentId : activeAgentId;
   const selectedConfig = getAgentConfig(selectedAgentId);
+  const selectedLifecycleState = agent.uiState.lifecycle;
+  const selectedOnboardingFlow = agent.uiState.onboardingFlow;
+  const selectedTask = agent.uiState.task;
+  const selectedMetrics = agent.metrics;
+  const selectedActivity = agent.activity;
+  const selectedProfileSource = agent.profile;
   const onboardingOwnerAgentId = selectedConfig.onboardingOwnerAgentId;
   const selectedProfile = {
-    ...agent.profile,
+    ...selectedProfileSource,
     chains:
-      agent.profile.chains && agent.profile.chains.length > 0
-        ? agent.profile.chains
+      selectedProfileSource.chains && selectedProfileSource.chains.length > 0
+        ? selectedProfileSource.chains
         : selectedConfig.chains ?? [],
     protocols:
-      agent.profile.protocols && agent.profile.protocols.length > 0
-        ? agent.profile.protocols
+      selectedProfileSource.protocols && selectedProfileSource.protocols.length > 0
+        ? selectedProfileSource.protocols
         : selectedConfig.protocols ?? [],
     tokens:
-      agent.profile.tokens && agent.profile.tokens.length > 0
-        ? agent.profile.tokens
+      selectedProfileSource.tokens && selectedProfileSource.tokens.length > 0
+        ? selectedProfileSource.tokens
         : selectedConfig.tokens ?? [],
   };
+  const selectedHasLoadedView = agent.hasLoadedView;
+  const selectedIsHired = agent.isHired;
+  const isRestoringState = Boolean(agent.threadId && !agent.hasAuthoritativeState);
   const projectionHydrationKeyRef = useRef<string | null>(null);
 
   const handleBack = () => {
@@ -168,7 +177,7 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const uiPreviewTab = uiPreviewEnabled ? parseAgentRouteTab(searchParams.get('__tab')) : null;
   const uiPreviewFixture = uiPreviewEnabled ? parseUiPreviewFixture(searchParams.get('__fixture')) : null;
   const selectedTab = requestedTab ?? uiPreviewTab;
-  const selectedLifecyclePhase = agent.uiState.lifecycle?.phase;
+  const selectedLifecyclePhase = selectedLifecycleState?.phase;
   const hasManagedProjection = hasManagedMandateEditorProjection(agent.domainProjection);
   const portfolioManagerThreadId =
     selectedAgentId === 'agent-portfolio-manager' && agent.threadId
@@ -215,7 +224,7 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   );
 
   useEffect(() => {
-    if (!agent.threadId || !agent.isHired || selectedLifecyclePhase !== 'active' || hasManagedProjection) {
+    if (!agent.threadId || !selectedIsHired || selectedLifecyclePhase !== 'active' || hasManagedProjection) {
       return;
     }
 
@@ -248,7 +257,7 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
         }
       })
       .catch(() => undefined);
-  }, [agent, agent.isHired, agent.threadId, hasManagedProjection, selectedAgentId, selectedLifecyclePhase]);
+  }, [agent, agent.threadId, hasManagedProjection, selectedAgentId, selectedIsHired, selectedLifecyclePhase]);
 
   if (uiPreviewState) {
     const previewAgentId = routeHasRegisteredAgent ? routeAgentId : selectedAgentId;
@@ -360,19 +369,20 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
         tokens: selectedProfile.tokens,
       }}
       metrics={{
-        iteration: agent.metrics.iteration,
-        cyclesSinceRebalance: agent.metrics.cyclesSinceRebalance,
-        staleCycles: agent.metrics.staleCycles,
-        rebalanceCycles: agent.metrics.rebalanceCycles,
-        aumUsd: agent.metrics.aumUsd,
-        apy: agent.metrics.apy,
-        lifetimePnlUsd: agent.metrics.lifetimePnlUsd,
+        iteration: selectedMetrics.iteration,
+        cyclesSinceRebalance: selectedMetrics.cyclesSinceRebalance,
+        staleCycles: selectedMetrics.staleCycles,
+        rebalanceCycles: selectedMetrics.rebalanceCycles,
+        aumUsd: selectedMetrics.aumUsd,
+        apy: selectedMetrics.apy,
+        lifetimePnlUsd: selectedMetrics.lifetimePnlUsd,
       }}
-      fullMetrics={agent.metrics}
-      initialTab={agent.isHired ? (selectedTab ?? undefined) : undefined}
-      isHired={agent.isHired}
+      fullMetrics={selectedMetrics}
+      initialTab={selectedIsHired ? (selectedTab ?? undefined) : undefined}
+      isHired={selectedIsHired}
+      isRestoringState={isRestoringState}
       isHiring={agent.isHiring}
-      hasLoadedView={agent.hasLoadedView}
+      hasLoadedView={selectedHasLoadedView}
       isFiring={agent.isFiring}
       isSyncing={agent.isSyncing}
       uiError={agent.uiError}
@@ -384,17 +394,17 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
       activeInterrupt={agent.activeInterrupt}
       allowedPools={selectedProfile.allowedPools ?? []}
       onInterruptSubmit={agent.resolveInterrupt}
-      taskId={agent.uiState.task?.id}
-      taskStatus={agent.uiState.task?.taskStatus?.state}
+      taskId={selectedTask?.id}
+      taskStatus={selectedTask?.taskStatus?.state}
       haltReason={agent.uiState.haltReason}
       executionError={agent.uiState.executionError}
       delegationsBypassActive={agent.uiState.delegationsBypassActive}
-      onboardingFlow={agent.uiState.onboardingFlow}
+      onboardingFlow={selectedOnboardingFlow}
       transactions={agent.transactionHistory}
-      telemetry={agent.activity.telemetry}
+      telemetry={selectedActivity.telemetry}
       events={agent.events}
       messages={agent.messages}
-      lifecycleState={agent.uiState.lifecycle}
+      lifecycleState={selectedLifecycleState}
       domainProjection={agent.domainProjection}
       settings={agent.settings}
       onSendChatMessage={agent.sendChatMessage}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
@@ -330,7 +330,6 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
         telemetry={[]}
         events={[]}
         messages={EMPTY_MESSAGES}
-        messageSnapshotEpoch={0}
         lifecycleState={previewLifecycleState}
         domainProjection={previewDomainProjection}
         settings={agent.settings}
@@ -395,7 +394,6 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
       telemetry={agent.activity.telemetry}
       events={agent.events}
       messages={agent.messages}
-      messageSnapshotEpoch={agent.messageSnapshotEpoch}
       lifecycleState={agent.uiState.lifecycle}
       domainProjection={agent.domainProjection}
       settings={agent.settings}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
@@ -59,6 +59,7 @@ function createAgentValue(overrides: Record<string, unknown> = {}) {
     },
     isConnected: true,
     hasLoadedView: true,
+    hasAuthoritativeState: true,
     threadId: 'thread-1',
     domainProjection: {},
     applyDomainProjection: mocks.applyDomainProjection,
@@ -204,6 +205,57 @@ describe('AgentDetailRoute managed mandate wiring', () => {
         mandateRef: 'mandate-ember-lending-001',
       },
     });
+  });
+
+  it('keeps the route in reconnecting mode until an authoritative thread snapshot lands', async () => {
+    mocks.agentValue = createAgentValue({
+      hasLoadedView: false,
+      hasAuthoritativeState: false,
+      isHired: false,
+      isActive: false,
+      uiState: {
+        lifecycle: undefined,
+        task: undefined,
+        haltReason: undefined,
+        executionError: undefined,
+        delegationsBypassActive: false,
+        onboardingFlow: undefined,
+      },
+      profile: {
+        agentIncome: 0,
+        aum: 0,
+        totalUsers: 0,
+        apy: 0,
+        chains: [],
+        protocols: [],
+        tokens: [],
+      },
+      metrics: {
+        iteration: 0,
+        cyclesSinceRebalance: 0,
+        staleCycles: 0,
+        rebalanceCycles: 0,
+        aumUsd: 0,
+        apy: 0,
+        lifetimePnlUsd: 0,
+      },
+    });
+    mocks.invokeAgentCommandRoute.mockResolvedValue({
+      ok: true,
+      domainProjection: {
+        managedMandateEditor: {
+          mandateRef: 'mandate-ember-lending-001',
+        },
+      },
+    });
+
+    await renderRoute('agent-portfolio-manager');
+
+    const props = readCapturedProps();
+    expect(props.isHired).toBe(false);
+    expect(props.isRestoringState).toBe(true);
+    expect(props.hasLoadedView).toBe(false);
+    expect(mocks.invokeAgentCommandRoute).not.toHaveBeenCalled();
   });
 
   it('routes hosted lending edits through the PM-owned command and then rehydrates the lending thread projection', async () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
@@ -100,7 +100,6 @@ function createAgentValue(overrides: Record<string, unknown> = {}) {
     transactionHistory: [],
     events: [],
     messages: [],
-    messageSnapshotEpoch: 0,
     settings: {
       amount: 100,
     },

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/page.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/page.int.test.ts
@@ -8,6 +8,8 @@ type HireAgentsRoutePropsCapture = {
   agents: Array<{
     id: string;
     name: string;
+    status: 'for_hire' | 'hired' | 'unavailable';
+    isActive?: boolean;
     chains: string[];
     protocols: string[];
     tokens: string[];
@@ -24,6 +26,7 @@ type HireAgentsRoutePropsCapture = {
   featuredAgents: Array<{
     id: string;
     name: string;
+    status: 'for_hire' | 'hired' | 'unavailable';
     description?: string;
     chains: string[];
     protocols: string[];
@@ -124,6 +127,36 @@ describe('HireAgentsRoute integration', () => {
             iteration: 1,
           },
         },
+        'agent-portfolio-manager': {
+          synced: true,
+          lifecyclePhase: 'active',
+          profile: {
+            chains: ['Arbitrum'],
+            protocols: ['Pi Runtime', 'Shared Ember Domain Service'],
+            tokens: ['USDC'],
+            totalUsers: 12,
+            aum: 9200,
+            apy: 4,
+          },
+          metrics: {
+            iteration: 5,
+          },
+        },
+        'agent-ember-lending': {
+          synced: true,
+          lifecyclePhase: 'active',
+          profile: {
+            chains: ['Arbitrum'],
+            protocols: ['Aave'],
+            tokens: ['USDC'],
+            totalUsers: 4,
+            aum: 9100,
+            apy: 3,
+          },
+          metrics: {
+            iteration: 2,
+          },
+        },
       },
     });
   });
@@ -167,8 +200,10 @@ describe('HireAgentsRoute integration', () => {
     expect(portfolioManager?.marketplaceRowBg).toBe('rgba(124,58,237,0.08)');
     expect(portfolioManager?.marketplaceRowHoverBg).toBe('rgba(124,58,237,0.12)');
     expect(portfolioManager?.surfaceTag).toBe('Swarm');
-    expect(portfolioManager?.pointsTrend).toBeUndefined();
-    expect(portfolioManager?.trendMultiplier).toBeUndefined();
+    expect(portfolioManager?.status).toBe('hired');
+    expect(portfolioManager?.isActive).toBe(true);
+    expect(portfolioManager?.pointsTrend).toBe('up');
+    expect(portfolioManager?.trendMultiplier).toBe('5x');
 
     expect(emberLending?.chains).toEqual(['Arbitrum']);
     expect(emberLending?.name).toBe('Ember Lending');
@@ -177,8 +212,10 @@ describe('HireAgentsRoute integration', () => {
     expect(emberLending?.imageUrl).toBe('/ember-lending-avatar.svg');
     expect(emberLending?.avatarBg).toBe('#9896FF');
     expect(emberLending?.surfaceTag).toBe('Swarm');
-    expect(emberLending?.pointsTrend).toBeUndefined();
-    expect(emberLending?.trendMultiplier).toBeUndefined();
+    expect(emberLending?.status).toBe('hired');
+    expect(emberLending?.isActive).toBe(true);
+    expect(emberLending?.pointsTrend).toBe('up');
+    expect(emberLending?.trendMultiplier).toBe('2x');
     expect(clmm?.surfaceTag).toBe('Workflow');
 
     expect(props.featuredAgents.map((agent) => agent.id).slice(0, 3)).toEqual([
@@ -186,6 +223,12 @@ describe('HireAgentsRoute integration', () => {
       'agent-ember-lending',
       'agent-clmm',
     ]);
+    expect(props.featuredAgents.find((agent) => agent.id === 'agent-portfolio-manager')?.status).toBe(
+      'hired',
+    );
+    expect(props.featuredAgents.find((agent) => agent.id === 'agent-ember-lending')?.status).toBe(
+      'hired',
+    );
   });
 
   it('routes hire/view handlers to the correct detail URL', () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/page.tsx
@@ -4,12 +4,28 @@ import { useRouter } from 'next/navigation';
 import { HireAgentsPage, type Agent, type FeaturedAgent } from '@/components/HireAgentsPage';
 import { useAgentList } from '@/contexts/AgentListContext';
 import { getFeaturedAgents, getVisibleAgents } from '@/config/agents';
+import type { AgentListEntry } from '@/contexts/agentListTypes';
 import { canonicalizeChainLabel } from '@/utils/iconResolution';
 import { mergeUniqueStrings, normalizeStringList } from '@/utils/agentCollections';
 
 const PAGINATION_QA_MOCK_COUNT = 27;
 const PAGINATION_QA_MOCKS_ENABLED =
   process.env.NEXT_PUBLIC_ENABLE_HIRE_AGENTS_PAGINATION_MOCKS === 'true';
+
+function deriveMarketplaceAgentStatus(
+  listState: AgentListEntry | undefined,
+): Pick<Agent, 'status' | 'isActive'> {
+  const lifecyclePhase = listState?.lifecyclePhase ?? null;
+  const isHired =
+    lifecyclePhase === 'onboarding' ||
+    lifecyclePhase === 'active' ||
+    lifecyclePhase === 'firing';
+
+  return {
+    status: isHired ? 'hired' : 'for_hire',
+    isActive: lifecyclePhase === 'active',
+  };
+}
 
 export default function HireAgentsRoute() {
   const router = useRouter();
@@ -22,6 +38,7 @@ export default function HireAgentsRoute() {
     const profile = listState?.profile;
     const metrics = listState?.metrics;
     const isLoaded = Boolean(listState?.synced);
+    const { status, isActive } = deriveMarketplaceAgentStatus(listState);
 
     const chains = mergeUniqueStrings({
       primary: normalizeStringList(profile?.chains),
@@ -65,8 +82,8 @@ export default function HireAgentsRoute() {
       marketplaceCardHoverBg: agentConfig.marketplaceCardHoverBg,
       marketplaceRowBg: agentConfig.marketplaceRowBg,
       marketplaceRowHoverBg: agentConfig.marketplaceRowHoverBg,
-      status: 'for_hire' as const,
-      isActive: false,
+      status,
+      isActive,
       isFeatured: agentConfig.isFeatured,
       featuredRank: agentConfig.featuredRank,
       isLoaded,
@@ -113,6 +130,7 @@ export default function HireAgentsRoute() {
     const profile = listState?.profile;
     const metrics = listState?.metrics;
     const isLoaded = Boolean(listState?.synced);
+    const { status } = deriveMarketplaceAgentStatus(listState);
 
     const chains = mergeUniqueStrings({
       primary: normalizeStringList(profile?.chains),
@@ -156,7 +174,7 @@ export default function HireAgentsRoute() {
       marketplaceRowHoverBg: config.marketplaceRowHoverBg,
       pointsTrend: isLoaded && metrics?.iteration && metrics.iteration > 0 ? 'up' : undefined,
       trendMultiplier: isLoaded && metrics?.iteration ? `${metrics.iteration}x` : undefined,
-      status: 'for_hire' as const,
+      status,
       isLoaded,
     };
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.agentContracts.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.agentContracts.unit.test.ts
@@ -118,7 +118,7 @@ function renderAgentDetail(params: {
 }
 
 describe('AgentDetailPage (cross-agent contracts)', () => {
-  it('keeps pre-hire layout visible even when detail sync has not loaded yet', () => {
+  it('keeps pre-hire layout visible even when detail refresh has not loaded yet', () => {
     const html = renderAgentDetail({
       agentId: 'agent-gmx-allora',
       agentName: 'GMX Allora Trader',

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.piExampleA2ui.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.piExampleA2ui.unit.test.ts
@@ -95,8 +95,8 @@ describe('AgentDetailPage Pi example A2UI rendering', () => {
             data: {
               type: 'automation-status',
               status: 'scheduled',
-              command: 'sync',
-              detail: 'Scheduled sync every 5 minutes.',
+              command: 'refresh',
+              detail: 'Scheduled refresh every 5 minutes.',
             },
           },
         },
@@ -110,8 +110,8 @@ describe('AgentDetailPage Pi example A2UI rendering', () => {
                   kind: 'automation-status',
                   payload: {
                     status: 'scheduled',
-                    command: 'sync',
-                    detail: 'Scheduled sync every 5 minutes.',
+                    command: 'refresh',
+                    detail: 'Scheduled refresh every 5 minutes.',
                   },
                 },
               },
@@ -123,7 +123,7 @@ describe('AgentDetailPage Pi example A2UI rendering', () => {
 
     expect(container.querySelector('.a2ui-card')).not.toBeNull();
     expect(container.textContent).toContain('Automation scheduled');
-    expect(container.textContent).toContain('Scheduled sync every 5 minutes.');
+    expect(container.textContent).toContain('Scheduled refresh every 5 minutes.');
 
     act(() => {
       root.unmount();
@@ -205,8 +205,8 @@ describe('AgentDetailPage Pi example A2UI rendering', () => {
             data: {
               type: 'automation-status',
               status: 'running',
-              command: 'sync',
-              detail: 'Running automation sync.',
+              command: 'refresh',
+              detail: 'Running automation refresh.',
             },
           },
         },
@@ -217,16 +217,16 @@ describe('AgentDetailPage Pi example A2UI rendering', () => {
             data: {
               type: 'automation-status',
               status: 'completed',
-              command: 'sync',
-              detail: 'Automation sync executed successfully.',
+              command: 'refresh',
+              detail: 'Automation refresh executed successfully.',
             },
           },
         },
       ] as never,
     });
 
-    expect(container.textContent).toContain('Running automation sync.');
-    expect(container.textContent).toContain('Automation sync executed successfully.');
+    expect(container.textContent).toContain('Running automation refresh.');
+    expect(container.textContent).toContain('Automation refresh executed successfully.');
     expect(consoleErrorSpy).not.toHaveBeenCalledWith(
       expect.stringContaining('Encountered two children with the same key'),
     );

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
@@ -253,8 +253,8 @@ describe('AgentDetailPage (pre-hire + onboarding affordances)', () => {
               data: {
                 type: 'automation-status',
                 status: 'scheduled',
-                command: 'sync',
-                detail: 'Scheduled sync every 5 minutes.',
+                command: 'refresh',
+                detail: 'Scheduled refresh every 5 minutes.',
               },
             },
           },
@@ -268,8 +268,8 @@ describe('AgentDetailPage (pre-hire + onboarding affordances)', () => {
                     kind: 'automation-status',
                     payload: {
                       status: 'scheduled',
-                      command: 'sync',
-                      detail: 'Scheduled sync every 5 minutes.',
+                      command: 'refresh',
+                      detail: 'Scheduled refresh every 5 minutes.',
                     },
                   },
                 },

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
@@ -179,7 +179,7 @@ describe('AgentDetailPage (pre-hire + onboarding affordances)', () => {
     expect(html).toContain('Analyzing the request before answering.');
   });
 
-  it('keeps reasoning ahead of its linked assistant response in the transcript', () => {
+  it('renders linked reasoning in the order supplied by the runtime transcript', () => {
     const messages: Message[] = [
       {
         id: 'assistant-1',
@@ -222,8 +222,8 @@ describe('AgentDetailPage (pre-hire + onboarding affordances)', () => {
 
     expect(html).toContain('Thinking through the request first.');
     expect(html).toContain('Here is the final answer.');
-    expect(html.indexOf('Thinking through the request first.')).toBeLessThan(
-      html.indexOf('Here is the final answer.'),
+    expect(html.indexOf('Here is the final answer.')).toBeLessThan(
+      html.indexOf('Thinking through the request first.'),
     );
   });
 

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
@@ -111,6 +111,37 @@ describe('AgentDetailPage (pre-hire + onboarding affordances)', () => {
     expect(html).toMatch(new RegExp('<button[^>]*disabled[^>]*>\\s*Chat\\s*</button>'));
   });
 
+  it('shows reconnecting state instead of a hire affordance while waiting for an authoritative snapshot', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(AgentDetailPage, {
+        agentId: 'agent-portfolio-manager',
+        agentName: 'Ember Portfolio Agent',
+        agentDescription: 'desc',
+        creatorName: 'Ember AI Team',
+        creatorVerified: true,
+        profile: {
+          chains: [],
+          protocols: [],
+          tokens: [],
+        },
+        metrics: {},
+        isHired: false,
+        isRestoringState: true,
+        isHiring: false,
+        hasLoadedView: false,
+        onHire: () => {},
+        onFire: () => {},
+        onSync: () => {},
+        onBack: () => {},
+        allowedPools: [],
+      }),
+    );
+
+    expect(html).toContain('Reconnecting...');
+    expect(html).toContain('Restoring state');
+    expect(html).not.toContain('>Hire<');
+  });
+
   it('enables pre-hire chat for the Pi example agent', () => {
     const html = renderToStaticMarkup(
       React.createElement(AgentDetailPage, {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.transcriptOrdering.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.transcriptOrdering.unit.test.tsx
@@ -39,7 +39,6 @@ function renderPage(messages: Message[], overrides: Partial<React.ComponentProps
     isHiring: false,
     hasLoadedView: true,
     messages,
-    messageSnapshotEpoch: 0,
     onHire: () => {},
     onFire: () => {},
     onSync: () => {},
@@ -74,7 +73,7 @@ describe('AgentDetailPage transcript ordering', () => {
     container.remove();
   });
 
-  it('keeps reasoning ahead of an assistant reply that becomes visible later', () => {
+  it('renders later transcript order exactly as provided when an assistant reply becomes visible later', () => {
     const root = createRoot(container);
     const initialMessages: Message[] = [
       {
@@ -116,8 +115,8 @@ describe('AgentDetailPage transcript ordering', () => {
     const transcriptText = container.textContent ?? '';
     expect(transcriptText).toContain('Thinking through the request first.');
     expect(transcriptText).toContain('Here is the final answer.');
-    expect(transcriptText.indexOf('Thinking through the request first.')).toBeLessThan(
-      transcriptText.indexOf('Here is the final answer.'),
+    expect(transcriptText.indexOf('Here is the final answer.')).toBeLessThan(
+      transcriptText.indexOf('Thinking through the request first.'),
     );
 
     act(() => {
@@ -125,7 +124,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('keeps a canonical user message ahead of a new assistant reply when the user message id changes', () => {
+  it('renders canonical replacement message ids in the order supplied by the runtime', () => {
     const root = createRoot(container);
     const initialMessages: Message[] = [
       {
@@ -159,8 +158,8 @@ describe('AgentDetailPage transcript ordering', () => {
     const transcriptText = container.textContent ?? '';
     expect(transcriptText).toContain('Schedule a sync every minute.');
     expect(transcriptText).toContain('Scheduled a sync every minute.');
-    expect(transcriptText.indexOf('Schedule a sync every minute.')).toBeLessThan(
-      transcriptText.indexOf('Scheduled a sync every minute.'),
+    expect(transcriptText.indexOf('Scheduled a sync every minute.')).toBeLessThan(
+      transcriptText.indexOf('Schedule a sync every minute.'),
     );
 
     act(() => {
@@ -168,7 +167,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('keeps a new user turn ahead of newly-added reasoning and assistant messages on later renders', () => {
+  it('renders new user, reasoning, and assistant turns in the order supplied by the runtime', () => {
     const root = createRoot(container);
     const initialMessages: Message[] = [
       {
@@ -214,11 +213,11 @@ describe('AgentDetailPage transcript ordering', () => {
     expect(transcriptText).toContain('tell me more');
     expect(transcriptText).toContain('Thinking about the follow-up.');
     expect(transcriptText).toContain('Here is the next answer.');
-    expect(transcriptText.indexOf('tell me more')).toBeLessThan(
+    expect(transcriptText.indexOf('Here is the next answer.')).toBeLessThan(
       transcriptText.indexOf('Thinking about the follow-up.'),
     );
-    expect(transcriptText.indexOf('tell me more')).toBeLessThan(
-      transcriptText.indexOf('Here is the next answer.'),
+    expect(transcriptText.indexOf('Thinking about the follow-up.')).toBeLessThan(
+      transcriptText.indexOf('tell me more'),
     );
 
     act(() => {
@@ -226,7 +225,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('keeps an existing reasoning message ahead of its assistant reply across a later snapshot', () => {
+  it('renders later runtime snapshots in the order supplied even when reasoning follows its assistant', () => {
     const root = createRoot(container);
     const initialMessages: Message[] = [
       {
@@ -271,12 +270,12 @@ describe('AgentDetailPage transcript ordering', () => {
     ];
 
     act(() => {
-      root.render(renderPage(laterSnapshotMessages, { messageSnapshotEpoch: 1 }));
+      root.render(renderPage(laterSnapshotMessages));
     });
 
     transcriptText = container.textContent ?? '';
-    expect(transcriptText.indexOf('Thinking through the first answer.')).toBeLessThan(
-      transcriptText.indexOf('Here is the first answer.'),
+    expect(transcriptText.indexOf('Here is the first answer.')).toBeLessThan(
+      transcriptText.indexOf('Thinking through the first answer.'),
     );
 
     act(() => {
@@ -284,7 +283,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('preserves existing reasoning-before-assistant order across a later snapshot even without parent linkage', () => {
+  it('renders later runtime snapshots in the order supplied even without reasoning parent linkage', () => {
     const root = createRoot(container);
     const initialMessages: Message[] = [
       {
@@ -327,12 +326,12 @@ describe('AgentDetailPage transcript ordering', () => {
     ];
 
     act(() => {
-      root.render(renderPage(laterSnapshotMessages, { messageSnapshotEpoch: 1 }));
+      root.render(renderPage(laterSnapshotMessages));
     });
 
     transcriptText = container.textContent ?? '';
-    expect(transcriptText.indexOf('Thinking through the first answer.')).toBeLessThan(
-      transcriptText.indexOf('Here is the first answer.'),
+    expect(transcriptText.indexOf('Here is the first answer.')).toBeLessThan(
+      transcriptText.indexOf('Thinking through the first answer.'),
     );
 
     act(() => {
@@ -340,14 +339,15 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('hides sync-noise transcript rows while preserving non-sync reasoning', () => {
+  it('does not special-case legacy sync envelope content in the transcript', () => {
     const root = createRoot(container);
     const syncAckContent = JSON.stringify({ status: 'synced', clientMutationId: 'sync-1' });
+    const syncCommandContent = JSON.stringify({ command: 'sync', clientMutationId: 'sync-1' });
     const messages: Message[] = [
       {
         id: 'user-sync-1',
         role: 'user',
-        content: JSON.stringify({ command: 'sync', clientMutationId: 'sync-1' }),
+        content: syncCommandContent,
       },
       {
         id: 'assistant-sync-1',
@@ -378,9 +378,9 @@ describe('AgentDetailPage transcript ordering', () => {
     });
 
     const transcriptText = container.textContent ?? '';
-    expect(transcriptText).not.toContain('Requested a runtime sync.');
-    expect(transcriptText).not.toContain(syncAckContent);
-    expect(transcriptText).not.toContain('Thinking about how to acknowledge the sync request.');
+    expect(transcriptText).toContain(syncCommandContent);
+    expect(transcriptText).toContain(syncAckContent);
+    expect(transcriptText).toContain('Thinking about how to acknowledge the sync request.');
     expect(transcriptText).toContain('Thinking about the actual portfolio update.');
     expect(transcriptText).toContain('Here is the portfolio update you asked for.');
 
@@ -389,13 +389,14 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('keeps unlinked reasoning visible even when a sync acknowledgment is filtered', () => {
+  it('keeps unlinked reasoning visible alongside a legacy sync acknowledgment', () => {
     const root = createRoot(container);
+    const syncAckContent = JSON.stringify({ status: 'synced', clientMutationId: 'sync-1' });
     const messages: Message[] = [
       {
         id: 'assistant-sync-1',
         role: 'assistant',
-        content: JSON.stringify({ status: 'synced', clientMutationId: 'sync-1' }),
+        content: syncAckContent,
       },
       {
         id: 'reasoning-unlinked-1',
@@ -409,6 +410,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
 
     const transcriptText = container.textContent ?? '';
+    expect(transcriptText).toContain(syncAckContent);
     expect(transcriptText).toContain('Thinking about whether the sync completed cleanly.');
 
     act(() => {
@@ -416,7 +418,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
   });
 
-  it('hides sync reasoning when the runtime encodes the linked assistant id inside the reasoning message id', () => {
+  it('keeps reasoning visible even when the runtime encodes the linked assistant id inside the reasoning message id', () => {
     const root = createRoot(container);
     const linkedAssistantId = 'pi:agent-runtime:thread-1:assistant:1775509885583';
     const messages: Message[] = [
@@ -442,7 +444,7 @@ describe('AgentDetailPage transcript ordering', () => {
     });
 
     const transcriptText = container.textContent ?? '';
-    expect(transcriptText).not.toContain('Considering sync response');
+    expect(transcriptText).toContain('Considering sync response');
     expect(transcriptText).toContain('Visible assistant reply.');
 
     act(() => {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -726,7 +726,7 @@ function buildPiExampleChatCards(events: ClmmEvent[]): PiExampleChatCard[] {
       const artifactData = asRecord(event.artifact?.data);
       if (artifactData?.type === 'automation-status') {
         const status = typeof artifactData.status === 'string' ? artifactData.status : 'unknown';
-        const command = typeof artifactData.command === 'string' ? artifactData.command : 'sync';
+        const command = typeof artifactData.command === 'string' ? artifactData.command : 'refresh';
         const detail = typeof artifactData.detail === 'string' ? artifactData.detail : 'Automation status updated.';
         return [
           {
@@ -801,7 +801,7 @@ function buildPiExampleChatCards(events: ClmmEvent[]): PiExampleChatCard[] {
         }
 
         const status = typeof payload.status === 'string' ? payload.status : 'unknown';
-        const command = typeof payload.command === 'string' ? payload.command : 'sync';
+        const command = typeof payload.command === 'string' ? payload.command : 'refresh';
         const detail = typeof payload.detail === 'string' ? payload.detail : 'Automation status updated.';
         return [
           {
@@ -1484,7 +1484,7 @@ export function AgentDetailPage({
   ) : null;
 
   // Use the upgraded layout only for hired agents. Pre-hire must remain stable even
-  // while detail sync is still loading, otherwise the Hire CTA can disappear.
+  // while detail refresh is still loading, otherwise the Hire CTA can disappear.
   if (showPostHireLayout) {
     const tabs = (
       <div className="flex items-center gap-1 mb-6 border-b border-[#2a2a2a]">
@@ -1635,7 +1635,7 @@ export function AgentDetailPage({
               <ChevronRight className="w-4 h-4" />
               <span className="text-white">{agentName}</span>
             </div>
-            {/* Sync Button */}
+            {/* Refresh button */}
             <button
               onClick={onSync}
               disabled={isSyncing}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -155,7 +155,6 @@ interface AgentDetailPageProps {
   telemetry?: TelemetryItem[];
   events?: ClmmEvent[];
   messages?: Message[];
-  messageSnapshotEpoch?: number;
   lifecycleState?: ThreadLifecycle;
   domainProjection?: Record<string, unknown>;
   // Settings
@@ -264,80 +263,9 @@ function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
-function parseJsonMessageContent(content: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(content) as unknown;
-    if (typeof parsed !== 'object' || parsed === null) return null;
-    return parsed as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
-function parseCommandMessage(content: string): string | null {
-  const parsed = parseJsonMessageContent(content);
-  if (!parsed || !('command' in parsed)) {
-    return null;
-  }
-
-  const command = parsed.command;
-  if (command === 'hire') return 'Submitted hire request.';
-  if (command === 'fire') return 'Submitted fire request.';
-  if (command === 'sync') return 'Requested a runtime sync.';
-  if (command === 'resume') return 'Submitted onboarding response.';
-  return typeof command === 'string' ? `Submitted ${command} request.` : null;
-}
-
-function isSyncCommandMessage(message: Message): boolean {
-  if (message.role !== 'user' || typeof message.content !== 'string') {
-    return false;
-  }
-
-  return parseJsonMessageContent(message.content)?.command === 'sync';
-}
-
-function isSyncedAckMessage(message: Message): boolean {
-  if (message.role !== 'assistant' || typeof message.content !== 'string') {
-    return false;
-  }
-
-  const parsed = parseJsonMessageContent(message.content);
-  const clientMutationId = parsed?.clientMutationId;
-  return parsed?.status === 'synced' && typeof clientMutationId === 'string' && clientMutationId.trim().length > 0;
-}
-
-function getReasoningLinkedAssistantId(message: Message): string | null {
-  if (message.role !== 'reasoning') {
-    return null;
-  }
-
-  const parentMessageId = getParentMessageId(message);
-  if (parentMessageId) {
-    return parentMessageId;
-  }
-
-  const idMatch = message.id.match(/:reasoning:(.+):\d+$/);
-  return idMatch?.[1] ?? null;
-}
-
-function filterVisibleTranscriptMessages(messages: Message[]): Message[] {
-  const hiddenSyncAckMessageIds = new Set(
-    messages.filter((message) => isSyncedAckMessage(message)).map((message) => message.id),
-  );
-
-  return messages.filter((message) => {
-    if (isSyncCommandMessage(message) || hiddenSyncAckMessageIds.has(message.id)) {
-      return false;
-    }
-
-    const linkedAssistantId = getReasoningLinkedAssistantId(message);
-    return !(linkedAssistantId && hiddenSyncAckMessageIds.has(linkedAssistantId));
-  });
-}
-
 function getMessageText(message: Message): string {
   if (typeof message.content === 'string') {
-    return parseCommandMessage(message.content) ?? message.content;
+    return message.content;
   }
 
   if (Array.isArray(message.content)) {
@@ -368,131 +296,7 @@ type VisibleChatMessage = {
   label: string;
   text: string;
   role: Message['role'];
-  parentMessageId?: string;
-  originalIndex: number;
-  appearanceOrder: number;
 };
-
-type VisibleMessageOrderEntry = {
-  nextOrder: number;
-  orderById: Map<string, number>;
-  previousVisibleMessages: Array<{
-    id: string;
-    role: Message['role'];
-    text: string;
-    appearanceOrder: number;
-  }>;
-};
-
-const visibleMessageOrderCache = new Map<string, VisibleMessageOrderEntry>();
-
-function getVisibleMessageOrderEntry(cacheKey: string): VisibleMessageOrderEntry {
-  const existing = visibleMessageOrderCache.get(cacheKey);
-  if (existing) {
-    return existing;
-  }
-
-  const created: VisibleMessageOrderEntry = {
-    nextOrder: 0,
-    orderById: new Map<string, number>(),
-    previousVisibleMessages: [],
-  };
-  visibleMessageOrderCache.set(cacheKey, created);
-  return created;
-}
-
-function buildVisibleMessageReplacementKey(message: {
-  role: Message['role'];
-  text: string;
-}): string {
-  return `${message.role}\u0000${message.text}`;
-}
-
-function getIncrementalMessagePriority(role: Message['role']): number {
-  switch (role) {
-    case 'user':
-      return 0;
-    case 'reasoning':
-      return 1;
-    case 'assistant':
-      return 2;
-    default:
-      return 3;
-  }
-}
-
-function getParentMessageId(message: Message): string | undefined {
-  if (!('parentMessageId' in message)) {
-    return undefined;
-  }
-  return typeof message.parentMessageId === 'string' ? message.parentMessageId : undefined;
-}
-
-function orderVisibleChatMessages(
-  messages: Message[],
-  appearanceOrderById: ReadonlyMap<string, number>,
-): VisibleChatMessage[] {
-  const visibleMessages = messages
-    .map(
-      (message, originalIndex): VisibleChatMessage => ({
-        id: message.id,
-        label: getMessageRoleLabel(message),
-        text: getMessageText(message),
-        role: message.role,
-        parentMessageId: getParentMessageId(message),
-        originalIndex,
-        appearanceOrder: appearanceOrderById.get(message.id) ?? Number.MAX_SAFE_INTEGER,
-      }),
-    )
-    .filter((message) => message.text.length > 0);
-
-  const rankedVisibleMessages = [...visibleMessages].sort(
-    (left, right) =>
-      left.appearanceOrder - right.appearanceOrder || left.originalIndex - right.originalIndex,
-  );
-
-  const visibleMessageIds = new Set(rankedVisibleMessages.map((message) => message.id));
-  const reasoningByParentId = new Map<string, VisibleChatMessage[]>();
-
-  for (const message of rankedVisibleMessages) {
-    if (message.role !== 'reasoning' || !message.parentMessageId || !visibleMessageIds.has(message.parentMessageId)) {
-      continue;
-    }
-
-    const groupedMessages = reasoningByParentId.get(message.parentMessageId) ?? [];
-    groupedMessages.push(message);
-    reasoningByParentId.set(message.parentMessageId, groupedMessages);
-  }
-
-  const orderedMessages: VisibleChatMessage[] = [];
-  const appendedMessageIds = new Set<string>();
-
-  for (const message of rankedVisibleMessages) {
-    if (message.parentMessageId && reasoningByParentId.has(message.parentMessageId)) {
-      continue;
-    }
-
-    const reasoningMessages = reasoningByParentId.get(message.id) ?? [];
-    for (const reasoningMessage of reasoningMessages.sort(
-      (left, right) =>
-        left.appearanceOrder - right.appearanceOrder || left.originalIndex - right.originalIndex,
-    )) {
-      if (appendedMessageIds.has(reasoningMessage.id)) {
-        continue;
-      }
-      orderedMessages.push(reasoningMessage);
-      appendedMessageIds.add(reasoningMessage.id);
-    }
-
-    if (appendedMessageIds.has(message.id)) {
-      continue;
-    }
-    orderedMessages.push(message);
-    appendedMessageIds.add(message.id);
-  }
-
-  return orderedMessages;
-}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
@@ -1109,7 +913,6 @@ export function AgentDetailPage({
   telemetry = [],
   events = [],
   messages = [],
-  messageSnapshotEpoch = 0,
   lifecycleState,
   domainProjection,
   settings,
@@ -1484,7 +1287,6 @@ export function AgentDetailPage({
       isHired={isHired}
       isHiring={isHiring}
       messages={messages}
-      messageSnapshotEpoch={messageSnapshotEpoch}
       activityEvents={events}
       chatDraft={chatDraft}
       onChatDraftChange={setChatDraft}
@@ -2483,7 +2285,6 @@ function AgentChatTab(props: {
   isHired: boolean;
   isHiring: boolean;
   messages: Message[];
-  messageSnapshotEpoch: number;
   activityEvents: ClmmEvent[];
   chatDraft: string;
   onChatDraftChange: (value: string) => void;
@@ -2493,97 +2294,18 @@ function AgentChatTab(props: {
   onSendChatMessage?: (content: string) => void;
   onInterruptSubmit?: (input: PiOperatorNoteInput) => void;
 }) {
-  const visibleMessageOrderCacheKey = useId();
-  useEffect(() => {
-    return () => {
-      visibleMessageOrderCache.delete(visibleMessageOrderCacheKey);
-    };
-  }, [visibleMessageOrderCacheKey]);
-
   const visibleMessages = useMemo(() => {
-    const visibleMessageOrderEntry = getVisibleMessageOrderEntry(visibleMessageOrderCacheKey);
-    // TODO(i574): Remove this temporary sync-noise filter during the agent-state/thread-state refactor.
-    const filteredMessages = filterVisibleTranscriptMessages(props.messages);
-    const allMessageIds = new Set(filteredMessages.map((message) => message.id));
-    for (const messageId of [...visibleMessageOrderEntry.orderById.keys()]) {
-      if (!allMessageIds.has(messageId)) {
-        visibleMessageOrderEntry.orderById.delete(messageId);
-      }
-    }
-
-    const nextVisibleMessages = filteredMessages
-      .map((message) => ({
-        id: message.id,
-        role: message.role,
-        text: getMessageText(message),
-      }))
+    return props.messages
+      .map(
+        (message): VisibleChatMessage => ({
+          id: message.id,
+          label: getMessageRoleLabel(message),
+          role: message.role,
+          text: getMessageText(message),
+        }),
+      )
       .filter((message) => message.text.length > 0);
-
-    if (filteredMessages.length === 0) {
-      visibleMessageOrderEntry.orderById.clear();
-      visibleMessageOrderEntry.nextOrder = 0;
-      visibleMessageOrderEntry.previousVisibleMessages = [];
-      return [];
-    }
-
-    const nextVisibleMessageIds = new Set(nextVisibleMessages.map((message) => message.id));
-    const reusableOrdersByKey = new Map<string, number[]>();
-
-    for (const previousMessage of visibleMessageOrderEntry.previousVisibleMessages) {
-      if (nextVisibleMessageIds.has(previousMessage.id)) {
-        continue;
-      }
-
-      const replacementKey = buildVisibleMessageReplacementKey(previousMessage);
-      const reusableOrders = reusableOrdersByKey.get(replacementKey) ?? [];
-      reusableOrders.push(previousMessage.appearanceOrder);
-      reusableOrdersByKey.set(replacementKey, reusableOrders);
-    }
-
-    for (const reusableOrders of reusableOrdersByKey.values()) {
-      reusableOrders.sort((left, right) => left - right);
-    }
-
-    const pendingNewMessages: typeof nextVisibleMessages = [];
-
-    for (const message of nextVisibleMessages) {
-      if (visibleMessageOrderEntry.orderById.has(message.id)) {
-        continue;
-      }
-
-      const replacementKey = buildVisibleMessageReplacementKey(message);
-      const reusableOrders = reusableOrdersByKey.get(replacementKey);
-      const reusableOrder = reusableOrders?.shift();
-      if (reusableOrder !== undefined) {
-        visibleMessageOrderEntry.orderById.set(message.id, reusableOrder);
-        continue;
-      }
-
-      pendingNewMessages.push(message);
-    }
-
-    const orderedPendingNewMessages =
-      visibleMessageOrderEntry.previousVisibleMessages.length === 0
-        ? pendingNewMessages
-        : [...pendingNewMessages].sort(
-            (left, right) =>
-              getIncrementalMessagePriority(left.role) - getIncrementalMessagePriority(right.role) ||
-              left.id.localeCompare(right.id),
-          );
-
-    for (const message of orderedPendingNewMessages) {
-      visibleMessageOrderEntry.orderById.set(message.id, visibleMessageOrderEntry.nextOrder);
-      visibleMessageOrderEntry.nextOrder += 1;
-    }
-    const orderedMessages = orderVisibleChatMessages(filteredMessages, visibleMessageOrderEntry.orderById);
-    visibleMessageOrderEntry.previousVisibleMessages = orderedMessages.map((message) => ({
-      id: message.id,
-      role: message.role,
-      text: message.text,
-      appearanceOrder: message.appearanceOrder,
-    }));
-    return orderedMessages;
-  }, [props.messages, visibleMessageOrderCacheKey]);
+  }, [props.messages]);
   const activityCards = buildPiExampleChatCards(props.activityEvents);
 
   return (

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -119,6 +119,7 @@ interface AgentDetailPageProps {
   fullMetrics?: ThreadMetrics;
   initialTab?: TabType;
   isHired: boolean;
+  isRestoringState?: boolean;
   isHiring: boolean;
   hasLoadedView: boolean;
   isFiring?: boolean;
@@ -890,6 +891,7 @@ export function AgentDetailPage({
   fullMetrics,
   initialTab,
   isHired,
+  isRestoringState = false,
   isHiring,
   hasLoadedView,
   isFiring,
@@ -1957,10 +1959,10 @@ export function AgentDetailPage({
 
               <button
                 onClick={handleHire}
-                disabled={isHiring}
+                disabled={isHiring || isRestoringState}
                 className={[
                   CTA_SIZE_MD_FULL,
-                  isHiring
+                  isHiring || isRestoringState
                     ? 'bg-purple-500/50 text-white cursor-wait'
                     : 'bg-purple-500 hover:bg-purple-600 text-white shadow-[0_10px_30px_rgba(168,85,247,0.25)]',
                   'transition-[background-color,box-shadow] duration-200',
@@ -1968,12 +1970,23 @@ export function AgentDetailPage({
               >
                 {managedOnboardingOwner
                   ? `Open ${managedOnboardingOwner.name}`
-                  : isHiring
+                  : isRestoringState
+                    ? 'Reconnecting...'
+                    : isHiring
                     ? 'Hiring...'
                     : 'Hire'}
               </button>
 
-              {managedOnboardingOwner ? (
+              {isRestoringState ? (
+                <div className="mt-4 rounded-xl bg-[#121212] border border-[#2a2a2a] p-4">
+                  <div className="text-gray-300 text-sm font-medium mb-2">Restoring state</div>
+                  <p className="text-gray-400 text-xs leading-relaxed">
+                    Waiting for the latest runtime snapshot before rendering agent controls.
+                  </p>
+                </div>
+              ) : null}
+
+              {managedOnboardingOwner && !isRestoringState ? (
                 <div className="mt-4 rounded-xl bg-[#121212] border border-[#2a2a2a] p-4">
                   <div className="text-gray-300 text-sm font-medium mb-2">Managed onboarding</div>
                   <p className="text-gray-400 text-xs leading-relaxed">

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentRuntimeProvider.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentRuntimeProvider.tsx
@@ -8,6 +8,7 @@ import { CopilotKit } from '@copilotkit/react-core';
 import { isRegisteredAgentId } from '../config/agents';
 import { AgentProvider, InactiveAgentProvider, useAgent } from '../contexts/AgentContext';
 import { projectAgentListUpdate } from '../contexts/agentListProjection';
+import type { ThreadSnapshot, ThreadState } from '../types/agent';
 import { useAgentList } from '../contexts/AgentListContext';
 import { usePrivyWalletClient } from '../hooks/usePrivyWalletClient';
 import {
@@ -17,6 +18,29 @@ import {
 } from '../utils/agentThread';
 import { emitAgentConnectDebug } from '../utils/agentConnectDebug';
 
+type DetailConnectAgentListUpdateInput = {
+  uiState: Pick<
+    ThreadSnapshot['thread'],
+    'lifecycle' | 'onboardingFlow' | 'task' | 'haltReason' | 'executionError'
+  >;
+  profile: ThreadState['profile'];
+  metrics: ThreadState['metrics'];
+};
+
+export function projectDetailConnectAgentListUpdate(
+  input: DetailConnectAgentListUpdateInput,
+) {
+  return projectAgentListUpdate({
+    lifecycle: input.uiState.lifecycle,
+    onboardingFlow: input.uiState.onboardingFlow,
+    profile: input.profile,
+    metrics: input.metrics,
+    task: input.uiState.task,
+    haltReason: input.uiState.haltReason,
+    executionError: input.uiState.executionError,
+  });
+}
+
 function AgentListRuntimeBridge() {
   const agent = useAgent();
   const { upsertAgent } = useAgentList();
@@ -25,16 +49,21 @@ function AgentListRuntimeBridge() {
 
   const { uiState, config } = agent;
   const agentId = config.id;
+  const { lifecycle, onboardingFlow, task, haltReason, executionError, profile, metrics } = uiState;
 
   useEffect(() => {
     if (!agentId || agentId === 'inactive-agent') return;
 
-    const update = projectAgentListUpdate({
-      profile: uiState.profile,
-      metrics: uiState.metrics,
-      task: uiState.task,
-      haltReason: uiState.haltReason,
-      executionError: uiState.executionError,
+    const update = projectDetailConnectAgentListUpdate({
+      uiState: {
+        lifecycle,
+        onboardingFlow,
+        task,
+        haltReason,
+        executionError,
+      },
+      profile,
+      metrics,
     });
     const snapshotKey = JSON.stringify(update);
     if (snapshotKey === lastSnapshotRef.current) {
@@ -57,12 +86,14 @@ function AgentListRuntimeBridge() {
   }, [
     agentId,
     debugStatus,
+    executionError,
+    haltReason,
+    lifecycle,
+    metrics,
+    onboardingFlow,
+    profile,
+    task,
     upsertAgent,
-    uiState.executionError,
-    uiState.haltReason,
-    uiState.metrics,
-    uiState.profile,
-    uiState.task,
   ]);
 
   return null;

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentRuntimeProvider.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentRuntimeProvider.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { CopilotKit } from '@copilotkit/react-core';
 
 import { isRegisteredAgentId } from '../config/agents';
+import { AuthoritativeAgentSnapshotCacheProvider } from '../contexts/AuthoritativeAgentSnapshotCache';
 import { AgentProvider, InactiveAgentProvider, useAgent } from '../contexts/AgentContext';
 import { projectAgentListUpdate } from '../contexts/agentListProjection';
 import type { ThreadSnapshot, ThreadState } from '../types/agent';
@@ -156,17 +157,10 @@ export function AgentRuntimeProvider({ children }: { children: ReactNode }) {
     walletThreadId,
   ]);
 
-  if (!agentId) {
-    return <InactiveAgentProvider>{children}</InactiveAgentProvider>;
-  }
-
   const threadId = walletThreadId ?? anonymousThreadId;
-
-  if (!threadId) {
-    return <InactiveAgentProvider>{children}</InactiveAgentProvider>;
-  }
-
-  return (
+  const content = !agentId || !threadId ? (
+    <InactiveAgentProvider>{children}</InactiveAgentProvider>
+  ) : (
     <CopilotKit
       runtimeUrl="/api/copilotkit"
       useSingleEndpoint
@@ -179,5 +173,11 @@ export function AgentRuntimeProvider({ children }: { children: ReactNode }) {
         {children}
       </AgentProvider>
     </CopilotKit>
+  );
+
+  return (
+    <AuthoritativeAgentSnapshotCacheProvider>
+      {content}
+    </AuthoritativeAgentSnapshotCacheProvider>
   );
 }

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentRuntimeProvider.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentRuntimeProvider.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectDetailConnectAgentListUpdate } from './AgentRuntimeProvider';
+
+describe('projectDetailConnectAgentListUpdate', () => {
+  it('propagates lifecycle and onboarding status into the list update', () => {
+    const update = projectDetailConnectAgentListUpdate({
+      uiState: {
+        lifecycle: {
+          phase: 'active',
+        },
+        onboardingFlow: {
+          status: 'completed',
+          steps: [],
+        },
+        task: {
+          id: 'task-1',
+          taskStatus: {
+            state: 'working',
+            message: { content: 'Processing managed onboarding.' },
+          },
+        },
+        haltReason: null,
+        executionError: null,
+      },
+      profile: {
+        agentIncome: 0,
+        aum: 0,
+        totalUsers: 0,
+        apy: 0,
+        chains: ['Arbitrum'],
+        protocols: ['Aave'],
+        tokens: ['USDC'],
+        pools: [],
+        allowedPools: [],
+      },
+      metrics: {
+        iteration: 0,
+        cyclesSinceRebalance: 0,
+        staleCycles: 0,
+        rebalanceCycles: 0,
+        aumUsd: 0,
+        apy: 0,
+        lifetimePnlUsd: 0,
+      },
+    });
+
+    expect(update).toMatchObject({
+      lifecyclePhase: 'active',
+      onboardingStatus: 'completed',
+      taskId: 'task-1',
+      taskState: 'working',
+      taskMessage: 'Processing managed onboarding.',
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/components/HireAgentsPage.skeletons.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/HireAgentsPage.skeletons.unit.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { HireAgentsPage } from './HireAgentsPage';
 
 describe('HireAgentsPage (skeleton numbers)', () => {
-  it('renders skeletons for agent numeric fields until list sync has completed', () => {
+  it('renders skeletons for agent numeric fields until list refresh has completed', () => {
     const html = renderToStaticMarkup(
       React.createElement(HireAgentsPage, {
         agents: [

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
@@ -18,6 +18,7 @@ export interface AgentConfig {
   visibleInUserLists?: boolean;
   onboardingOwnerAgentId?: string;
   imperativeCommandTransport?: 'message' | 'forwarded-props';
+  settingsSyncTransport?: 'sync-command' | 'shared-state-update';
   // Static metadata used for pre-auth and degraded modes before runtime stream data arrives.
   chains?: string[];
   protocols?: string[];
@@ -38,7 +39,8 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatar: '🏰',
     avatarBg: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)',
     surfaceTag: 'Workflow',
-    imperativeCommandTransport: 'message',
+    imperativeCommandTransport: 'forwarded-props',
+    settingsSyncTransport: 'sync-command',
     chains: ['Arbitrum'],
     protocols: ['Camelot'],
     tokens: ['USDC', 'WETH', 'WBTC'],
@@ -55,7 +57,8 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatar: '🪙',
     avatarBg: 'linear-gradient(135deg, #f97316 0%, #facc15 100%)',
     surfaceTag: 'Workflow',
-    imperativeCommandTransport: 'message',
+    imperativeCommandTransport: 'forwarded-props',
+    settingsSyncTransport: 'sync-command',
     chains: ['Arbitrum'],
     protocols: ['Pendle'],
     tokens: [
@@ -87,7 +90,8 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatar: '📈',
     avatarBg: 'linear-gradient(135deg, #10b981 0%, #22c55e 100%)',
     surfaceTag: 'Workflow',
-    imperativeCommandTransport: 'message',
+    imperativeCommandTransport: 'forwarded-props',
+    settingsSyncTransport: 'sync-command',
     chains: ['Arbitrum'],
     protocols: ['GMX', 'Allora'],
     tokens: ['USDC', 'WETH'],
@@ -105,6 +109,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #0891b2 0%, #2563eb 100%)',
     visibleInUserLists: false,
     imperativeCommandTransport: 'forwarded-props',
+    settingsSyncTransport: 'sync-command',
     chains: ['Arbitrum'],
     protocols: ['Pi Runtime', 'OpenRouter'],
     tokens: ['USDC'],
@@ -125,6 +130,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     marketplaceRowHoverBg: 'rgba(124,58,237,0.12)',
     surfaceTag: 'Swarm',
     imperativeCommandTransport: 'forwarded-props',
+    settingsSyncTransport: 'shared-state-update',
     chains: ['Arbitrum'],
     protocols: ['Pi Runtime', 'Shared Ember Domain Service'],
     tokens: ['USDC'],
@@ -144,6 +150,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     surfaceTag: 'Swarm',
     onboardingOwnerAgentId: 'agent-portfolio-manager',
     imperativeCommandTransport: 'forwarded-props',
+    settingsSyncTransport: 'shared-state-update',
     chains: ['Arbitrum'],
     protocols: ['Aave'],
     tokens: ['USDC'],

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
@@ -38,6 +38,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatar: '🏰',
     avatarBg: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)',
     surfaceTag: 'Workflow',
+    imperativeCommandTransport: 'message',
     chains: ['Arbitrum'],
     protocols: ['Camelot'],
     tokens: ['USDC', 'WETH', 'WBTC'],
@@ -54,6 +55,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatar: '🪙',
     avatarBg: 'linear-gradient(135deg, #f97316 0%, #facc15 100%)',
     surfaceTag: 'Workflow',
+    imperativeCommandTransport: 'message',
     chains: ['Arbitrum'],
     protocols: ['Pendle'],
     tokens: [
@@ -85,6 +87,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatar: '📈',
     avatarBg: 'linear-gradient(135deg, #10b981 0%, #22c55e 100%)',
     surfaceTag: 'Workflow',
+    imperativeCommandTransport: 'message',
     chains: ['Arbitrum'],
     protocols: ['GMX', 'Allora'],
     tokens: ['USDC', 'WETH'],

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
@@ -18,7 +18,7 @@ export interface AgentConfig {
   visibleInUserLists?: boolean;
   onboardingOwnerAgentId?: string;
   imperativeCommandTransport?: 'message' | 'forwarded-props';
-  settingsSyncTransport?: 'sync-command' | 'shared-state-update';
+  settingsSyncTransport?: 'refresh-command' | 'shared-state-update';
   // Static metadata used for pre-auth and degraded modes before runtime stream data arrives.
   chains?: string[];
   protocols?: string[];
@@ -40,7 +40,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)',
     surfaceTag: 'Workflow',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'sync-command',
+    settingsSyncTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['Camelot'],
     tokens: ['USDC', 'WETH', 'WBTC'],
@@ -58,7 +58,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #f97316 0%, #facc15 100%)',
     surfaceTag: 'Workflow',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'sync-command',
+    settingsSyncTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['Pendle'],
     tokens: [
@@ -91,7 +91,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #10b981 0%, #22c55e 100%)',
     surfaceTag: 'Workflow',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'sync-command',
+    settingsSyncTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['GMX', 'Allora'],
     tokens: ['USDC', 'WETH'],
@@ -109,7 +109,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #0891b2 0%, #2563eb 100%)',
     visibleInUserLists: false,
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'sync-command',
+    settingsSyncTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['Pi Runtime', 'OpenRouter'],
     tokens: ['USDC'],

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
@@ -18,7 +18,7 @@ export interface AgentConfig {
   visibleInUserLists?: boolean;
   onboardingOwnerAgentId?: string;
   imperativeCommandTransport?: 'message' | 'forwarded-props';
-  settingsSyncTransport?: 'refresh-command' | 'shared-state-update';
+  settingsRefreshTransport?: 'refresh-command' | 'shared-state-update';
   // Static metadata used for pre-auth and degraded modes before runtime stream data arrives.
   chains?: string[];
   protocols?: string[];
@@ -40,7 +40,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)',
     surfaceTag: 'Workflow',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'refresh-command',
+    settingsRefreshTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['Camelot'],
     tokens: ['USDC', 'WETH', 'WBTC'],
@@ -58,7 +58,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #f97316 0%, #facc15 100%)',
     surfaceTag: 'Workflow',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'refresh-command',
+    settingsRefreshTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['Pendle'],
     tokens: [
@@ -91,7 +91,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #10b981 0%, #22c55e 100%)',
     surfaceTag: 'Workflow',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'refresh-command',
+    settingsRefreshTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['GMX', 'Allora'],
     tokens: ['USDC', 'WETH'],
@@ -109,7 +109,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     avatarBg: 'linear-gradient(135deg, #0891b2 0%, #2563eb 100%)',
     visibleInUserLists: false,
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'refresh-command',
+    settingsRefreshTransport: 'refresh-command',
     chains: ['Arbitrum'],
     protocols: ['Pi Runtime', 'OpenRouter'],
     tokens: ['USDC'],
@@ -130,7 +130,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     marketplaceRowHoverBg: 'rgba(124,58,237,0.12)',
     surfaceTag: 'Swarm',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'shared-state-update',
+    settingsRefreshTransport: 'shared-state-update',
     chains: ['Arbitrum'],
     protocols: ['Pi Runtime', 'Shared Ember Domain Service'],
     tokens: ['USDC'],
@@ -150,7 +150,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     surfaceTag: 'Swarm',
     onboardingOwnerAgentId: 'agent-portfolio-manager',
     imperativeCommandTransport: 'forwarded-props',
-    settingsSyncTransport: 'shared-state-update',
+    settingsRefreshTransport: 'shared-state-update',
     chains: ['Arbitrum'],
     protocols: ['Aave'],
     tokens: ['USDC'],

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
@@ -37,9 +37,9 @@ describe('agents config', () => {
     expect(emberLending.protocols).toEqual(['Aave']);
     expect(clmm.surfaceTag).toBe('Workflow');
     expect(clmm.imperativeCommandTransport).toBe('forwarded-props');
-    expect(clmm.settingsSyncTransport).toBe('sync-command');
+    expect(clmm.settingsSyncTransport).toBe('refresh-command');
     expect(piExample.imperativeCommandTransport).toBe('forwarded-props');
-    expect(piExample.settingsSyncTransport).toBe('sync-command');
+    expect(piExample.settingsSyncTransport).toBe('refresh-command');
     expect(portfolioManager.imperativeCommandTransport).toBe('forwarded-props');
     expect(portfolioManager.settingsSyncTransport).toBe('shared-state-update');
     expect(emberLending.settingsSyncTransport).toBe('shared-state-update');

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
@@ -36,6 +36,9 @@ describe('agents config', () => {
     expect(emberLending.surfaceTag).toBe('Swarm');
     expect(emberLending.protocols).toEqual(['Aave']);
     expect(clmm.surfaceTag).toBe('Workflow');
+    expect(clmm.imperativeCommandTransport).toBe('message');
+    expect(piExample.imperativeCommandTransport).toBe('forwarded-props');
+    expect(portfolioManager.imperativeCommandTransport).toBe('forwarded-props');
     expect(isRegisteredAgentId('agent-clmm')).toBe(true);
     expect(isRegisteredAgentId('agent-pi-example')).toBe(true);
     expect(isRegisteredAgentId('agent-portfolio-manager')).toBe(true);

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
@@ -37,12 +37,12 @@ describe('agents config', () => {
     expect(emberLending.protocols).toEqual(['Aave']);
     expect(clmm.surfaceTag).toBe('Workflow');
     expect(clmm.imperativeCommandTransport).toBe('forwarded-props');
-    expect(clmm.settingsSyncTransport).toBe('refresh-command');
+    expect(clmm.settingsRefreshTransport).toBe('refresh-command');
     expect(piExample.imperativeCommandTransport).toBe('forwarded-props');
-    expect(piExample.settingsSyncTransport).toBe('refresh-command');
+    expect(piExample.settingsRefreshTransport).toBe('refresh-command');
     expect(portfolioManager.imperativeCommandTransport).toBe('forwarded-props');
-    expect(portfolioManager.settingsSyncTransport).toBe('shared-state-update');
-    expect(emberLending.settingsSyncTransport).toBe('shared-state-update');
+    expect(portfolioManager.settingsRefreshTransport).toBe('shared-state-update');
+    expect(emberLending.settingsRefreshTransport).toBe('shared-state-update');
     expect(isRegisteredAgentId('agent-clmm')).toBe(true);
     expect(isRegisteredAgentId('agent-pi-example')).toBe(true);
     expect(isRegisteredAgentId('agent-portfolio-manager')).toBe(true);

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
@@ -36,9 +36,13 @@ describe('agents config', () => {
     expect(emberLending.surfaceTag).toBe('Swarm');
     expect(emberLending.protocols).toEqual(['Aave']);
     expect(clmm.surfaceTag).toBe('Workflow');
-    expect(clmm.imperativeCommandTransport).toBe('message');
+    expect(clmm.imperativeCommandTransport).toBe('forwarded-props');
+    expect(clmm.settingsSyncTransport).toBe('sync-command');
     expect(piExample.imperativeCommandTransport).toBe('forwarded-props');
+    expect(piExample.settingsSyncTransport).toBe('sync-command');
     expect(portfolioManager.imperativeCommandTransport).toBe('forwarded-props');
+    expect(portfolioManager.settingsSyncTransport).toBe('shared-state-update');
+    expect(emberLending.settingsSyncTransport).toBe('shared-state-update');
     expect(isRegisteredAgentId('agent-clmm')).toBe(true);
     expect(isRegisteredAgentId('agent-pi-example')).toBe(true);
     expect(isRegisteredAgentId('agent-portfolio-manager')).toBe(true);

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/AgentContext.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/AgentContext.tsx
@@ -35,7 +35,6 @@ const inactiveAgent: UseAgentConnectionResult = {
   messages: Array.isArray(initialAgentState.messages)
     ? (initialAgentState.messages as Message[])
     : emptyMessages,
-  messageSnapshotEpoch: 0,
   settings: defaultSettings,
   isHired: false,
   isActive: false,

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/AgentContext.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/AgentContext.tsx
@@ -20,6 +20,7 @@ const inactiveAgent: UseAgentConnectionResult = {
   config: getAgentConfig('inactive-agent'),
   isConnected: false,
   hasLoadedView: false,
+  hasAuthoritativeState: false,
   threadId: undefined,
   domainProjection: {},
   applyDomainProjection: () => undefined,

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/AuthoritativeAgentSnapshotCache.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/AuthoritativeAgentSnapshotCache.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { createContext, useContext, useMemo, useRef, type ReactNode } from 'react';
+
+import type { ThreadSnapshot } from '../types/agent';
+
+type AuthoritativeAgentSnapshotCache = {
+  getSnapshot: (key: string) => ThreadSnapshot | null;
+  setSnapshot: (key: string, snapshot: ThreadSnapshot) => void;
+};
+
+const noopCache: AuthoritativeAgentSnapshotCache = {
+  getSnapshot: () => null,
+  setSnapshot: () => undefined,
+};
+
+const AuthoritativeAgentSnapshotCacheContext =
+  createContext<AuthoritativeAgentSnapshotCache>(noopCache);
+
+export function AuthoritativeAgentSnapshotCacheProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const snapshotsRef = useRef(new Map<string, ThreadSnapshot>());
+
+  const value = useMemo<AuthoritativeAgentSnapshotCache>(
+    () => ({
+      getSnapshot: (key) => snapshotsRef.current.get(key) ?? null,
+      setSnapshot: (key, snapshot) => {
+        snapshotsRef.current.set(key, structuredClone(snapshot));
+      },
+    }),
+    [],
+  );
+
+  return (
+    <AuthoritativeAgentSnapshotCacheContext.Provider value={value}>
+      {children}
+    </AuthoritativeAgentSnapshotCacheContext.Provider>
+  );
+}
+
+export function useAuthoritativeAgentSnapshotCache(): AuthoritativeAgentSnapshotCache {
+  return useContext(AuthoritativeAgentSnapshotCacheContext);
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
@@ -1,5 +1,4 @@
 import type { AgentSubscriber } from '@ag-ui/client';
-import { getAgentConfig } from '../config/agents';
 import { cleanupAgentConnection } from '../utils/agentConnectionCleanup';
 import { isBusyRunError } from '../utils/runConcurrency';
 import {
@@ -12,15 +11,8 @@ type RuntimeSubscription = {
   unsubscribe: () => void;
 };
 
-type CommandMessage = {
-  id: string;
-  role: 'user';
-  content: string;
-};
-
 export type AgentListPollingRuntimeAgent = {
   subscribe: (subscriber: AgentSubscriber) => RuntimeSubscription;
-  addMessage: (message: CommandMessage) => void;
   runAgent: (params?: {
     forwardedProps?: {
       command?: {
@@ -50,10 +42,6 @@ type PollRuntimeAgentFactory = (params: {
   agentId: string;
   threadId: string;
 }) => AgentListPollingRuntimeAgent;
-
-function resolveAgentListPollTransport(agentId: string): 'message' | 'forwarded-props' {
-  return getAgentConfig(agentId).imperativeCommandTransport ?? 'message';
-}
 
 export function resolveAgentListPollIntervalMs(rawValue: string | undefined): number {
   const parsed = Number(rawValue ?? 15_000);
@@ -187,29 +175,14 @@ export async function pollAgentListUpdateViaAgUi(params: {
   });
 
   const runPromise = Promise.resolve(
-    (() => {
-      const commandTransport = resolveAgentListPollTransport(params.agentId);
-      if (commandTransport === 'message') {
-        runtimeAgent.addMessage({
-          id: `agent-list-poll:${params.threadId}:${Date.now()}`,
-          role: 'user',
-          content: JSON.stringify({
-            command: AGENT_LIST_POLL_COMMAND,
-            source: AGENT_LIST_POLL_SOURCE,
-          }),
-        });
-        return runtimeAgent.runAgent();
-      }
-
-      return runtimeAgent.runAgent({
+    runtimeAgent.runAgent({
         forwardedProps: {
           command: {
             name: AGENT_LIST_POLL_COMMAND,
             source: AGENT_LIST_POLL_SOURCE,
           },
         },
-      });
-    })(),
+      }),
   )
     .then(() => {
       runCompleted = true;

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
@@ -31,7 +31,7 @@ export type AgentListPollOutcome = {
 
 const DEFAULT_RUN_COMPLETION_GRACE_MS = 1_000;
 const AGENT_LIST_POLL_SOURCE = 'agent-list-poll';
-const AGENT_LIST_POLL_COMMAND = 'sync';
+const AGENT_LIST_POLL_COMMAND = 'refresh';
 
 function describeError(error: unknown): string {
   if (error instanceof Error) return error.message;

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
@@ -15,9 +15,9 @@ export type AgentListPollingRuntimeAgent = {
   subscribe: (subscriber: AgentSubscriber) => RuntimeSubscription;
   runAgent: (params?: {
     forwardedProps?: {
+      source?: string;
       command?: {
         name?: string;
-        source?: string;
       };
     };
   }) => Promise<unknown>;
@@ -176,13 +176,13 @@ export async function pollAgentListUpdateViaAgUi(params: {
 
   const runPromise = Promise.resolve(
     runtimeAgent.runAgent({
-        forwardedProps: {
-          command: {
-            name: AGENT_LIST_POLL_COMMAND,
-            source: AGENT_LIST_POLL_SOURCE,
-          },
+      forwardedProps: {
+        source: AGENT_LIST_POLL_SOURCE,
+        command: {
+          name: AGENT_LIST_POLL_COMMAND,
         },
-      }),
+      },
+    }),
   )
     .then(() => {
       runCompleted = true;

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.ts
@@ -1,4 +1,5 @@
 import type { AgentSubscriber } from '@ag-ui/client';
+import { getAgentConfig } from '../config/agents';
 import { cleanupAgentConnection } from '../utils/agentConnectionCleanup';
 import { isBusyRunError } from '../utils/runConcurrency';
 import {
@@ -37,6 +38,8 @@ export type AgentListPollOutcome = {
 };
 
 const DEFAULT_RUN_COMPLETION_GRACE_MS = 1_000;
+const AGENT_LIST_POLL_SOURCE = 'agent-list-poll';
+const AGENT_LIST_POLL_COMMAND = 'sync';
 
 function describeError(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -47,6 +50,10 @@ type PollRuntimeAgentFactory = (params: {
   agentId: string;
   threadId: string;
 }) => AgentListPollingRuntimeAgent;
+
+function resolveAgentListPollTransport(agentId: string): 'message' | 'forwarded-props' {
+  return getAgentConfig(agentId).imperativeCommandTransport ?? 'message';
+}
 
 export function resolveAgentListPollIntervalMs(rawValue: string | undefined): number {
   const parsed = Number(rawValue ?? 15_000);
@@ -180,14 +187,29 @@ export async function pollAgentListUpdateViaAgUi(params: {
   });
 
   const runPromise = Promise.resolve(
-    runtimeAgent.runAgent({
-      forwardedProps: {
-        command: {
-          name: 'sync',
-          source: 'agent-list-poll',
+    (() => {
+      const commandTransport = resolveAgentListPollTransport(params.agentId);
+      if (commandTransport === 'message') {
+        runtimeAgent.addMessage({
+          id: `agent-list-poll:${params.threadId}:${Date.now()}`,
+          role: 'user',
+          content: JSON.stringify({
+            command: AGENT_LIST_POLL_COMMAND,
+            source: AGENT_LIST_POLL_SOURCE,
+          }),
+        });
+        return runtimeAgent.runAgent();
+      }
+
+      return runtimeAgent.runAgent({
+        forwardedProps: {
+          command: {
+            name: AGENT_LIST_POLL_COMMAND,
+            source: AGENT_LIST_POLL_SOURCE,
+          },
         },
-      },
-    }),
+      });
+    })(),
   )
     .then(() => {
       runCompleted = true;
@@ -197,7 +219,7 @@ export async function pollAgentListUpdateViaAgUi(params: {
       runCompleted = true;
       pollBusy = isBusyRunError(error);
       console.warn('[agent-list-poll] Poll run rejected', {
-        source: 'agent-list-poll',
+        source: AGENT_LIST_POLL_SOURCE,
         agentId: params.agentId,
         threadId: params.threadId,
         busy: pollBusy,
@@ -215,7 +237,7 @@ export async function pollAgentListUpdateViaAgUi(params: {
   if (!runTerminated) {
     pollBusy = true;
     console.warn('[agent-list-poll] Poll run did not terminate before completion timeout', {
-      source: 'agent-list-poll',
+      source: AGENT_LIST_POLL_SOURCE,
       agentId: params.agentId,
       threadId: params.threadId,
       runCompletionTimeoutMs,

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
@@ -91,7 +91,7 @@ describe('agentListPolling', () => {
     expect(resolveAgentListPollBusyCooldownMs('60000')).toBe(60_000);
   });
 
-  it('preserves workflow-agent poll compatibility through message transport during the migration window', async () => {
+  it('dispatches workflow-agent poll runs through the direct command lane', async () => {
     const unsubscribe = vi.fn();
     const detachActiveRun = vi.fn().mockResolvedValue(undefined);
 
@@ -153,19 +153,16 @@ describe('agentListPolling', () => {
       taskMessage: 'Cycling',
     });
     expect(outcome.busy).toBe(false);
-    expect(runtimeAgent.addMessage).toHaveBeenCalledTimes(1);
-    const syncMessage = runtimeAgent.addMessage.mock.calls[0]?.[0] as { content?: string; role?: string } | undefined;
-    const parsedSyncMessage =
-      typeof syncMessage?.content === 'string'
-        ? (JSON.parse(syncMessage.content) as { command?: string; source?: string })
-        : null;
-    expect(syncMessage?.role).toBe('user');
-    expect(parsedSyncMessage).toEqual({
-      command: 'sync',
-      source: 'agent-list-poll',
-    });
+    expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
     expect(runtimeAgent.runAgent).toHaveBeenCalledTimes(1);
-    expect(runtimeAgent.runAgent).toHaveBeenCalledWith();
+    expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
+      forwardedProps: {
+        command: {
+          name: 'sync',
+          source: 'agent-list-poll',
+        },
+      },
+    });
     expect(runtimeAgent.connectAgent).not.toHaveBeenCalled();
     expect(detachActiveRun).toHaveBeenCalledTimes(1);
     expect(unsubscribe).toHaveBeenCalledTimes(1);

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
@@ -157,9 +157,9 @@ describe('agentListPolling', () => {
     expect(runtimeAgent.runAgent).toHaveBeenCalledTimes(1);
     expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
           forwardedProps: {
+            source: 'agent-list-poll',
             command: {
               name: 'refresh',
-              source: 'agent-list-poll',
             },
           },
     });
@@ -229,9 +229,9 @@ describe('agentListPolling', () => {
     expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
     expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
           forwardedProps: {
+            source: 'agent-list-poll',
             command: {
               name: 'refresh',
-              source: 'agent-list-poll',
             },
           },
     });

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
@@ -156,12 +156,12 @@ describe('agentListPolling', () => {
     expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
     expect(runtimeAgent.runAgent).toHaveBeenCalledTimes(1);
     expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
-      forwardedProps: {
-        command: {
-          name: 'sync',
-          source: 'agent-list-poll',
-        },
-      },
+          forwardedProps: {
+            command: {
+              name: 'refresh',
+              source: 'agent-list-poll',
+            },
+          },
     });
     expect(runtimeAgent.connectAgent).not.toHaveBeenCalled();
     expect(detachActiveRun).toHaveBeenCalledTimes(1);
@@ -228,12 +228,12 @@ describe('agentListPolling', () => {
     expect(outcome.busy).toBe(false);
     expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
     expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
-      forwardedProps: {
-        command: {
-          name: 'sync',
-          source: 'agent-list-poll',
-        },
-      },
+          forwardedProps: {
+            command: {
+              name: 'refresh',
+              source: 'agent-list-poll',
+            },
+          },
     });
     expect(detachActiveRun).toHaveBeenCalledTimes(1);
     expect(unsubscribe).toHaveBeenCalledTimes(1);
@@ -285,7 +285,7 @@ describe('agentListPolling', () => {
             snapshot: {
               settings: {},
               thread: {
-                command: 'sync',
+                command: 'refresh',
                 profile: {
                   chains: [],
                   protocols: [],
@@ -348,7 +348,7 @@ describe('agentListPolling', () => {
             snapshot: {
               settings: {},
               thread: {
-                command: 'sync',
+                command: 'refresh',
                 profile: {
                   chains: [],
                   protocols: [],

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentListPolling.unit.test.ts
@@ -91,7 +91,7 @@ describe('agentListPolling', () => {
     expect(resolveAgentListPollBusyCooldownMs('60000')).toBe(60_000);
   });
 
-  it('projects state snapshot into list update and detaches the short-lived stream', async () => {
+  it('preserves workflow-agent poll compatibility through message transport during the migration window', async () => {
     const unsubscribe = vi.fn();
     const detachActiveRun = vi.fn().mockResolvedValue(undefined);
 
@@ -153,8 +153,83 @@ describe('agentListPolling', () => {
       taskMessage: 'Cycling',
     });
     expect(outcome.busy).toBe(false);
-    expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
+    expect(runtimeAgent.addMessage).toHaveBeenCalledTimes(1);
+    const syncMessage = runtimeAgent.addMessage.mock.calls[0]?.[0] as { content?: string; role?: string } | undefined;
+    const parsedSyncMessage =
+      typeof syncMessage?.content === 'string'
+        ? (JSON.parse(syncMessage.content) as { command?: string; source?: string })
+        : null;
+    expect(syncMessage?.role).toBe('user');
+    expect(parsedSyncMessage).toEqual({
+      command: 'sync',
+      source: 'agent-list-poll',
+    });
     expect(runtimeAgent.runAgent).toHaveBeenCalledTimes(1);
+    expect(runtimeAgent.runAgent).toHaveBeenCalledWith();
+    expect(runtimeAgent.connectAgent).not.toHaveBeenCalled();
+    expect(detachActiveRun).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the canonical direct command lane for Pi-backed poll runs', async () => {
+    const unsubscribe = vi.fn();
+    const detachActiveRun = vi.fn().mockResolvedValue(undefined);
+    let stateSubscriber: AgentSubscriber | null = null;
+
+    const runtimeAgent = {
+      subscribe: vi.fn((subscriber: AgentSubscriber) => {
+        stateSubscriber = subscriber;
+        return { unsubscribe };
+      }),
+      addMessage: vi.fn(),
+      runAgent: vi.fn(async (_params?: { forwardedProps?: { command?: Record<string, unknown> } }) => {
+        stateSubscriber?.onStateSnapshotEvent?.({
+          event: {
+            type: 'STATE_SNAPSHOT',
+            snapshot: {
+              settings: {},
+              thread: {
+                command: 'hire',
+                profile: {
+                  chains: ['Arbitrum'],
+                  protocols: ['Pi Runtime'],
+                  tokens: ['USDC'],
+                  pools: [],
+                  allowedPools: [],
+                },
+                activity: { telemetry: [], events: [] },
+                metrics: { iteration: 0, cyclesSinceRebalance: 0, staleCycles: 0 },
+                task: {
+                  id: 'task-pi',
+                  taskStatus: {
+                    state: 'working',
+                    message: { content: 'Polling live runtime state' },
+                  },
+                },
+                transactionHistory: [],
+              },
+            } as ThreadSnapshot,
+          },
+        } as never);
+      }),
+      detachActiveRun,
+    };
+
+    const outcome = await pollAgentListUpdateViaAgUi({
+      agentId: 'agent-portfolio-manager',
+      threadId: 'thread-pi',
+      timeoutMs: 250,
+      createRuntimeAgent: () => runtimeAgent,
+    });
+
+    expect(outcome.update).toMatchObject({
+      synced: true,
+      taskId: 'task-pi',
+      taskState: 'working',
+      taskMessage: 'Polling live runtime state',
+    });
+    expect(outcome.busy).toBe(false);
+    expect(runtimeAgent.addMessage).not.toHaveBeenCalled();
     expect(runtimeAgent.runAgent).toHaveBeenCalledWith({
       forwardedProps: {
         command: {
@@ -163,7 +238,6 @@ describe('agentListPolling', () => {
         },
       },
     });
-    expect(runtimeAgent.connectAgent).not.toHaveBeenCalled();
     expect(detachActiveRun).toHaveBeenCalledTimes(1);
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/contexts/agentProjection.ts
@@ -47,6 +47,7 @@ function cloneInitialState(): ThreadSnapshot {
     settings: { ...defaultSettings },
     thread: {
       ...defaultThreadState,
+      lifecycle: undefined,
       profile: {
         ...defaultProfile,
         chains: [],

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentSubscriber } from '@ag-ui/client';
 
 import { useAgentConnection } from './useAgentConnection';
+import { AuthoritativeAgentSnapshotCacheProvider } from '../contexts/AuthoritativeAgentSnapshotCache';
 import type { AgentInterrupt } from '../types/agent';
 import { __resetAgentStreamCoordinatorForTests } from '../utils/agentStreamCoordinator';
 import { getAgentThreadId } from '../utils/agentThread';
@@ -133,8 +134,28 @@ vi.mock('../hooks/usePrivyWalletClient', () => ({
   }),
 }));
 
-function TestHarness({ agentId }: { agentId: string }) {
+function TestHarnessInner({ agentId }: { agentId: string }) {
   useAgentConnection(agentId);
+  return <div data-testid="agent-connection-harness" />;
+}
+
+function TestHarness({ agentId }: { agentId: string }) {
+  return (
+    <AuthoritativeAgentSnapshotCacheProvider>
+      <TestHarnessInner agentId={agentId} />
+    </AuthoritativeAgentSnapshotCacheProvider>
+  );
+}
+
+function CapturingHarnessInner({
+  agentId,
+  onSnapshot,
+}: {
+  agentId: string;
+  onSnapshot: (value: ReturnType<typeof useAgentConnection>) => void;
+}) {
+  const value = useAgentConnection(agentId);
+  onSnapshot(value);
   return <div data-testid="agent-connection-harness" />;
 }
 
@@ -145,9 +166,27 @@ function CapturingHarness({
   agentId: string;
   onSnapshot: (value: ReturnType<typeof useAgentConnection>) => void;
 }) {
-  const value = useAgentConnection(agentId);
-  onSnapshot(value);
-  return <div data-testid="agent-connection-harness" />;
+  return (
+    <AuthoritativeAgentSnapshotCacheProvider>
+      <CapturingHarnessInner agentId={agentId} onSnapshot={onSnapshot} />
+    </AuthoritativeAgentSnapshotCacheProvider>
+  );
+}
+
+function RemountableCapturingHarness({
+  mounted,
+  agentId,
+  onSnapshot,
+}: {
+  mounted: boolean;
+  agentId: string;
+  onSnapshot: (value: ReturnType<typeof useAgentConnection>) => void;
+}) {
+  return (
+    <AuthoritativeAgentSnapshotCacheProvider>
+      {mounted ? <CapturingHarnessInner agentId={agentId} onSnapshot={onSnapshot} /> : null}
+    </AuthoritativeAgentSnapshotCacheProvider>
+  );
 }
 
 async function flushEffects(): Promise<void> {
@@ -663,13 +702,17 @@ describe('useAgentConnection integration', () => {
 
     subscriber?.onMessagesSnapshotEvent?.({
       input: { threadId: 'thread-1' },
-      messages: [
-        {
-          id: chatMessage?.id as string,
-          role: 'user',
-          content: 'Hello from the chat tab',
-        },
-      ],
+      messages: [],
+      event: {
+        type: 'MESSAGES_SNAPSHOT',
+        messages: [
+          {
+            id: chatMessage?.id as string,
+            role: 'user',
+            content: 'Hello from the chat tab',
+          },
+        ],
+      },
     });
     await flushEffects();
 
@@ -1571,13 +1614,17 @@ describe('useAgentConnection integration', () => {
 
     subscriber?.onMessagesSnapshotEvent?.({
       input: { threadId: 'thread-1' },
-      messages: [
-        {
-          id: 'assistant-1',
-          role: 'assistant',
-          content: 'Scheduled refresh every minute.',
-        },
-      ],
+      messages: [],
+      event: {
+        type: 'MESSAGES_SNAPSHOT',
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: 'Scheduled refresh every minute.',
+          },
+        ],
+      },
     });
     await flushEffects();
     await act(async () => {
@@ -2200,6 +2247,406 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
 
     expect(latestValue?.hasLoadedView).toBe(true);
+  });
+
+  it('surfaces an authoritative reconnect snapshot immediately without waiting for a later rerender', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.hasAuthoritativeState).toBe(false);
+
+    subscriber?.onStateSnapshotEvent?.({
+      event: {
+        snapshot: {
+          projected: {
+            managedMandateEditor: {
+              mandateRef: 'mandate-ember-lending-primary',
+            },
+          },
+          thread: {
+            lifecycle: {
+              phase: 'active',
+            },
+            task: {
+              id: 'task-refresh',
+              taskStatus: {
+                state: 'completed',
+                message: { content: 'Portfolio state refreshed from Shared Ember Domain Service.' },
+              },
+            },
+          },
+        },
+      },
+      input: { threadId: 'thread-1' },
+    });
+    await flushEffects();
+
+    expect(latestValue?.hasAuthoritativeState).toBe(true);
+    expect(latestValue?.uiState.lifecycle?.phase).toBe('active');
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-primary',
+      },
+    });
+  });
+
+  it('retains the last authoritative snapshot across a route remount while reconnect is still in flight', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+
+    mocks.agent.state = {
+      thread: {
+        lifecycle: {
+          phase: 'active',
+        },
+        task: {
+          id: 'task-managed',
+          taskStatus: {
+            state: 'completed',
+            message: { content: 'Managed lending lane ready.' },
+          },
+        },
+        profile: {
+          chains: ['Arbitrum'],
+          protocols: ['Aave'],
+          tokens: ['USDC'],
+          pools: [],
+          allowedPools: [],
+          totalUsers: 42,
+        },
+        metrics: {
+          iteration: 2,
+          cyclesSinceRebalance: 0,
+          staleCycles: 0,
+          rebalanceCycles: 0,
+          aumUsd: 1000,
+          apy: 4.2,
+          lifetimePnlUsd: 12,
+        },
+        domainProjection: {
+          managedMandateEditor: {
+            mandateRef: 'mandate-ember-lending-001',
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      root.render(
+        <RemountableCapturingHarness
+          mounted
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.hasAuthoritativeState).toBe(true);
+    expect(latestValue?.isHired).toBe(true);
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-001',
+      },
+    });
+
+    mocks.agent.state = {};
+
+    await act(async () => {
+      root.render(
+        <RemountableCapturingHarness
+          mounted={false}
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    await act(async () => {
+      root.render(
+        <RemountableCapturingHarness
+          mounted
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.hasAuthoritativeState).toBe(false);
+    expect(latestValue?.isHired).toBe(true);
+    expect(latestValue?.hasLoadedView).toBe(true);
+    expect(latestValue?.uiState.lifecycle?.phase).toBe('active');
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-001',
+      },
+    });
+  });
+
+  it('preserves normalized mandate projection and transcript when CopilotKit rerenders with raw AG-UI state', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    subscriber?.onStateSnapshotEvent?.({
+      event: {
+        snapshot: {
+          projected: {
+            managedMandateEditor: {
+              mandateRef: 'mandate-ember-lending-primary',
+            },
+          },
+          thread: {
+            lifecycle: {
+              phase: 'active',
+            },
+            task: {
+              id: 'task-refresh',
+              taskStatus: {
+                state: 'completed',
+                message: { content: 'Portfolio state refreshed from Shared Ember Domain Service.' },
+              },
+            },
+          },
+        },
+      },
+      input: { threadId: 'thread-1' },
+    });
+    await flushEffects();
+
+    subscriber?.onMessagesSnapshotEvent?.({
+      input: { threadId: 'thread-1' },
+      messages: [],
+      event: {
+        type: 'MESSAGES_SNAPSHOT',
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: 'Portfolio manager reconnected successfully.',
+          },
+        ],
+      },
+    });
+    await flushEffects();
+
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-primary',
+      },
+    });
+    expect(latestValue?.messages).toEqual([
+      expect.objectContaining({
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Portfolio manager reconnected successfully.',
+      }),
+    ]);
+
+    mocks.agent.state = {
+      projected: {
+        managedMandateEditor: {
+          mandateRef: 'mandate-ember-lending-primary',
+        },
+      },
+      thread: {
+        lifecycle: {
+          phase: 'active',
+        },
+        task: {
+          id: 'task-refresh',
+          taskStatus: {
+            state: 'completed',
+            message: { content: 'Portfolio state refreshed from Shared Ember Domain Service.' },
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-primary',
+      },
+    });
+    expect(latestValue?.messages).toEqual([
+      expect.objectContaining({
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Portfolio manager reconnected successfully.',
+      }),
+    ]);
+  });
+
+  it('keeps the last authoritative active snapshot when a later raw state rerender regresses lifecycle to prehire', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    let subscriber: AgentSubscriber | undefined;
+
+    mocks.agent.subscribe.mockImplementation((nextSubscriber) => {
+      subscriber = nextSubscriber as AgentSubscriber;
+      return {
+        unsubscribe: vi.fn(),
+      };
+    });
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    subscriber?.onStateSnapshotEvent?.({
+      event: {
+        snapshot: {
+          projected: {
+            managedMandateEditor: {
+              mandateRef: 'mandate-ember-lending-primary',
+            },
+          },
+          thread: {
+            lifecycle: {
+              phase: 'active',
+            },
+            task: {
+              id: 'task-refresh',
+              taskStatus: {
+                state: 'completed',
+                message: { content: 'Portfolio state refreshed from Shared Ember Domain Service.' },
+              },
+            },
+          },
+        },
+      },
+      input: { threadId: 'thread-1' },
+    });
+    await flushEffects();
+
+    subscriber?.onMessagesSnapshotEvent?.({
+      input: { threadId: 'thread-1' },
+      messages: [],
+      event: {
+        type: 'MESSAGES_SNAPSHOT',
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: 'Portfolio manager reconnected successfully.',
+          },
+        ],
+      },
+    });
+    await flushEffects();
+
+    expect(latestValue?.isHired).toBe(true);
+    expect(latestValue?.uiState.lifecycle?.phase).toBe('active');
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-primary',
+      },
+    });
+    expect(latestValue?.messages).toEqual([
+      expect.objectContaining({
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Portfolio manager reconnected successfully.',
+      }),
+    ]);
+
+    mocks.agent.state = {
+      thread: {
+        lifecycle: {
+          phase: 'prehire',
+        },
+      },
+    };
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(latestValue?.isHired).toBe(true);
+    expect(latestValue?.uiState.lifecycle?.phase).toBe('active');
+    expect(latestValue?.domainProjection).toMatchObject({
+      managedMandateEditor: {
+        mandateRef: 'mandate-ember-lending-primary',
+      },
+    });
+    expect(latestValue?.messages).toEqual([
+      expect.objectContaining({
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Portfolio manager reconnected successfully.',
+      }),
+    ]);
   });
 
   it('marks agent active from non-terminal task state even when command is omitted', async () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -156,6 +156,28 @@ async function flushEffects(): Promise<void> {
   });
 }
 
+function readLastRunCommand():
+  | {
+      name?: string;
+      clientMutationId?: string;
+      update?: Record<string, unknown>;
+    }
+  | null {
+  const latestCall = mocks.runAgent.mock.calls.at(-1)?.[0] as
+    | {
+        forwardedProps?: {
+          command?: {
+            name?: string;
+            clientMutationId?: string;
+            update?: Record<string, unknown>;
+          };
+        };
+      }
+    | undefined;
+
+  return latestCall?.forwardedProps?.command ?? null;
+}
+
 describe('useAgentConnection integration', () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -430,24 +452,23 @@ describe('useAgentConnection integration', () => {
 
     expect(latestValue).not.toBeNull();
 
+    mocks.agent.addMessage.mockClear();
+    mocks.runAgent.mockClear();
     latestValue?.saveSettings({ amount: 250 });
     await flushEffects();
 
     expect(mocks.agent.setState).toHaveBeenCalled();
-    const syncMessage = mocks.agent.addMessage.mock.calls.at(-1)?.[0] as
-      | { content?: string; role?: string }
-      | undefined;
-    const parsedMessage =
-      typeof syncMessage?.content === 'string'
-        ? (JSON.parse(syncMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(syncMessage?.role).toBe('user');
-    expect(parsedMessage?.command).toBe('sync');
-    expect(typeof parsedMessage?.clientMutationId).toBe('string');
+    expect(mocks.agent.addMessage).not.toHaveBeenCalled();
     expect(mocks.runAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agent: mocks.agent,
         threadId: 'thread-1',
+        forwardedProps: {
+          command: {
+            name: 'sync',
+            clientMutationId: expect.any(String),
+          },
+        },
       }),
     );
   });
@@ -694,15 +715,9 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
     expect(latestValue?.isSyncing).toBe(true);
 
-    const syncMessage = mocks.agent.addMessage.mock.calls.at(-1)?.[0] as
-      | { content?: string }
-      | undefined;
-    const parsedMessage =
-      typeof syncMessage?.content === 'string'
-        ? (JSON.parse(syncMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(parsedMessage?.command).toBe('sync');
-    expect(typeof parsedMessage?.clientMutationId).toBe('string');
+    const forwardedCommand = readLastRunCommand();
+    expect(forwardedCommand?.name).toBe('sync');
+    expect(typeof forwardedCommand?.clientMutationId).toBe('string');
 
     subscriber?.onRunInitialized?.({
       input: { threadId: 'thread-1' },
@@ -710,7 +725,7 @@ describe('useAgentConnection integration', () => {
         settings: { amount: 250 },
         thread: {
           command: 'cycle',
-          lastAppliedClientMutationId: parsedMessage?.clientMutationId,
+          lastAppliedClientMutationId: forwardedCommand?.clientMutationId,
         } as unknown as never,
       },
     });
@@ -1665,19 +1680,23 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
 
     mocks.agent.addMessage.mockClear();
+    mocks.runAgent.mockClear();
     latestValue?.runHire();
     await flushEffects();
 
-    const resumedHireMessage = mocks.agent.addMessage.mock.calls.at(-1)?.[0] as
-      | { role?: string; content?: string }
-      | undefined;
-    const parsedResumedHireMessage =
-      typeof resumedHireMessage?.content === 'string'
-        ? (JSON.parse(resumedHireMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(resumedHireMessage?.role).toBe('user');
-    expect(parsedResumedHireMessage?.command).toBe('hire');
-    expect(typeof parsedResumedHireMessage?.clientMutationId).toBe('string');
+    expect(mocks.agent.addMessage).not.toHaveBeenCalled();
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: mocks.agent,
+        threadId: 'thread-1',
+        forwardedProps: {
+          command: {
+            name: 'hire',
+            clientMutationId: expect.any(String),
+          },
+        },
+      }),
+    );
   });
 
   it('surfaces busy UI state when saveSettings sync dispatch is rejected as busy', async () => {
@@ -1748,19 +1767,24 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
 
     mocks.agent.setState.mockClear();
+    mocks.agent.addMessage.mockClear();
+    mocks.runAgent.mockClear();
     latestValue?.runHire();
     await flushEffects();
 
-    const hireMessage = mocks.agent.addMessage.mock.calls.at(-1)?.[0] as
-      | { role?: string; content?: string }
-      | undefined;
-    const parsedHireMessage =
-      typeof hireMessage?.content === 'string'
-        ? (JSON.parse(hireMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(hireMessage?.role).toBe('user');
-    expect(parsedHireMessage?.command).toBe('hire');
-    expect(typeof parsedHireMessage?.clientMutationId).toBe('string');
+    expect(mocks.agent.addMessage).not.toHaveBeenCalled();
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: mocks.agent,
+        threadId: 'thread-1',
+        forwardedProps: {
+          command: {
+            name: 'hire',
+            clientMutationId: expect.any(String),
+          },
+        },
+      }),
+    );
     expect(mocks.agent.setState).not.toHaveBeenCalled();
   });
 
@@ -1792,6 +1816,7 @@ describe('useAgentConnection integration', () => {
       forwardedProps: {
         command: {
           name: 'hire',
+          clientMutationId: expect.any(String),
         },
       },
     });
@@ -1856,16 +1881,19 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
     await flushEffects();
 
-    const fireMessage = mocks.agent.addMessage.mock.calls.at(-1)?.[0] as
-      | { role?: string; content?: string }
-      | undefined;
-    const parsedFireMessage =
-      typeof fireMessage?.content === 'string'
-        ? (JSON.parse(fireMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(fireMessage?.role).toBe('user');
-    expect(parsedFireMessage?.command).toBe('fire');
-    expect(typeof parsedFireMessage?.clientMutationId).toBe('string');
+    expect(mocks.agent.addMessage).not.toHaveBeenCalled();
+    expect(mocks.runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: mocks.agent,
+        threadId: 'thread-1',
+        forwardedProps: {
+          command: expect.objectContaining({
+            name: 'fire',
+            clientMutationId: expect.any(String),
+          }),
+        },
+      }),
+    );
   });
 
   it('uses stopAgent preemption when backend reports an active run during fire', async () => {
@@ -1943,9 +1971,10 @@ describe('useAgentConnection integration', () => {
         agent: mocks.agent,
         threadId: 'thread-1',
         forwardedProps: {
-          command: {
+          command: expect.objectContaining({
             name: 'fire',
-          },
+            clientMutationId: expect.any(String),
+          }),
         },
       }),
     );

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -435,7 +435,7 @@ describe('useAgentConnection integration', () => {
     }
   });
 
-  it('saveSettings mutates local state and dispatches sync through AG-UI run', async () => {
+  it('saveSettings mutates local state and dispatches refresh through AG-UI run', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
 
     await act(async () => {
@@ -465,7 +465,7 @@ describe('useAgentConnection integration', () => {
         threadId: 'thread-1',
         forwardedProps: {
           command: {
-            name: 'sync',
+            name: 'refresh',
             clientMutationId: expect.any(String),
           },
         },
@@ -473,7 +473,7 @@ describe('useAgentConnection integration', () => {
     );
   });
 
-  it('dispatches PI-runtime settings saves through forwardedProps.command.update instead of a JSON sync message', async () => {
+  it('dispatches PI-runtime settings saves through forwardedProps.command.update instead of a JSON refresh message', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     let subscriber: AgentSubscriber | undefined;
 
@@ -688,7 +688,7 @@ describe('useAgentConnection integration', () => {
     );
   });
 
-  it('does not clear legacy sync pending from lastAppliedClientMutationId thread payloads', async () => {
+  it('does not clear legacy refresh pending from lastAppliedClientMutationId thread payloads', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     let subscriber: AgentSubscriber | undefined;
 
@@ -716,7 +716,7 @@ describe('useAgentConnection integration', () => {
     expect(latestValue?.isSyncing).toBe(true);
 
     const forwardedCommand = readLastRunCommand();
-    expect(forwardedCommand?.name).toBe('sync');
+    expect(forwardedCommand?.name).toBe('refresh');
     expect(typeof forwardedCommand?.clientMutationId).toBe('string');
 
     subscriber?.onRunInitialized?.({
@@ -734,7 +734,7 @@ describe('useAgentConnection integration', () => {
     expect(latestValue?.isSyncing).toBe(true);
   });
 
-  it('clears PI-runtime sync pending when shared-state.control acknowledges the mutation', async () => {
+  it('clears PI-runtime refresh pending when shared-state.control acknowledges the mutation', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     let subscriber: AgentSubscriber | undefined;
 
@@ -971,7 +971,7 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
 
     expect(latestValue?.settings.amount).toBe(100);
-    expect(latestValue?.uiError).toBe('Unable to sync settings until shared state is hydrated.');
+    expect(latestValue?.uiError).toBe('Unable to refresh settings until shared state is hydrated.');
     expect(mocks.runAgent).not.toHaveBeenCalled();
   });
 
@@ -1056,7 +1056,7 @@ describe('useAgentConnection integration', () => {
     await flushEffects();
 
     expect(latestValue?.settings.amount).toBe(100);
-    expect(latestValue?.uiError).toBe('Unable to sync settings right now. Please retry.');
+    expect(latestValue?.uiError).toBe('Unable to refresh settings right now. Please retry.');
     expect(mocks.runAgent).not.toHaveBeenCalled();
   });
 
@@ -1575,7 +1575,7 @@ describe('useAgentConnection integration', () => {
         {
           id: 'assistant-1',
           role: 'assistant',
-          content: 'Scheduled sync every minute.',
+          content: 'Scheduled refresh every minute.',
         },
       ],
     });
@@ -1596,7 +1596,7 @@ describe('useAgentConnection integration', () => {
       expect.objectContaining({
         id: 'assistant-1',
         role: 'assistant',
-        content: 'Scheduled sync every minute.',
+        content: 'Scheduled refresh every minute.',
       }),
     ]);
 
@@ -1606,7 +1606,7 @@ describe('useAgentConnection integration', () => {
           id: 'task-1',
           taskStatus: {
             state: 'completed',
-            message: 'Automation sync executed successfully.',
+            message: 'Automation refresh executed successfully.',
           },
         },
       },
@@ -1699,7 +1699,7 @@ describe('useAgentConnection integration', () => {
     );
   });
 
-  it('surfaces busy UI state when saveSettings sync dispatch is rejected as busy', async () => {
+  it('surfaces busy UI state when saveSettings refresh dispatch is rejected as busy', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     vi.useFakeTimers();
     mocks.runAgent.mockRejectedValue(new Error('run already active'));
@@ -1722,7 +1722,7 @@ describe('useAgentConnection integration', () => {
       await vi.advanceTimersByTimeAsync(2_500);
       await flushEffects();
 
-      expect(latestValue?.uiError).toContain("busy while processing 'sync'");
+      expect(latestValue?.uiError).toContain("busy while processing 'refresh'");
     } finally {
       vi.useRealTimers();
     }
@@ -2171,7 +2171,7 @@ describe('useAgentConnection integration', () => {
     expect(latestValue?.isHired).toBe(false);
   });
 
-  it('treats thread payloads as loaded state for sync gating', async () => {
+  it('treats thread payloads as loaded state for refresh gating', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
 
     mocks.agent.state = {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -8,6 +8,7 @@ import { v7 } from 'uuid';
 import { useLangGraphInterruptCustomUI } from '../app/hooks/useLangGraphInterruptCustomUI';
 import { getAgentConfig, type AgentConfig } from '../config/agents';
 import { projectDetailStateFromPayload } from '../contexts/agentProjection';
+import { useAuthoritativeAgentSnapshotCache } from '../contexts/AuthoritativeAgentSnapshotCache';
 import {
   type ThreadSnapshot,
   type ThreadState,
@@ -157,6 +158,7 @@ export interface UseAgentConnectionResult {
   config: AgentConfig;
   isConnected: boolean;
   hasLoadedView: boolean;
+  hasAuthoritativeState: boolean;
   threadId: string | undefined;
   domainProjection: Record<string, unknown>;
   applyDomainProjection: (projection: Record<string, unknown>) => void;
@@ -247,10 +249,12 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     rollbackSettings: null,
   });
   const [uiError, setUiError] = useState<string | null>(null);
-  const [, setMessageStateRevision] = useState(0);
+  const [, setLocalStateRevision] = useState(0);
   const lastConnectedThreadRef = useRef<string | null>(null);
   const agentRef = useRef<ReturnType<typeof useAgent>['agent'] | null>(null);
   const threadIdRef = useRef<string | undefined>(undefined);
+  const retainedThreadSnapshotRef = useRef<ThreadSnapshot | null>(null);
+  const retainedThreadSnapshotKeyRef = useRef<string | null>(null);
   const activeRunRef = useRef<{
     threadId: string | undefined;
     runId: string | null;
@@ -280,9 +284,11 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     agentId,
     updates: ['OnStateChanged'] as NonNullable<Parameters<typeof useAgent>[0]>['updates'],
   });
+  const authoritativeSnapshotCache = useAuthoritativeAgentSnapshotCache();
   const { threadId: copilotThreadId } = useCopilotContext();
   const { privyWallet } = usePrivyWalletClient();
   const threadId = getAgentThreadId(agentId, privyWallet?.address) ?? copilotThreadId;
+  const authoritativeSnapshotCacheKey = threadId ? `${agentId}:${threadId}` : null;
   const runtimeStatus = copilotkit.runtimeConnectionStatus;
 
   const { activeInterrupt } = useLangGraphInterruptCustomUI<AgentInterrupt>({
@@ -481,6 +487,178 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     );
   }, []);
 
+  const shouldPreserveRetainedThreadSnapshot = useCallback(
+    (params: {
+      rawValue: unknown;
+      nextSnapshot: ThreadSnapshot | null;
+      retainedSnapshot: ThreadSnapshot | null;
+    }): boolean => {
+      const { rawValue, nextSnapshot, retainedSnapshot } = params;
+      if (!nextSnapshot || !retainedSnapshot) {
+        return false;
+      }
+
+      const retainedPhase = retainedSnapshot.thread?.lifecycle?.phase ?? null;
+      if (retainedPhase !== 'active' && retainedPhase !== 'onboarding' && retainedPhase !== 'firing') {
+        return false;
+      }
+
+      const nextPhase = nextSnapshot.thread?.lifecycle?.phase ?? null;
+      if (nextPhase !== 'prehire') {
+        return false;
+      }
+
+      if (typeof rawValue !== 'object' || rawValue === null) {
+        return false;
+      }
+
+      const rawThread =
+        'thread' in rawValue &&
+        typeof (rawValue as { thread?: unknown }).thread === 'object' &&
+        (rawValue as { thread?: unknown }).thread !== null
+          ? ((rawValue as { thread: Record<string, unknown> }).thread as Record<string, unknown>)
+          : null;
+      const rawTask =
+        rawThread &&
+        typeof rawThread.task === 'object' &&
+        rawThread.task !== null
+          ? (rawThread.task as Record<string, unknown>)
+          : null;
+      const rawTaskStatus =
+        rawTask &&
+        typeof rawTask.taskStatus === 'object' &&
+        rawTask.taskStatus !== null
+          ? (rawTask.taskStatus as Record<string, unknown>)
+          : null;
+      const rawTaskState = typeof rawTaskStatus?.state === 'string' ? rawTaskStatus.state : null;
+      const rawProjected =
+        ('projected' in rawValue &&
+          typeof (rawValue as { projected?: unknown }).projected === 'object' &&
+          (rawValue as { projected?: unknown }).projected !== null) ||
+        Boolean(
+          rawThread &&
+            typeof rawThread.domainProjection === 'object' &&
+            rawThread.domainProjection !== null,
+        );
+      const rawMessages = Array.isArray((rawValue as { messages?: unknown }).messages)
+        ? ((rawValue as { messages: unknown[] }).messages as unknown[])
+        : null;
+
+      return rawTaskState === null && !rawProjected && (!rawMessages || rawMessages.length === 0);
+    },
+    [],
+  );
+
+  const bumpLocalStateRevision = useCallback(() => {
+    setLocalStateRevision((current) => current + 1);
+  }, []);
+
+  const readActiveRetainedThreadSnapshot = useCallback((): ThreadSnapshot | null => {
+    if (retainedThreadSnapshotKeyRef.current !== authoritativeSnapshotCacheKey) {
+      return null;
+    }
+    return retainedThreadSnapshotRef.current;
+  }, [authoritativeSnapshotCacheKey]);
+
+  const commitRetainedThreadSnapshot = useCallback(
+    (snapshot: ThreadSnapshot | null) => {
+      retainedThreadSnapshotKeyRef.current = authoritativeSnapshotCacheKey;
+      retainedThreadSnapshotRef.current = snapshot;
+      if (snapshot && authoritativeSnapshotCacheKey) {
+        authoritativeSnapshotCache.setSnapshot(authoritativeSnapshotCacheKey, snapshot);
+      }
+      bumpLocalStateRevision();
+    },
+    [authoritativeSnapshotCache, authoritativeSnapshotCacheKey, bumpLocalStateRevision],
+  );
+
+  const normalizeThreadSnapshotFromBase = useCallback(
+    (value: unknown, cachedSnapshot: ThreadSnapshot | null): ThreadSnapshot | null => {
+      if (!hasStateValues(value)) {
+        return cachedSnapshot;
+      }
+
+      const nextSnapshot = projectDetailStateFromPayload(value, cachedSnapshot);
+      if (!nextSnapshot) {
+        return cachedSnapshot;
+      }
+
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        Array.isArray((value as { messages?: unknown }).messages)
+      ) {
+        nextSnapshot.messages = (value as { messages: Message[] }).messages;
+      }
+
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as { settings?: unknown }).settings === 'object' &&
+        (value as { settings?: unknown }).settings !== null
+      ) {
+        nextSnapshot.settings = {
+          ...(nextSnapshot.settings ?? defaultSettings),
+          ...((value as { settings: Partial<AgentSettings> }).settings ?? {}),
+        };
+      }
+
+      const threadDomainProjection =
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as { thread?: { domainProjection?: unknown } }).thread === 'object' &&
+        (value as { thread?: { domainProjection?: unknown } }).thread !== null &&
+        typeof (value as { thread?: { domainProjection?: unknown } }).thread?.domainProjection === 'object' &&
+        (value as { thread?: { domainProjection?: unknown } }).thread?.domainProjection !== null
+          ? ((value as { thread: { domainProjection: Record<string, unknown> } }).thread
+              .domainProjection as Record<string, unknown>)
+          : null;
+
+      if (threadDomainProjection) {
+        nextSnapshot.thread = {
+          ...nextSnapshot.thread,
+          domainProjection: {
+            ...(typeof nextSnapshot.thread.domainProjection === 'object' &&
+            nextSnapshot.thread.domainProjection !== null
+              ? (nextSnapshot.thread.domainProjection as Record<string, unknown>)
+              : {}),
+            ...threadDomainProjection,
+          },
+        };
+      }
+
+      return nextSnapshot;
+    },
+    [hasStateValues],
+  );
+
+  const normalizeThreadSnapshot = useCallback(
+    (value: unknown): ThreadSnapshot | null => {
+      const cachedSnapshot =
+        readActiveRetainedThreadSnapshot() ??
+        (authoritativeSnapshotCacheKey
+          ? authoritativeSnapshotCache.getSnapshot(authoritativeSnapshotCacheKey)
+          : null);
+
+      return normalizeThreadSnapshotFromBase(value, cachedSnapshot);
+    },
+    [
+      authoritativeSnapshotCache,
+      authoritativeSnapshotCacheKey,
+      normalizeThreadSnapshotFromBase,
+      readActiveRetainedThreadSnapshot,
+    ],
+  );
+
+  const readRetainedThreadSnapshot = useCallback(
+    (value: unknown): ThreadSnapshot | null => normalizeThreadSnapshot(value),
+    [normalizeThreadSnapshot],
+  );
+
+  const readEffectiveThreadSnapshot = useCallback((value: unknown): ThreadSnapshot => {
+    return readActiveRetainedThreadSnapshot() ?? readRetainedThreadSnapshot(value) ?? initialAgentState;
+  }, [readActiveRetainedThreadSnapshot, readRetainedThreadSnapshot]);
+
   const clearPendingSyncMutation = useCallback((clientMutationId: string | null) => {
     if (!clientMutationId) return;
     setPendingSyncMutationByThread((pendingSyncMutation) => {
@@ -552,19 +730,51 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     pendingSyncMutationRef.current = pendingSyncMutationByThread;
   }, [pendingSyncMutationByThread]);
 
+  useEffect(() => {
+    const activeRetainedSnapshot = readActiveRetainedThreadSnapshot();
+    const currentSnapshot = normalizeThreadSnapshot(agent.state);
+    if (!currentSnapshot) {
+      return;
+    }
+
+    if (
+      shouldPreserveRetainedThreadSnapshot({
+        rawValue: agent.state,
+        nextSnapshot: currentSnapshot,
+        retainedSnapshot: activeRetainedSnapshot,
+      })
+    ) {
+      return;
+    }
+
+    retainedThreadSnapshotKeyRef.current = authoritativeSnapshotCacheKey;
+    retainedThreadSnapshotRef.current = currentSnapshot;
+    if (authoritativeSnapshotCacheKey) {
+      authoritativeSnapshotCache.setSnapshot(authoritativeSnapshotCacheKey, currentSnapshot);
+    }
+  }, [
+    agent.state,
+    authoritativeSnapshotCache,
+    authoritativeSnapshotCacheKey,
+    normalizeThreadSnapshot,
+    readActiveRetainedThreadSnapshot,
+    shouldPreserveRetainedThreadSnapshot,
+  ]);
+
   const restoreSettingsSnapshot = useCallback((rollbackSettings: AgentSettings | null) => {
     const currentAgent = agentRef.current;
     if (!currentAgent || !rollbackSettings) return;
 
-    const nextState =
-      hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
-    currentAgent.setState({
+    const nextState = readEffectiveThreadSnapshot(currentAgent.state);
+    const restoredState = {
       ...nextState,
       settings: {
         ...rollbackSettings,
       },
-    });
-  }, [hasStateValues]);
+    };
+    currentAgent.setState(restoredState);
+    commitRetainedThreadSnapshot(restoredState);
+  }, [commitRetainedThreadSnapshot, readEffectiveThreadSnapshot]);
 
   const rollbackPendingSyncMutation = useCallback(
     (clientMutationId: string | null, rollbackSettings: AgentSettings | null) => {
@@ -770,7 +980,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
             ? (statePayload as { tasks: unknown[] }).tasks.length
             : null,
       });
-      const previousState = hasStateValues(agent.state) ? (agent.state as ThreadSnapshot) : null;
+      const previousState = readRetainedThreadSnapshot(agent.state);
       const projectedState = projectDetailStateFromPayload(statePayload, previousState);
       if (projectedState) {
         const previousThread = previousState?.thread;
@@ -795,6 +1005,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           nextTopLevelTaskCount: Array.isArray(projectedState.tasks) ? projectedState.tasks.length : null,
         });
         agent.setState(projectedState);
+        commitRetainedThreadSnapshot(projectedState);
         return;
       }
 
@@ -813,20 +1024,30 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       return (event as { snapshot?: unknown }).snapshot ?? null;
     };
 
+    const extractSnapshotMessages = (payload: unknown): unknown => {
+      if (typeof payload !== 'object' || payload === null) return null;
+      if (!('event' in payload)) return null;
+      const event = (payload as { event?: unknown }).event;
+      if (typeof event !== 'object' || event === null) return null;
+      if (!('messages' in event)) return null;
+      return (event as { messages?: unknown }).messages ?? null;
+    };
+
     const applyMessages = (nextMessages: unknown) => {
       const normalized = Array.isArray(nextMessages) ? (nextMessages as Message[]) : [];
-      const previousState = hasStateValues(agent.state) ? (agent.state as ThreadSnapshot) : initialAgentState;
+      const previousState = readEffectiveThreadSnapshot(agent.state);
       const previousMessages = Array.isArray(previousState.messages)
         ? (previousState.messages as Message[])
         : [];
       if (messagesEqual(previousMessages, normalized)) {
         return;
       }
-      agent.setState({
+      const nextState = {
         ...previousState,
         messages: normalized,
-      });
-      setMessageStateRevision((current) => current + 1);
+      };
+      agent.setState(nextState);
+      commitRetainedThreadSnapshot(nextState);
     };
 
     const subscription = agent.subscribe({
@@ -896,7 +1117,11 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           inputRunId: getInputRunId(payload),
           currentThreadId: threadIdRef.current ?? null,
         });
-        applyMessages(payload.messages);
+        const snapshotMessages = extractSnapshotMessages(payload);
+        if (snapshotMessages === null) {
+          return;
+        }
+        applyMessages(snapshotMessages);
       },
       onMessagesChanged: (payload) => {
         if (!isCurrentThreadEvent(payload)) return;
@@ -925,10 +1150,12 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     emitConnectTrace,
     extractSharedStateControlAck,
     extractSharedStateControlRevision,
-    hasStateValues,
     logConnectEvent,
+    readEffectiveThreadSnapshot,
+    readRetainedThreadSnapshot,
     reconcileSharedStateControlAck,
     setRunInFlight,
+    commitRetainedThreadSnapshot,
   ]);
 
   // Initial refresh when the thread is established - runs once per agent instance
@@ -1214,10 +1441,17 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
   ]);
 
   // Extract state with defaults
-  const currentState =
-    agent.state && Object.keys(agent.state).length > 0
-      ? (agent.state as ThreadSnapshot)
-      : initialAgentState;
+  const renderCachedSnapshot = authoritativeSnapshotCacheKey
+    ? authoritativeSnapshotCache.getSnapshot(authoritativeSnapshotCacheKey)
+    : null;
+  const normalizedCurrentState = normalizeThreadSnapshotFromBase(agent.state, renderCachedSnapshot);
+  const currentState = shouldPreserveRetainedThreadSnapshot({
+    rawValue: agent.state,
+    nextSnapshot: normalizedCurrentState,
+    retainedSnapshot: renderCachedSnapshot,
+  })
+    ? renderCachedSnapshot ?? normalizedCurrentState ?? initialAgentState
+    : normalizedCurrentState ?? renderCachedSnapshot ?? initialAgentState;
   const threadState = currentState.thread ?? defaultThreadState;
   const syncRunPending = syncingState.threadId === threadId ? syncingState.isSyncing : false;
   const pendingSyncMutationId =
@@ -1226,6 +1460,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       : null;
   const isSyncing = syncRunPending || pendingSyncMutationId !== null;
   const hasLoadedView = !needsSync(currentState);
+  const hasAuthoritativeState = hasStateValues(agent.state);
   const uiState: UiState = deriveUiState({
     threadState,
     runtime: {
@@ -1252,10 +1487,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           ? latestEvent.parts[0]?.kind ?? null
           : null;
   const settings = currentState.settings ?? defaultSettings;
-  const messages = useMemo(
-    () => (Array.isArray(currentState.messages) ? (currentState.messages as Message[]) : []),
-    [currentState.messages],
-  );
+  const messages = Array.isArray(currentState.messages) ? (currentState.messages as Message[]) : [];
   const syncedPendingInterrupt = deriveSyncedInterrupt(currentState);
   useEffect(() => {
     emitConnectTrace('state-applied', {
@@ -1337,7 +1569,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     }
   }, [dispatchCommand]);
 
-  const runHire = useCallback(() => {
+  const runHire = () => {
     if (!isHired && !isHiring) {
       setUiError(null);
       if (!runCommand('hire')) {
@@ -1348,7 +1580,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       setIsHiring(true);
       setTimeout(() => setIsHiring(false), 5000);
     }
-  }, [isHired, isHiring, runCommand]);
+  };
 
   const runFire = useCallback(() => {
     if (isFiring) return;
@@ -1579,18 +1811,19 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       const currentAgent = agentRef.current;
       if (!currentAgent) return;
 
-      const nextState =
-        hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
+      const nextState = readEffectiveThreadSnapshot(currentAgent.state);
 
-      currentAgent.setState({
+      const nextSnapshot = {
         ...nextState,
         settings: {
           ...(nextState.settings ?? defaultSettings),
           ...updates,
         },
-      });
+      };
+      currentAgent.setState(nextSnapshot);
+      commitRetainedThreadSnapshot(nextSnapshot);
     },
-    [hasStateValues],
+    [commitRetainedThreadSnapshot, readEffectiveThreadSnapshot],
   );
 
   const saveSettings = useCallback(
@@ -1598,9 +1831,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       setUiError(null);
       const clientMutationId = v7();
       const rollbackSettings = {
-        ...((hasStateValues(agentRef.current?.state)
-          ? ((agentRef.current?.state as ThreadSnapshot).settings ?? defaultSettings)
-          : defaultSettings) as AgentSettings),
+        ...(readEffectiveThreadSnapshot(agentRef.current?.state).settings ?? defaultSettings),
       };
       const sharedStateRevision =
         sharedStateRevisionByThread.threadId === threadId ? sharedStateRevisionByThread.revision : null;
@@ -1626,8 +1857,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         const accepted = scheduler.dispatchCustom({
           command: 'update',
           run: async (currentAgent) => {
-            const nextState =
-              hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
+            const nextState = readEffectiveThreadSnapshot(currentAgent.state);
             const nextSettings = {
               ...(nextState.settings ?? defaultSettings),
               ...updates,
@@ -1683,7 +1913,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     [
       config.settingsRefreshTransport,
       dispatchCommand,
-      hasStateValues,
+      readEffectiveThreadSnapshot,
       runAgentOnCurrentThread,
       rollbackPendingSyncMutation,
       sharedStateRevisionByThread.revision,
@@ -1697,23 +1927,25 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     const currentAgent = agentRef.current;
     if (!currentAgent) return;
 
-    const previousState =
-      hasStateValues(currentAgent.state) ? (currentAgent.state as ThreadSnapshot) : initialAgentState;
+    const previousState = readEffectiveThreadSnapshot(currentAgent.state);
     const previousThread = previousState.thread ?? defaultThreadState;
 
-    currentAgent.setState({
+    const nextSnapshot = {
       ...previousState,
       thread: {
         ...previousThread,
         domainProjection: projection,
       },
-    });
-  }, [hasStateValues]);
+    };
+    currentAgent.setState(nextSnapshot);
+    commitRetainedThreadSnapshot(nextSnapshot);
+  }, [commitRetainedThreadSnapshot, readEffectiveThreadSnapshot]);
 
   return {
     config,
     isConnected: !!threadId,
     hasLoadedView,
+    hasAuthoritativeState,
     threadId,
     domainProjection:
       typeof threadState.domainProjection === 'object' && threadState.domainProjection !== null

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -172,7 +172,6 @@ export interface UseAgentConnectionResult {
   transactionHistory: Transaction[];
   events: ClmmEvent[];
   messages: Message[];
-  messageSnapshotEpoch: number;
   settings: AgentSettings;
 
   // Derived state
@@ -248,7 +247,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     rollbackSettings: null,
   });
   const [uiError, setUiError] = useState<string | null>(null);
-  const [messageSnapshotEpoch, setMessageSnapshotEpoch] = useState(0);
+  const [, setMessageStateRevision] = useState(0);
   const lastConnectedThreadRef = useRef<string | null>(null);
   const agentRef = useRef<ReturnType<typeof useAgent>['agent'] | null>(null);
   const threadIdRef = useRef<string | undefined>(undefined);
@@ -415,7 +414,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
   const dispatchCommand = useCallback(
     (
       command: string,
-      options?: { allowSyncCoalesce?: boolean; messagePayload?: Record<string, unknown> },
+      options?: { allowSyncCoalesce?: boolean; commandPayload?: Record<string, unknown> },
     ) => {
       const scheduler = commandSchedulerRef.current;
       if (!scheduler) {
@@ -441,42 +440,33 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     [copilotkit],
   );
 
+  const runNamedCommandOnCurrentThread = useCallback(
+    (
+      currentAgent: HookAgent,
+      params: {
+        command: string;
+        commandPayload?: Record<string, unknown>;
+      },
+    ) =>
+      runAgentOnCurrentThread(currentAgent, {
+        forwardedProps: {
+          command: {
+            name: params.command,
+            ...(params.commandPayload ?? {}),
+          },
+        },
+      }),
+    [runAgentOnCurrentThread],
+  );
+
   const stopAgentOnCurrentThread = useCallback(
     (currentAgent: HookAgent) => copilotkit.stopAgent({ agent: currentAgent }),
     [copilotkit],
   );
 
-  const runDirectCommand = useCallback(
-    (command: string) => {
-      const scheduler = commandSchedulerRef.current;
-      if (!scheduler) {
-        return false;
-      }
-
-      return scheduler.dispatchCustom({
-        command,
-        run: async (currentAgent) =>
-          runAgentOnCurrentThread(currentAgent, {
-            forwardedProps: {
-              command: {
-                name: command,
-              },
-            },
-          }),
-      });
-    },
-    [runAgentOnCurrentThread],
-  );
-
   const runCommand = useCallback(
-    (command: string) => {
-      if (config.imperativeCommandTransport === 'forwarded-props') {
-        return runDirectCommand(command);
-      }
-
-      return dispatchCommand(command);
-    },
-    [config.imperativeCommandTransport, dispatchCommand, runDirectCommand],
+    (command: string) => dispatchCommand(command),
+    [dispatchCommand],
   );
 
   const setRunInFlight = useCallback((next: boolean) => {
@@ -823,7 +813,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       return (event as { snapshot?: unknown }).snapshot ?? null;
     };
 
-    const applyMessages = (nextMessages: unknown, options?: { resetVisibleOrder?: boolean }) => {
+    const applyMessages = (nextMessages: unknown) => {
       const normalized = Array.isArray(nextMessages) ? (nextMessages as Message[]) : [];
       const previousState = hasStateValues(agent.state) ? (agent.state as ThreadSnapshot) : initialAgentState;
       const previousMessages = Array.isArray(previousState.messages)
@@ -832,13 +822,11 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       if (messagesEqual(previousMessages, normalized)) {
         return;
       }
-      if (options?.resetVisibleOrder) {
-        setMessageSnapshotEpoch((current) => current + 1);
-      }
       agent.setState({
         ...previousState,
         messages: normalized,
       });
+      setMessageStateRevision((current) => current + 1);
     };
 
     const subscription = agent.subscribe({
@@ -908,7 +896,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           inputRunId: getInputRunId(payload),
           currentThreadId: threadIdRef.current ?? null,
         });
-        applyMessages(payload.messages, { resetVisibleOrder: true });
+        applyMessages(payload.messages);
       },
       onMessagesChanged: (payload) => {
         if (!isCurrentThreadEvent(payload)) return;
@@ -958,7 +946,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       getThreadId: () => threadIdRef.current,
       getRunInFlight: () => runInFlightRef.current,
       setRunInFlight,
-      runAgent: async (currentAgent) => runAgentOnCurrentThread(currentAgent),
+      runCommand: async (currentAgent, params) => runNamedCommandOnCurrentThread(currentAgent, params),
       createId: v7,
       isBusyRunError,
       isAbortLikeError,
@@ -969,9 +957,9 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           isSyncing,
         });
       },
-      onSyncRunTerminal: (messagePayload) => {
+      onSyncRunTerminal: (commandPayload) => {
         const clientMutationId =
-          typeof messagePayload?.clientMutationId === 'string' ? messagePayload.clientMutationId : null;
+          typeof commandPayload?.clientMutationId === 'string' ? commandPayload.clientMutationId : null;
         clearPendingSyncMutation(clientMutationId);
       },
       onCommandBusy: (command, error) => {
@@ -1020,7 +1008,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         commandSchedulerRef.current = null;
       }
     };
-  }, [agentId, clearPendingSyncMutation, runAgentOnCurrentThread, setRunInFlight]);
+  }, [agentId, clearPendingSyncMutation, runNamedCommandOnCurrentThread, setRunInFlight]);
 
   useEffect(() => {
     const ownerId = streamOwnerIdRef.current;
@@ -1392,20 +1380,17 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         });
         const ok = await fireAgentRun({
           agent: value,
-          runAgent: async (current) => runAgentOnCurrentThread(current),
-          runDirectCommand: async (current, commandName) =>
-            runAgentOnCurrentThread(current, {
-              forwardedProps: {
-                command: {
-                  name: commandName,
-                },
+          runDirectCommand: async (current, input) =>
+            runNamedCommandOnCurrentThread(current, {
+              command: input.commandName,
+              commandPayload: {
+                clientMutationId: input.clientMutationId,
               },
             }),
           preemptActiveRun: stopAgentOnCurrentThread,
           threadId,
           runInFlightRef,
           createId: v7,
-          commandTransport: config.imperativeCommandTransport,
           onError: (message) => {
             setUiError(message);
             setIsFiring(false);
@@ -1439,9 +1424,8 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
 
     setTimeout(() => setIsFiring(false), 3000);
   }, [
-    config.imperativeCommandTransport,
     isFiring,
-    runAgentOnCurrentThread,
+    runNamedCommandOnCurrentThread,
     stopAgentOnCurrentThread,
     threadId,
   ]);
@@ -1627,7 +1611,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       });
       updateSettings(updates);
 
-      if (config.imperativeCommandTransport === 'forwarded-props') {
+      if (config.settingsSyncTransport === 'shared-state-update') {
         const scheduler = commandSchedulerRef.current;
         if (!scheduler || !sharedStateRevision) {
           rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
@@ -1687,7 +1671,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
 
       const accepted = dispatchCommand('sync', {
         allowSyncCoalesce: true,
-        messagePayload: {
+        commandPayload: {
           clientMutationId,
         },
       });
@@ -1697,7 +1681,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       }
     },
     [
-      config.imperativeCommandTransport,
+      config.settingsSyncTransport,
       dispatchCommand,
       hasStateValues,
       runAgentOnCurrentThread,
@@ -1746,7 +1730,6 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     transactionHistory,
     events,
     messages,
-    messageSnapshotEpoch,
     settings,
     isHired,
     isActive,

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -594,7 +594,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           ack.code === 'stale_revision'
             ? 'Shared settings changed elsewhere. Restored the last saved values; please retry.'
             : ack.code === 'missing_base_revision'
-              ? 'Unable to sync settings until shared state is hydrated.'
+              ? 'Unable to refresh settings until shared state is hydrated.'
               : 'Unable to apply those settings. Restored the last saved values.',
         );
       }
@@ -931,7 +931,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     setRunInFlight,
   ]);
 
-  // Initial sync when thread is established - runs once per agent instance
+  // Initial refresh when the thread is established - runs once per agent instance
   useEffect(() => {
     agentRef.current = agent ?? null;
   }, [agent]);
@@ -964,7 +964,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       },
       onCommandBusy: (command, error) => {
         const detail = error instanceof Error ? error.message : String(error);
-        if (command === 'sync') {
+        if (command === 'refresh') {
           setPendingSyncMutationByThread({
             threadId: threadIdRef.current,
             clientMutationId: null,
@@ -981,7 +981,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
         });
       },
       onCommandError: (command, error) => {
-        if (command === 'sync') {
+        if (command === 'refresh') {
           setPendingSyncMutationByThread({
             threadId: threadIdRef.current,
             clientMutationId: null,
@@ -1331,9 +1331,9 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
 
   const runSync = useCallback(() => {
     setUiError(null);
-    const accepted = dispatchCommand('sync', { allowSyncCoalesce: true });
+    const accepted = dispatchCommand('refresh', { allowSyncCoalesce: true });
     if (!accepted) {
-      setUiError('Unable to queue sync right now. Please retry.');
+      setUiError('Unable to queue refresh right now. Please retry.');
     }
   }, [dispatchCommand]);
 
@@ -1573,7 +1573,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
     [effectiveActiveInterrupt?.type, emitConnectTrace, runAgentOnCurrentThread, runCommand],
   );
 
-  // Local settings mutation helper; caller decides whether to enqueue a sync run.
+  // Local settings mutation helper; caller decides whether to enqueue a refresh run.
   const updateSettings = useCallback(
     (updates: Partial<AgentSettings>) => {
       const currentAgent = agentRef.current;
@@ -1617,8 +1617,8 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
           rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
           setUiError(
             sharedStateRevision
-              ? 'Unable to sync settings right now. Please retry.'
-              : 'Unable to sync settings until shared state is hydrated.',
+              ? 'Unable to refresh settings right now. Please retry.'
+              : 'Unable to refresh settings until shared state is hydrated.',
           );
           return;
         }
@@ -1664,12 +1664,12 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
 
         if (!accepted) {
           rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
-          setUiError('Unable to sync settings right now. Please retry.');
+          setUiError('Unable to refresh settings right now. Please retry.');
         }
         return;
       }
 
-      const accepted = dispatchCommand('sync', {
+      const accepted = dispatchCommand('refresh', {
         allowSyncCoalesce: true,
         commandPayload: {
           clientMutationId,
@@ -1677,7 +1677,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       });
       if (!accepted) {
         rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
-        setUiError('Unable to sync settings right now. Please retry.');
+        setUiError('Unable to refresh settings right now. Please retry.');
       }
     },
     [

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -414,7 +414,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
   const dispatchCommand = useCallback(
     (
       command: string,
-      options?: { allowSyncCoalesce?: boolean; commandPayload?: Record<string, unknown> },
+      options?: { allowRefreshCoalesce?: boolean; commandPayload?: Record<string, unknown> },
     ) => {
       const scheduler = commandSchedulerRef.current;
       if (!scheduler) {
@@ -951,13 +951,13 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       isBusyRunError,
       isAbortLikeError,
       isAgentRunning,
-      onSyncingChange: (isSyncing) => {
+      onRefreshingChange: (isSyncing) => {
         setSyncingState({
           threadId: threadIdRef.current,
           isSyncing,
         });
       },
-      onSyncRunTerminal: (commandPayload) => {
+      onRefreshRunTerminal: (commandPayload) => {
         const clientMutationId =
           typeof commandPayload?.clientMutationId === 'string' ? commandPayload.clientMutationId : null;
         clearPendingSyncMutation(clientMutationId);
@@ -1331,7 +1331,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
 
   const runSync = useCallback(() => {
     setUiError(null);
-    const accepted = dispatchCommand('refresh', { allowSyncCoalesce: true });
+    const accepted = dispatchCommand('refresh', { allowRefreshCoalesce: true });
     if (!accepted) {
       setUiError('Unable to queue refresh right now. Please retry.');
     }
@@ -1611,7 +1611,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       });
       updateSettings(updates);
 
-      if (config.settingsSyncTransport === 'shared-state-update') {
+      if (config.settingsRefreshTransport === 'shared-state-update') {
         const scheduler = commandSchedulerRef.current;
         if (!scheduler || !sharedStateRevision) {
           rollbackPendingSyncMutation(clientMutationId, rollbackSettings);
@@ -1670,7 +1670,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       }
 
       const accepted = dispatchCommand('refresh', {
-        allowSyncCoalesce: true,
+        allowRefreshCoalesce: true,
         commandPayload: {
           clientMutationId,
         },
@@ -1681,7 +1681,7 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
       }
     },
     [
-      config.settingsSyncTransport,
+      config.settingsRefreshTransport,
       dispatchCommand,
       hasStateValues,
       runAgentOnCurrentThread,

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.unit.test.ts
@@ -22,21 +22,21 @@ describe('interruptSelection', () => {
     expect(normalizeAgentInterrupt('{not-json')).toBeNull();
   });
 
-  it('prefers stream interrupt over sync fallback', () => {
+  it('prefers stream interrupt over refresh fallback', () => {
     const streamInterrupt: AgentInterrupt = {
       type: 'operator-config-request',
       message: 'From stream',
     };
-    const syncPendingInterrupt: AgentInterrupt = {
+    const refreshPendingInterrupt: AgentInterrupt = {
       type: 'gmx-setup-request',
-      message: 'From sync',
+      message: 'From refresh',
     };
 
-    expect(selectActiveInterrupt({ streamInterrupt, syncPendingInterrupt })).toEqual(streamInterrupt);
+    expect(selectActiveInterrupt({ streamInterrupt, syncPendingInterrupt: refreshPendingInterrupt })).toEqual(streamInterrupt);
   });
 
-  it('uses sync fallback when stream interrupt is absent', () => {
-    const syncPendingInterrupt: AgentInterrupt = {
+  it('uses refresh fallback when stream interrupt is absent', () => {
+    const refreshPendingInterrupt: AgentInterrupt = {
       type: 'clmm-delegation-signing-request',
       message: 'Sign delegations',
       chainId: 42161,
@@ -48,8 +48,8 @@ describe('interruptSelection', () => {
       warnings: [],
     };
 
-    expect(selectActiveInterrupt({ streamInterrupt: null, syncPendingInterrupt })).toEqual(
-      syncPendingInterrupt,
+    expect(selectActiveInterrupt({ streamInterrupt: null, syncPendingInterrupt: refreshPendingInterrupt })).toEqual(
+      refreshPendingInterrupt,
     );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
@@ -91,7 +91,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     }
 
     if (params.getRunInFlight()) {
-      if (command === 'sync' && options?.allowSyncCoalesce) {
+      if (command === 'refresh' && options?.allowSyncCoalesce) {
         pendingSyncIntent = true;
         pendingSyncCommandPayload = options.commandPayload;
         refreshSyncing();
@@ -106,7 +106,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
 
     params.setRunInFlight(true);
 
-    if (command === 'sync') {
+    if (command === 'refresh') {
       syncRunInFlight = true;
       activeSyncCommandPayload = options?.commandPayload;
       pendingSyncIntent = false;
@@ -123,7 +123,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     void Promise.resolve(run(agent)).catch((error) => {
       params.setRunInFlight(false);
 
-      if (command === 'sync') {
+      if (command === 'refresh') {
         syncRunInFlight = false;
         activeSyncCommandPayload = undefined;
 
@@ -208,7 +208,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   const replayPendingSync = () => {
     if (!pendingSyncIntent) return;
     if (params.getRunInFlight()) return;
-    void dispatch('sync', {
+    void dispatch('refresh', {
       allowSyncCoalesce: true,
       isReplayAttempt: true,
       commandPayload: pendingSyncCommandPayload,

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
@@ -10,7 +10,7 @@ export interface AgentCommandScheduler<TAgent extends SchedulableAgent> {
   dispatch(
     command: string,
     options?: {
-      allowSyncCoalesce?: boolean;
+      allowRefreshCoalesce?: boolean;
       isReplayAttempt?: boolean;
       commandPayload?: CommandPayload;
     },
@@ -41,29 +41,29 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   isBusyRunError: (error: unknown) => boolean;
   isAbortLikeError?: (error: unknown) => boolean;
   isAgentRunning: (agent: TAgent) => boolean;
-  onSyncingChange: (isSyncing: boolean) => void;
-  onSyncRunTerminal?: (commandPayload?: CommandPayload) => void;
+  onRefreshingChange: (isRefreshing: boolean) => void;
+  onRefreshRunTerminal?: (commandPayload?: CommandPayload) => void;
   onCommandError?: (command: string, error: unknown) => void;
   onCommandBusy?: (command: string, error: unknown) => void;
-  syncReplayDelayMs?: number;
-  syncBusyMaxRetries?: number;
+  refreshReplayDelayMs?: number;
+  refreshBusyMaxRetries?: number;
   setTimer?: (callback: () => void, ms: number) => TimerHandle;
   clearTimer?: (handle: TimerHandle) => void;
 }): AgentCommandScheduler<TAgent> {
-  const syncReplayDelayMs = params.syncReplayDelayMs ?? 500;
-  const syncBusyMaxRetries = params.syncBusyMaxRetries ?? 3;
+  const refreshReplayDelayMs = params.refreshReplayDelayMs ?? 500;
+  const refreshBusyMaxRetries = params.refreshBusyMaxRetries ?? 3;
   const setTimer = params.setTimer ?? ((callback: () => void, ms: number) => setTimeout(callback, ms));
   const clearTimer = params.clearTimer ?? ((handle: TimerHandle) => clearTimeout(handle));
 
-  let pendingSyncIntent = false;
-  let pendingSyncCommandPayload: CommandPayload | undefined;
-  let syncRunInFlight = false;
-  let activeSyncCommandPayload: CommandPayload | undefined;
-  let syncBusyRetries = 0;
+  let pendingRefreshIntent = false;
+  let pendingRefreshCommandPayload: CommandPayload | undefined;
+  let refreshRunInFlight = false;
+  let activeRefreshCommandPayload: CommandPayload | undefined;
+  let refreshBusyRetries = 0;
   let replayTimer: TimerHandle | null = null;
 
-  const refreshSyncing = () => {
-    params.onSyncingChange(pendingSyncIntent || syncRunInFlight);
+  const updateRefreshing = () => {
+    params.onRefreshingChange(pendingRefreshIntent || refreshRunInFlight);
   };
 
   const clearReplayTimer = () => {
@@ -76,7 +76,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     command: string;
     run: (agent: TAgent) => Promise<unknown>;
     options?: {
-      allowSyncCoalesce?: boolean;
+      allowRefreshCoalesce?: boolean;
       isReplayAttempt?: boolean;
       commandPayload?: CommandPayload;
       allowPreemptive?: boolean;
@@ -91,10 +91,10 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     }
 
     if (params.getRunInFlight()) {
-      if (command === 'refresh' && options?.allowSyncCoalesce) {
-        pendingSyncIntent = true;
-        pendingSyncCommandPayload = options.commandPayload;
-        refreshSyncing();
+      if (command === 'refresh' && options?.allowRefreshCoalesce) {
+        pendingRefreshIntent = true;
+        pendingRefreshCommandPayload = options.commandPayload;
+        updateRefreshing();
         return true;
       }
       if (options?.allowPreemptive) {
@@ -107,15 +107,15 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     params.setRunInFlight(true);
 
     if (command === 'refresh') {
-      syncRunInFlight = true;
-      activeSyncCommandPayload = options?.commandPayload;
-      pendingSyncIntent = false;
-      pendingSyncCommandPayload = options?.commandPayload;
+      refreshRunInFlight = true;
+      activeRefreshCommandPayload = options?.commandPayload;
+      pendingRefreshIntent = false;
+      pendingRefreshCommandPayload = options?.commandPayload;
       if (!options?.isReplayAttempt) {
-        syncBusyRetries = 0;
+        refreshBusyRetries = 0;
       }
       clearReplayTimer();
-      refreshSyncing();
+      updateRefreshing();
     }
 
     beforeRun?.(agent);
@@ -124,28 +124,28 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
       params.setRunInFlight(false);
 
       if (command === 'refresh') {
-        syncRunInFlight = false;
-        activeSyncCommandPayload = undefined;
+        refreshRunInFlight = false;
+        activeRefreshCommandPayload = undefined;
 
         const busy = params.isBusyRunError(error) || params.isAgentRunning(agent);
         const aborted = params.isAbortLikeError?.(error) ?? false;
-        if ((busy || aborted) && syncBusyRetries < syncBusyMaxRetries) {
-          syncBusyRetries += 1;
-          pendingSyncIntent = true;
-          refreshSyncing();
+        if ((busy || aborted) && refreshBusyRetries < refreshBusyMaxRetries) {
+          refreshBusyRetries += 1;
+          pendingRefreshIntent = true;
+          updateRefreshing();
 
           if (replayTimer === null) {
             replayTimer = setTimer(() => {
               replayTimer = null;
-              replayPendingSync();
-            }, syncReplayDelayMs);
+              replayPendingRefresh();
+            }, refreshReplayDelayMs);
           }
           return;
         }
 
-        pendingSyncIntent = false;
-        syncBusyRetries = 0;
-        refreshSyncing();
+        pendingRefreshIntent = false;
+        refreshBusyRetries = 0;
+        updateRefreshing();
       }
 
       const busy = params.isBusyRunError(error) || params.isAgentRunning(agent);
@@ -164,7 +164,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   const dispatch = (
     command: string,
     options?: {
-      allowSyncCoalesce?: boolean;
+      allowRefreshCoalesce?: boolean;
       isReplayAttempt?: boolean;
       commandPayload?: CommandPayload;
     },
@@ -205,35 +205,35 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     });
   };
 
-  const replayPendingSync = () => {
-    if (!pendingSyncIntent) return;
+  const replayPendingRefresh = () => {
+    if (!pendingRefreshIntent) return;
     if (params.getRunInFlight()) return;
     void dispatch('refresh', {
-      allowSyncCoalesce: true,
+      allowRefreshCoalesce: true,
       isReplayAttempt: true,
-      commandPayload: pendingSyncCommandPayload,
+      commandPayload: pendingRefreshCommandPayload,
     });
   };
 
   const handleRunTerminal = () => {
     params.setRunInFlight(false);
-    syncBusyRetries = 0;
-    if (syncRunInFlight) {
-      const completedSyncCommandPayload = activeSyncCommandPayload;
-      syncRunInFlight = false;
-      activeSyncCommandPayload = undefined;
-      params.onSyncRunTerminal?.(completedSyncCommandPayload);
+    refreshBusyRetries = 0;
+    if (refreshRunInFlight) {
+      const completedRefreshCommandPayload = activeRefreshCommandPayload;
+      refreshRunInFlight = false;
+      activeRefreshCommandPayload = undefined;
+      params.onRefreshRunTerminal?.(completedRefreshCommandPayload);
     }
-    refreshSyncing();
-    replayPendingSync();
+    updateRefreshing();
+    replayPendingRefresh();
   };
 
   const reset = () => {
-    pendingSyncIntent = false;
-    pendingSyncCommandPayload = undefined;
-    syncRunInFlight = false;
-    activeSyncCommandPayload = undefined;
-    syncBusyRetries = 0;
+    pendingRefreshIntent = false;
+    pendingRefreshCommandPayload = undefined;
+    refreshRunInFlight = false;
+    activeRefreshCommandPayload = undefined;
+    refreshBusyRetries = 0;
     clearReplayTimer();
   };
 

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.ts
@@ -1,13 +1,8 @@
-type CommandMessage = {
-  id: string;
-  role: 'user';
-  content: string;
-};
-
 type SchedulableAgent = {
-  addMessage: (message: CommandMessage) => void;
   isRunning?: boolean | (() => boolean);
 };
+
+type CommandPayload = Record<string, unknown>;
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 
@@ -17,7 +12,7 @@ export interface AgentCommandScheduler<TAgent extends SchedulableAgent> {
     options?: {
       allowSyncCoalesce?: boolean;
       isReplayAttempt?: boolean;
-      messagePayload?: Record<string, unknown>;
+      commandPayload?: CommandPayload;
     },
   ): boolean;
   dispatchCustom(params: {
@@ -35,13 +30,19 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   getThreadId: () => string | undefined;
   getRunInFlight: () => boolean;
   setRunInFlight: (next: boolean) => void;
-  runAgent: (agent: TAgent) => Promise<unknown>;
+  runCommand: (
+    agent: TAgent,
+    params: {
+      command: string;
+      commandPayload?: CommandPayload;
+    },
+  ) => Promise<unknown>;
   createId: () => string;
   isBusyRunError: (error: unknown) => boolean;
   isAbortLikeError?: (error: unknown) => boolean;
   isAgentRunning: (agent: TAgent) => boolean;
   onSyncingChange: (isSyncing: boolean) => void;
-  onSyncRunTerminal?: (messagePayload?: Record<string, unknown>) => void;
+  onSyncRunTerminal?: (commandPayload?: CommandPayload) => void;
   onCommandError?: (command: string, error: unknown) => void;
   onCommandBusy?: (command: string, error: unknown) => void;
   syncReplayDelayMs?: number;
@@ -55,9 +56,9 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
   const clearTimer = params.clearTimer ?? ((handle: TimerHandle) => clearTimeout(handle));
 
   let pendingSyncIntent = false;
-  let pendingSyncMessagePayload: Record<string, unknown> | undefined;
+  let pendingSyncCommandPayload: CommandPayload | undefined;
   let syncRunInFlight = false;
-  let activeSyncMessagePayload: Record<string, unknown> | undefined;
+  let activeSyncCommandPayload: CommandPayload | undefined;
   let syncBusyRetries = 0;
   let replayTimer: TimerHandle | null = null;
 
@@ -77,7 +78,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     options?: {
       allowSyncCoalesce?: boolean;
       isReplayAttempt?: boolean;
-      messagePayload?: Record<string, unknown>;
+      commandPayload?: CommandPayload;
       allowPreemptive?: boolean;
     };
     beforeRun?: (agent: TAgent) => void;
@@ -92,7 +93,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     if (params.getRunInFlight()) {
       if (command === 'sync' && options?.allowSyncCoalesce) {
         pendingSyncIntent = true;
-        pendingSyncMessagePayload = options.messagePayload;
+        pendingSyncCommandPayload = options.commandPayload;
         refreshSyncing();
         return true;
       }
@@ -107,9 +108,9 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
 
     if (command === 'sync') {
       syncRunInFlight = true;
-      activeSyncMessagePayload = options?.messagePayload;
+      activeSyncCommandPayload = options?.commandPayload;
       pendingSyncIntent = false;
-      pendingSyncMessagePayload = options?.messagePayload;
+      pendingSyncCommandPayload = options?.commandPayload;
       if (!options?.isReplayAttempt) {
         syncBusyRetries = 0;
       }
@@ -124,7 +125,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
 
       if (command === 'sync') {
         syncRunInFlight = false;
-        activeSyncMessagePayload = undefined;
+        activeSyncCommandPayload = undefined;
 
         const busy = params.isBusyRunError(error) || params.isAgentRunning(agent);
         const aborted = params.isAbortLikeError?.(error) ?? false;
@@ -165,33 +166,28 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     options?: {
       allowSyncCoalesce?: boolean;
       isReplayAttempt?: boolean;
-      messagePayload?: Record<string, unknown>;
+      commandPayload?: CommandPayload;
     },
   ): boolean => {
+    const payload = options?.commandPayload ?? {};
+    const hasClientMutationId =
+      typeof payload['clientMutationId'] === 'string' &&
+      (payload['clientMutationId'] as string).length > 0;
+    const commandPayload = hasClientMutationId
+      ? payload
+      : {
+          ...payload,
+          clientMutationId: params.createId(),
+        };
+
     return dispatchRun({
       command,
       options,
-      beforeRun: (agent) => {
-        const payload = options?.messagePayload ?? {};
-        const hasClientMutationId =
-          typeof payload['clientMutationId'] === 'string' &&
-          (payload['clientMutationId'] as string).length > 0;
-        const messagePayload = hasClientMutationId
-          ? payload
-          : {
-              ...payload,
-              clientMutationId: params.createId(),
-            };
-        agent.addMessage({
-          id: params.createId(),
-          role: 'user',
-          content: JSON.stringify({
-            command,
-            ...messagePayload,
-          }),
-        });
-      },
-      run: params.runAgent,
+      run: (agent) =>
+        params.runCommand(agent, {
+          command,
+          commandPayload,
+        }),
     });
   };
 
@@ -215,7 +211,7 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     void dispatch('sync', {
       allowSyncCoalesce: true,
       isReplayAttempt: true,
-      messagePayload: pendingSyncMessagePayload,
+      commandPayload: pendingSyncCommandPayload,
     });
   };
 
@@ -223,10 +219,10 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
     params.setRunInFlight(false);
     syncBusyRetries = 0;
     if (syncRunInFlight) {
-      const completedSyncMessagePayload = activeSyncMessagePayload;
+      const completedSyncCommandPayload = activeSyncCommandPayload;
       syncRunInFlight = false;
-      activeSyncMessagePayload = undefined;
-      params.onSyncRunTerminal?.(completedSyncMessagePayload);
+      activeSyncCommandPayload = undefined;
+      params.onSyncRunTerminal?.(completedSyncCommandPayload);
     }
     refreshSyncing();
     replayPendingSync();
@@ -234,9 +230,9 @@ export function createAgentCommandScheduler<TAgent extends SchedulableAgent>(par
 
   const reset = () => {
     pendingSyncIntent = false;
-    pendingSyncMessagePayload = undefined;
+    pendingSyncCommandPayload = undefined;
     syncRunInFlight = false;
-    activeSyncMessagePayload = undefined;
+    activeSyncCommandPayload = undefined;
     syncBusyRetries = 0;
     clearReplayTimer();
   };

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
@@ -55,11 +55,11 @@ describe('agentCommandScheduler', () => {
     });
   };
 
-  it('coalesces sync while a run is already in flight', () => {
+  it('coalesces refresh while a run is already in flight', () => {
     runInFlight = true;
     const scheduler = createScheduler();
 
-    const accepted = scheduler.dispatch('sync', { allowSyncCoalesce: true });
+    const accepted = scheduler.dispatch('refresh', { allowSyncCoalesce: true });
 
     expect(accepted).toBe(true);
     expect(runCommand).not.toHaveBeenCalled();
@@ -68,15 +68,15 @@ describe('agentCommandScheduler', () => {
     scheduler.dispose();
   });
 
-  it('replays coalesced sync using the latest command payload', async () => {
+  it('replays coalesced refresh using the latest command payload', async () => {
     runInFlight = true;
     const scheduler = createScheduler();
 
-    scheduler.dispatch('sync', {
+    scheduler.dispatch('refresh', {
       allowSyncCoalesce: true,
       commandPayload: { clientMutationId: 'm-1' },
     });
-    scheduler.dispatch('sync', {
+    scheduler.dispatch('refresh', {
       allowSyncCoalesce: true,
       commandPayload: { clientMutationId: 'm-2' },
     });
@@ -86,7 +86,7 @@ describe('agentCommandScheduler', () => {
 
     expect(runCommand).toHaveBeenCalledTimes(1);
     expect(runCommand).toHaveBeenCalledWith(agent, {
-      command: 'sync',
+      command: 'refresh',
       commandPayload: {
         clientMutationId: 'm-2',
       },
@@ -95,11 +95,11 @@ describe('agentCommandScheduler', () => {
     scheduler.dispose();
   });
 
-  it('replays pending sync once terminal run state is observed', async () => {
+  it('replays pending refresh once terminal run state is observed', async () => {
     runInFlight = true;
     const scheduler = createScheduler();
 
-    scheduler.dispatch('sync', { allowSyncCoalesce: true });
+    scheduler.dispatch('refresh', { allowSyncCoalesce: true });
     expect(runCommand).not.toHaveBeenCalled();
 
     scheduler.handleRunTerminal();
@@ -110,16 +110,16 @@ describe('agentCommandScheduler', () => {
     scheduler.dispose();
   });
 
-  it('reports only the completed sync mutation id when a newer sync is queued behind it', async () => {
+  it('reports only the completed refresh mutation id when a newer refresh is queued behind it', async () => {
     const scheduler = createScheduler();
 
-    scheduler.dispatch('sync', {
+    scheduler.dispatch('refresh', {
       allowSyncCoalesce: true,
       commandPayload: { clientMutationId: 'm-1' },
     });
 
     runInFlight = true;
-    scheduler.dispatch('sync', {
+    scheduler.dispatch('refresh', {
       allowSyncCoalesce: true,
       commandPayload: { clientMutationId: 'm-2' },
     });
@@ -133,7 +133,7 @@ describe('agentCommandScheduler', () => {
       clientMutationId: 'm-1',
     });
     expect(runCommand).toHaveBeenNthCalledWith(2, agent, {
-      command: 'sync',
+      command: 'refresh',
       commandPayload: {
         clientMutationId: 'm-2',
       },
@@ -142,7 +142,7 @@ describe('agentCommandScheduler', () => {
     scheduler.dispose();
   });
 
-  it('uses bounded retries for sync busy responses', async () => {
+  it('uses bounded retries for refresh busy responses', async () => {
     vi.useFakeTimers();
 
     runCommand = vi
@@ -153,14 +153,14 @@ describe('agentCommandScheduler', () => {
     const scheduler = createScheduler({ syncReplayDelayMs: 10, syncBusyMaxRetries: 1 });
 
     try {
-      scheduler.dispatch('sync', { allowSyncCoalesce: true });
+      scheduler.dispatch('refresh', { allowSyncCoalesce: true });
 
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(20);
 
       expect(runCommand).toHaveBeenCalledTimes(2);
       expect(onCommandBusy).toHaveBeenCalledTimes(1);
-      expect(onCommandBusy).toHaveBeenCalledWith('sync', expect.any(Error));
+      expect(onCommandBusy).toHaveBeenCalledWith('refresh', expect.any(Error));
       expect(onCommandError).not.toHaveBeenCalled();
       expect(onSyncingChange).toHaveBeenLastCalledWith(false);
     } finally {
@@ -169,7 +169,7 @@ describe('agentCommandScheduler', () => {
     }
   });
 
-  it('retries sync on abort-like transport failures before surfacing busy state', async () => {
+  it('retries refresh on abort-like transport failures before surfacing busy state', async () => {
     vi.useFakeTimers();
 
     runCommand = vi
@@ -180,7 +180,7 @@ describe('agentCommandScheduler', () => {
     const scheduler = createScheduler({ syncReplayDelayMs: 10, syncBusyMaxRetries: 2 });
 
     try {
-      scheduler.dispatch('sync', { allowSyncCoalesce: true });
+      scheduler.dispatch('refresh', { allowSyncCoalesce: true });
 
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(20);
@@ -194,7 +194,7 @@ describe('agentCommandScheduler', () => {
     }
   });
 
-  it('rejects non-sync command dispatch while run is in flight', () => {
+  it('rejects non-refresh command dispatch while run is in flight', () => {
     runInFlight = true;
     const scheduler = createScheduler();
 

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAgentCommandScheduler } from './agentCommandScheduler';
 
 type SchedulerAgent = {
-  addMessage: ReturnType<typeof vi.fn>;
   isRunning?: boolean;
 };
 
@@ -11,7 +10,7 @@ describe('agentCommandScheduler', () => {
   let runInFlight = false;
   let threadId: string | undefined = 'thread-1';
   let agent: SchedulerAgent | null;
-  let runAgent: ReturnType<typeof vi.fn>;
+  let runCommand: ReturnType<typeof vi.fn>;
   let onSyncingChange: ReturnType<typeof vi.fn>;
   let onCommandError: ReturnType<typeof vi.fn>;
   let onCommandBusy: ReturnType<typeof vi.fn>;
@@ -21,10 +20,9 @@ describe('agentCommandScheduler', () => {
     runInFlight = false;
     threadId = 'thread-1';
     agent = {
-      addMessage: vi.fn(),
       isRunning: false,
     };
-    runAgent = vi.fn(async () => undefined);
+    runCommand = vi.fn(async () => undefined);
     onSyncingChange = vi.fn();
     onCommandError = vi.fn();
     onCommandBusy = vi.fn();
@@ -42,7 +40,7 @@ describe('agentCommandScheduler', () => {
       setRunInFlight: (next) => {
         runInFlight = next;
       },
-      runAgent,
+      runCommand,
       createId: () => 'msg-1',
       isBusyRunError: (error) =>
         error instanceof Error && error.message.includes('already active'),
@@ -64,38 +62,34 @@ describe('agentCommandScheduler', () => {
     const accepted = scheduler.dispatch('sync', { allowSyncCoalesce: true });
 
     expect(accepted).toBe(true);
-    expect(runAgent).not.toHaveBeenCalled();
-    expect(agent?.addMessage).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
     expect(onSyncingChange).toHaveBeenCalledWith(true);
 
     scheduler.dispose();
   });
 
-  it('replays coalesced sync using the latest message payload', async () => {
+  it('replays coalesced sync using the latest command payload', async () => {
     runInFlight = true;
     const scheduler = createScheduler();
 
     scheduler.dispatch('sync', {
       allowSyncCoalesce: true,
-      messagePayload: { clientMutationId: 'm-1' },
+      commandPayload: { clientMutationId: 'm-1' },
     });
     scheduler.dispatch('sync', {
       allowSyncCoalesce: true,
-      messagePayload: { clientMutationId: 'm-2' },
+      commandPayload: { clientMutationId: 'm-2' },
     });
 
     scheduler.handleRunTerminal();
     await Promise.resolve();
 
-    const replayMessage = agent?.addMessage.mock.calls.at(-1)?.[0] as { content?: string } | undefined;
-    const parsedContent =
-      typeof replayMessage?.content === 'string'
-        ? (JSON.parse(replayMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-
-    expect(parsedContent).toEqual({
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expect(runCommand).toHaveBeenCalledWith(agent, {
       command: 'sync',
-      clientMutationId: 'm-2',
+      commandPayload: {
+        clientMutationId: 'm-2',
+      },
     });
 
     scheduler.dispose();
@@ -106,13 +100,12 @@ describe('agentCommandScheduler', () => {
     const scheduler = createScheduler();
 
     scheduler.dispatch('sync', { allowSyncCoalesce: true });
-    expect(runAgent).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
 
     scheduler.handleRunTerminal();
     await Promise.resolve();
 
-    expect(runAgent).toHaveBeenCalledTimes(1);
-    expect(agent?.addMessage).toHaveBeenCalledTimes(1);
+    expect(runCommand).toHaveBeenCalledTimes(1);
 
     scheduler.dispose();
   });
@@ -122,13 +115,13 @@ describe('agentCommandScheduler', () => {
 
     scheduler.dispatch('sync', {
       allowSyncCoalesce: true,
-      messagePayload: { clientMutationId: 'm-1' },
+      commandPayload: { clientMutationId: 'm-1' },
     });
 
     runInFlight = true;
     scheduler.dispatch('sync', {
       allowSyncCoalesce: true,
-      messagePayload: { clientMutationId: 'm-2' },
+      commandPayload: { clientMutationId: 'm-2' },
     });
 
     runInFlight = false;
@@ -139,16 +132,11 @@ describe('agentCommandScheduler', () => {
     expect(onSyncRunTerminal).toHaveBeenCalledWith({
       clientMutationId: 'm-1',
     });
-
-    const replayMessage = agent?.addMessage.mock.calls.at(-1)?.[0] as { content?: string } | undefined;
-    const parsedReplay =
-      typeof replayMessage?.content === 'string'
-        ? (JSON.parse(replayMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-
-    expect(parsedReplay).toEqual({
+    expect(runCommand).toHaveBeenNthCalledWith(2, agent, {
       command: 'sync',
-      clientMutationId: 'm-2',
+      commandPayload: {
+        clientMutationId: 'm-2',
+      },
     });
 
     scheduler.dispose();
@@ -157,7 +145,7 @@ describe('agentCommandScheduler', () => {
   it('uses bounded retries for sync busy responses', async () => {
     vi.useFakeTimers();
 
-    runAgent = vi
+    runCommand = vi
       .fn<() => Promise<void>>()
       .mockRejectedValueOnce(new Error('run already active'))
       .mockRejectedValueOnce(new Error('run already active'));
@@ -170,7 +158,7 @@ describe('agentCommandScheduler', () => {
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(20);
 
-      expect(runAgent).toHaveBeenCalledTimes(2);
+      expect(runCommand).toHaveBeenCalledTimes(2);
       expect(onCommandBusy).toHaveBeenCalledTimes(1);
       expect(onCommandBusy).toHaveBeenCalledWith('sync', expect.any(Error));
       expect(onCommandError).not.toHaveBeenCalled();
@@ -184,7 +172,7 @@ describe('agentCommandScheduler', () => {
   it('retries sync on abort-like transport failures before surfacing busy state', async () => {
     vi.useFakeTimers();
 
-    runAgent = vi
+    runCommand = vi
       .fn<() => Promise<void>>()
       .mockRejectedValueOnce(new Error('BodyStreamBuffer was aborted'))
       .mockResolvedValueOnce(undefined);
@@ -197,7 +185,7 @@ describe('agentCommandScheduler', () => {
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(20);
 
-      expect(runAgent).toHaveBeenCalledTimes(2);
+      expect(runCommand).toHaveBeenCalledTimes(2);
       expect(onCommandBusy).not.toHaveBeenCalled();
       expect(onCommandError).not.toHaveBeenCalled();
     } finally {
@@ -213,34 +201,29 @@ describe('agentCommandScheduler', () => {
     const accepted = scheduler.dispatch('hire');
 
     expect(accepted).toBe(false);
-    expect(runAgent).not.toHaveBeenCalled();
-    expect(agent?.addMessage).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
 
     scheduler.dispose();
   });
 
-  it('adds a clientMutationId to command messages when one is not provided', () => {
+  it('adds a clientMutationId to direct command payloads when one is not provided', () => {
     const scheduler = createScheduler();
 
     const accepted = scheduler.dispatch('hire');
 
     expect(accepted).toBe(true);
-    const firstMessage = agent?.addMessage.mock.calls[0]?.[0] as { content?: string } | undefined;
-    const parsedContent =
-      typeof firstMessage?.content === 'string'
-        ? (JSON.parse(firstMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-
-    expect(parsedContent).toEqual({
+    expect(runCommand).toHaveBeenCalledWith(agent, {
       command: 'hire',
-      clientMutationId: 'msg-1',
+      commandPayload: {
+        clientMutationId: 'msg-1',
+      },
     });
 
     scheduler.dispose();
   });
 
   it('normalizes busy failures for non-sync commands via onCommandBusy', async () => {
-    runAgent = vi.fn(async () => {
+    runCommand = vi.fn(async () => {
       throw new Error('run already active');
     });
     const scheduler = createScheduler();
@@ -256,7 +239,7 @@ describe('agentCommandScheduler', () => {
   });
 
   it('treats abort-like failures for non-sync commands as transient busy responses', async () => {
-    runAgent = vi.fn(async () => {
+    runCommand = vi.fn(async () => {
       throw new Error('BodyStreamBuffer was aborted');
     });
     const scheduler = createScheduler();
@@ -283,7 +266,6 @@ describe('agentCommandScheduler', () => {
 
     expect(accepted).toBe(true);
     expect(runCustom).toHaveBeenCalledTimes(1);
-    expect(agent?.addMessage).not.toHaveBeenCalled();
 
     scheduler.dispose();
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/agentCommandScheduler.unit.test.ts
@@ -11,10 +11,10 @@ describe('agentCommandScheduler', () => {
   let threadId: string | undefined = 'thread-1';
   let agent: SchedulerAgent | null;
   let runCommand: ReturnType<typeof vi.fn>;
-  let onSyncingChange: ReturnType<typeof vi.fn>;
+  let onRefreshingChange: ReturnType<typeof vi.fn>;
   let onCommandError: ReturnType<typeof vi.fn>;
   let onCommandBusy: ReturnType<typeof vi.fn>;
-  let onSyncRunTerminal: ReturnType<typeof vi.fn>;
+  let onRefreshRunTerminal: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     runInFlight = false;
@@ -23,15 +23,15 @@ describe('agentCommandScheduler', () => {
       isRunning: false,
     };
     runCommand = vi.fn(async () => undefined);
-    onSyncingChange = vi.fn();
+    onRefreshingChange = vi.fn();
     onCommandError = vi.fn();
     onCommandBusy = vi.fn();
-    onSyncRunTerminal = vi.fn();
+    onRefreshRunTerminal = vi.fn();
   });
 
   const createScheduler = (options?: {
-    syncReplayDelayMs?: number;
-    syncBusyMaxRetries?: number;
+    refreshReplayDelayMs?: number;
+    refreshBusyMaxRetries?: number;
   }) => {
     return createAgentCommandScheduler<SchedulerAgent>({
       getAgent: () => agent,
@@ -46,12 +46,12 @@ describe('agentCommandScheduler', () => {
         error instanceof Error && error.message.includes('already active'),
       isAbortLikeError: (error) => error instanceof Error && error.message.includes('aborted'),
       isAgentRunning: (value) => value.isRunning === true,
-      onSyncingChange,
+      onRefreshingChange,
       onCommandError,
       onCommandBusy,
-      onSyncRunTerminal,
-      syncReplayDelayMs: options?.syncReplayDelayMs ?? 25,
-      syncBusyMaxRetries: options?.syncBusyMaxRetries ?? 2,
+      onRefreshRunTerminal,
+      refreshReplayDelayMs: options?.refreshReplayDelayMs ?? 25,
+      refreshBusyMaxRetries: options?.refreshBusyMaxRetries ?? 2,
     });
   };
 
@@ -59,11 +59,11 @@ describe('agentCommandScheduler', () => {
     runInFlight = true;
     const scheduler = createScheduler();
 
-    const accepted = scheduler.dispatch('refresh', { allowSyncCoalesce: true });
+    const accepted = scheduler.dispatch('refresh', { allowRefreshCoalesce: true });
 
     expect(accepted).toBe(true);
     expect(runCommand).not.toHaveBeenCalled();
-    expect(onSyncingChange).toHaveBeenCalledWith(true);
+    expect(onRefreshingChange).toHaveBeenCalledWith(true);
 
     scheduler.dispose();
   });
@@ -73,11 +73,11 @@ describe('agentCommandScheduler', () => {
     const scheduler = createScheduler();
 
     scheduler.dispatch('refresh', {
-      allowSyncCoalesce: true,
+      allowRefreshCoalesce: true,
       commandPayload: { clientMutationId: 'm-1' },
     });
     scheduler.dispatch('refresh', {
-      allowSyncCoalesce: true,
+      allowRefreshCoalesce: true,
       commandPayload: { clientMutationId: 'm-2' },
     });
 
@@ -99,7 +99,7 @@ describe('agentCommandScheduler', () => {
     runInFlight = true;
     const scheduler = createScheduler();
 
-    scheduler.dispatch('refresh', { allowSyncCoalesce: true });
+    scheduler.dispatch('refresh', { allowRefreshCoalesce: true });
     expect(runCommand).not.toHaveBeenCalled();
 
     scheduler.handleRunTerminal();
@@ -114,13 +114,13 @@ describe('agentCommandScheduler', () => {
     const scheduler = createScheduler();
 
     scheduler.dispatch('refresh', {
-      allowSyncCoalesce: true,
+      allowRefreshCoalesce: true,
       commandPayload: { clientMutationId: 'm-1' },
     });
 
     runInFlight = true;
     scheduler.dispatch('refresh', {
-      allowSyncCoalesce: true,
+      allowRefreshCoalesce: true,
       commandPayload: { clientMutationId: 'm-2' },
     });
 
@@ -128,8 +128,8 @@ describe('agentCommandScheduler', () => {
     scheduler.handleRunTerminal();
     await Promise.resolve();
 
-    expect(onSyncRunTerminal).toHaveBeenCalledTimes(1);
-    expect(onSyncRunTerminal).toHaveBeenCalledWith({
+    expect(onRefreshRunTerminal).toHaveBeenCalledTimes(1);
+    expect(onRefreshRunTerminal).toHaveBeenCalledWith({
       clientMutationId: 'm-1',
     });
     expect(runCommand).toHaveBeenNthCalledWith(2, agent, {
@@ -150,10 +150,10 @@ describe('agentCommandScheduler', () => {
       .mockRejectedValueOnce(new Error('run already active'))
       .mockRejectedValueOnce(new Error('run already active'));
 
-    const scheduler = createScheduler({ syncReplayDelayMs: 10, syncBusyMaxRetries: 1 });
+    const scheduler = createScheduler({ refreshReplayDelayMs: 10, refreshBusyMaxRetries: 1 });
 
     try {
-      scheduler.dispatch('refresh', { allowSyncCoalesce: true });
+      scheduler.dispatch('refresh', { allowRefreshCoalesce: true });
 
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(20);
@@ -162,7 +162,7 @@ describe('agentCommandScheduler', () => {
       expect(onCommandBusy).toHaveBeenCalledTimes(1);
       expect(onCommandBusy).toHaveBeenCalledWith('refresh', expect.any(Error));
       expect(onCommandError).not.toHaveBeenCalled();
-      expect(onSyncingChange).toHaveBeenLastCalledWith(false);
+      expect(onRefreshingChange).toHaveBeenLastCalledWith(false);
     } finally {
       scheduler.dispose();
       vi.useRealTimers();
@@ -177,10 +177,10 @@ describe('agentCommandScheduler', () => {
       .mockRejectedValueOnce(new Error('BodyStreamBuffer was aborted'))
       .mockResolvedValueOnce(undefined);
 
-    const scheduler = createScheduler({ syncReplayDelayMs: 10, syncBusyMaxRetries: 2 });
+    const scheduler = createScheduler({ refreshReplayDelayMs: 10, refreshBusyMaxRetries: 2 });
 
     try {
-      scheduler.dispatch('refresh', { allowSyncCoalesce: true });
+      scheduler.dispatch('refresh', { allowRefreshCoalesce: true });
 
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(20);

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/fireAgentRun.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/fireAgentRun.ts
@@ -2,12 +2,9 @@ import type { v7 as uuidv7 } from 'uuid';
 import { isAbortLikeError, isAgentRunning, isBusyRunError } from './runConcurrency';
 
 type AgentLike = {
-  addMessage: (message: { id: string; role: 'user'; content: string }) => void;
   detachActiveRun?: () => Promise<void> | void;
   isRunning?: boolean | (() => boolean);
 };
-
-type FireCommandTransport = 'message' | 'forwarded-props';
 
 type BoolRef = { current: boolean };
 
@@ -140,13 +137,14 @@ const startFireRun = async <TAgent extends AgentLike>(
 
 export async function fireAgentRun<TAgent extends AgentLike>(params: {
   agent: TAgent | null;
-  runAgent: (agent: TAgent) => Promise<unknown>;
-  runDirectCommand?: (agent: TAgent, commandName: 'fire') => Promise<unknown>;
+  runDirectCommand: (
+    agent: TAgent,
+    input: { commandName: 'fire'; clientMutationId: string },
+  ) => Promise<unknown>;
   preemptActiveRun?: (agent: TAgent) => Promise<void> | void;
   threadId: string | undefined;
   runInFlightRef: BoolRef;
   createId: typeof uuidv7;
-  commandTransport?: FireCommandTransport;
   onError?: (message: string) => void;
   preemptWaitMs?: number;
   preemptPollMs?: number;
@@ -303,26 +301,12 @@ export async function fireAgentRun<TAgent extends AgentLike>(params: {
     runInFlight: runInFlightRef.current,
   });
 
-  const commandTransport = params.commandTransport ?? 'message';
-  if (commandTransport === 'message') {
-    const fireClientMutationId = params.createId();
-    agent.addMessage({
-      id: params.createId(),
-      role: 'user',
-      content: JSON.stringify({ command: 'fire', clientMutationId: fireClientMutationId }),
+  const fireClientMutationId = params.createId();
+  const startRun = (currentAgent: TAgent) =>
+    params.runDirectCommand(currentAgent, {
+      commandName: 'fire',
+      clientMutationId: fireClientMutationId,
     });
-  }
-
-  const startRun =
-    commandTransport === 'forwarded-props'
-      ? (currentAgent: TAgent) => {
-          if (!params.runDirectCommand) {
-            throw new Error('Direct fire command transport requires runDirectCommand.');
-          }
-
-          return params.runDirectCommand(currentAgent, 'fire');
-        }
-      : params.runAgent;
 
   // Fire-and-forget with short retry if the runtime is still finalizing a previous run.
   logFireCommandDebug('starting fire run dispatch', {

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/fireAgentRun.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/fireAgentRun.unit.test.ts
@@ -2,21 +2,32 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { fireAgentRun } from './fireAgentRun';
 
+function expectFireDispatch(
+  runDirectCommand: ReturnType<typeof vi.fn>,
+  callIndex = 0,
+  clientMutationId = 'msg-1',
+): void {
+  expect(runDirectCommand.mock.calls[callIndex]?.[1]).toEqual({
+    commandName: 'fire',
+    clientMutationId,
+  });
+}
+
 describe('fireAgentRun', () => {
   it('detaches stale runtime ownership before dispatching fire when no run appears active', async () => {
     const calls: string[] = [];
     const agent = {
       isRunning: false,
       detachActiveRun: vi.fn(async () => calls.push('detachActiveRun')),
-      addMessage: vi.fn(() => calls.push('addMessage')),
     };
+    const runDirectCommand = vi.fn(async () => {
+      calls.push('runDirectCommand');
+    });
     const runInFlightRef = { current: false };
 
     const ok = await fireAgentRun({
       agent,
-      runAgent: async () => {
-        calls.push('runAgent');
-      },
+      runDirectCommand,
       threadId: 'thread-1',
       runInFlightRef,
       createId: () => 'msg-1',
@@ -24,55 +35,47 @@ describe('fireAgentRun', () => {
 
     expect(ok).toBe(true);
     expect(agent.detachActiveRun).toHaveBeenCalledTimes(1);
-    expect(calls).toEqual(['detachActiveRun', 'addMessage', 'runAgent']);
+    expect(runDirectCommand).toHaveBeenCalledTimes(1);
+    expectFireDispatch(runDirectCommand);
+    expect(calls).toEqual(['detachActiveRun', 'runDirectCommand']);
   });
 
-  it('enqueues fire command with a clientMutationId for replay-safe routing', async () => {
+  it('dispatches fire command with a clientMutationId for replay-safe routing', async () => {
     const agent = {
       isRunning: false,
       detachActiveRun: vi.fn(async () => undefined),
-      addMessage: vi.fn(),
     };
+    const runDirectCommand = vi.fn(async () => undefined);
     const runInFlightRef = { current: false };
 
     const ok = await fireAgentRun({
       agent,
-      runAgent: async () => undefined,
+      runDirectCommand,
       threadId: 'thread-1',
       runInFlightRef,
       createId: () => 'msg-1',
     });
 
     expect(ok).toBe(true);
-    const firstMessage = agent.addMessage.mock.calls[0]?.[0] as { content?: string } | undefined;
-    const parsedContent =
-      typeof firstMessage?.content === 'string'
-        ? (JSON.parse(firstMessage.content) as { command?: string; clientMutationId?: string })
-        : null;
-    expect(parsedContent).toEqual({
-      command: 'fire',
-      clientMutationId: 'msg-1',
-    });
+    expectFireDispatch(runDirectCommand);
   });
 
-  it('preempts the active run via stop callback, detaches, then sends the fire command', async () => {
+  it('preempts the active run via stop callback, detaches, then dispatches the fire command', async () => {
     const calls: string[] = [];
 
     const agent = {
       isRunning: true,
       abortRun: vi.fn(() => calls.push('abortRun')),
       detachActiveRun: vi.fn(async () => calls.push('detachActiveRun')),
-      addMessage: vi.fn(() => calls.push('addMessage')),
     };
-    const copilotkit = {
-      runAgent: vi.fn(async () => calls.push('runAgent')),
-    };
-
+    const runDirectCommand = vi.fn(async () => {
+      calls.push('runDirectCommand');
+    });
     const runInFlightRef = { current: true };
 
     const ok = await fireAgentRun({
       agent,
-      runAgent: async (value) => copilotkit.runAgent({ agent: value }),
+      runDirectCommand,
       preemptActiveRun: async () => {
         calls.push('stopAgent');
         runInFlightRef.current = false;
@@ -86,9 +89,9 @@ describe('fireAgentRun', () => {
     expect(runInFlightRef.current).toBe(true);
     expect(agent.abortRun).not.toHaveBeenCalled();
     expect(agent.detachActiveRun).toHaveBeenCalledTimes(1);
-    expect(agent.addMessage).toHaveBeenCalledTimes(1);
-    expect(copilotkit.runAgent).toHaveBeenCalledTimes(1);
-    expect(calls).toEqual(['stopAgent', 'detachActiveRun', 'addMessage', 'runAgent']);
+    expect(runDirectCommand).toHaveBeenCalledTimes(1);
+    expectFireDispatch(runDirectCommand);
+    expect(calls).toEqual(['stopAgent', 'detachActiveRun', 'runDirectCommand']);
   });
 
   it('does not call stop when local run ownership is stale but backend run is not active', async () => {
@@ -97,8 +100,10 @@ describe('fireAgentRun', () => {
     const agent = {
       isRunning: false,
       detachActiveRun: vi.fn(async () => calls.push('detachActiveRun')),
-      addMessage: vi.fn(() => calls.push('addMessage')),
     };
+    const runDirectCommand = vi.fn(async () => {
+      calls.push('runDirectCommand');
+    });
     const runInFlightRef = { current: true };
     const preemptActiveRun = vi.fn(async () => {
       calls.push('stopAgent');
@@ -106,9 +111,7 @@ describe('fireAgentRun', () => {
 
     const ok = await fireAgentRun({
       agent,
-      runAgent: async () => {
-        calls.push('runAgent');
-      },
+      runDirectCommand,
       preemptActiveRun,
       threadId: 'thread-1',
       runInFlightRef,
@@ -118,79 +121,73 @@ describe('fireAgentRun', () => {
     expect(ok).toBe(true);
     expect(preemptActiveRun).not.toHaveBeenCalled();
     expect(agent.detachActiveRun).toHaveBeenCalledTimes(1);
-    expect(calls).toEqual(['detachActiveRun', 'addMessage', 'runAgent']);
+    expect(runDirectCommand).toHaveBeenCalledTimes(1);
+    expectFireDispatch(runDirectCommand);
+    expect(calls).toEqual(['detachActiveRun', 'runDirectCommand']);
   });
 
-  it('retries run start when the runtime reports an active run, without re-adding fire message', async () => {
+  it('retries run start when the runtime reports an active run, without changing the fire mutation id', async () => {
     vi.useFakeTimers();
 
     const agent = {
-      addMessage: vi.fn(),
-      abortRun: vi.fn(),
       detachActiveRun: vi.fn(),
     };
-    const copilotkit = {
-      runAgent: vi
-        .fn()
-        .mockRejectedValueOnce(new Error('Cannot send RUN_STARTED while a run is still active.'))
-        .mockResolvedValueOnce(undefined),
-    };
+    const runDirectCommand = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Cannot send RUN_STARTED while a run is still active.'))
+      .mockResolvedValueOnce(undefined);
     const runInFlightRef = { current: false };
 
     try {
       const ok = await fireAgentRun({
         agent,
-        runAgent: async (value) => copilotkit.runAgent({ agent: value }),
+        runDirectCommand,
         threadId: 'thread-1',
         runInFlightRef,
         createId: () => 'msg-1',
       });
 
       expect(ok).toBe(true);
-      expect(agent.addMessage).toHaveBeenCalledTimes(1);
-      expect(copilotkit.runAgent).toHaveBeenCalledTimes(1);
+      expect(runDirectCommand).toHaveBeenCalledTimes(1);
+      expectFireDispatch(runDirectCommand);
       expect(runInFlightRef.current).toBe(true);
 
       await vi.advanceTimersByTimeAsync(300);
 
-      expect(copilotkit.runAgent).toHaveBeenCalledTimes(2);
-      expect(agent.addMessage).toHaveBeenCalledTimes(1);
+      expect(runDirectCommand).toHaveBeenCalledTimes(2);
+      expectFireDispatch(runDirectCommand, 1);
       expect(runInFlightRef.current).toBe(true);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('releases run-in-flight when run start fails for non-busy reasons', async () => {
+  it('releases run-in-flight when fire start fails for non-busy reasons', async () => {
     const agent = {
-      addMessage: vi.fn(),
-      abortRun: vi.fn(),
       detachActiveRun: vi.fn(),
     };
-    const copilotkit = {
-      runAgent: vi.fn(async () => {
-        throw new Error('bad gateway');
-      }),
-    };
+    const runDirectCommand = vi.fn(async () => {
+      throw new Error('bad gateway');
+    });
     const runInFlightRef = { current: true };
 
     const ok = await fireAgentRun({
       agent,
-      runAgent: async (value) => copilotkit.runAgent({ agent: value }),
+      runDirectCommand,
       threadId: 'thread-1',
       runInFlightRef,
       createId: () => 'msg-1',
     });
 
     expect(ok).toBe(true);
-    expect(runInFlightRef.current).toBe(true);
 
     await Promise.resolve();
     await Promise.resolve();
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
     expect(runInFlightRef.current).toBe(false);
-    expect(copilotkit.runAgent).toHaveBeenCalledTimes(1);
+    expect(runDirectCommand).toHaveBeenCalledTimes(1);
+    expectFireDispatch(runDirectCommand);
   });
 
   it('retries on busy errors after detaching active run via AG-UI agent lifecycle', async () => {
@@ -202,22 +199,24 @@ describe('fireAgentRun', () => {
       isRunning: true,
       abortRun: vi.fn(),
       detachActiveRun: vi.fn(async () => calls.push('detachActiveRun')),
-      addMessage: vi.fn(() => calls.push('addMessage')),
     };
-    const copilotkit = {
-      runAgent: vi
-        .fn()
-        .mockRejectedValueOnce(
-          new Error('Thread is already running a task. Wait for it to finish or choose a different multitask strategy.'),
-        )
-        .mockResolvedValueOnce(undefined),
-    };
+    const runDirectCommand = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        calls.push('runDirectCommand');
+        throw new Error(
+          'Thread is already running a task. Wait for it to finish or choose a different multitask strategy.',
+        );
+      })
+      .mockImplementationOnce(async () => {
+        calls.push('runDirectCommand');
+      });
     const runInFlightRef = { current: false };
 
     try {
       const ok = await fireAgentRun({
         agent,
-        runAgent: async (value) => copilotkit.runAgent({ agent: value }),
+        runDirectCommand,
         preemptActiveRun: async () => {
           calls.push('stopAgent');
           runInFlightRef.current = false;
@@ -231,14 +230,16 @@ describe('fireAgentRun', () => {
       expect(ok).toBe(true);
       expect(agent.abortRun).not.toHaveBeenCalled();
       expect(agent.detachActiveRun).toHaveBeenCalledTimes(1);
-      expect(agent.addMessage).toHaveBeenCalledTimes(1);
+      expect(runDirectCommand).toHaveBeenCalledTimes(1);
+      expectFireDispatch(runDirectCommand);
       expect(calls[0]).toBe('stopAgent');
       expect(calls[1]).toBe('detachActiveRun');
-      expect(calls[2]).toBe('addMessage');
+      expect(calls[2]).toBe('runDirectCommand');
 
       await vi.advanceTimersByTimeAsync(300);
 
-      expect(copilotkit.runAgent).toHaveBeenCalledTimes(2);
+      expect(runDirectCommand).toHaveBeenCalledTimes(2);
+      expectFireDispatch(runDirectCommand, 1);
     } finally {
       vi.useRealTimers();
     }
@@ -249,11 +250,10 @@ describe('fireAgentRun', () => {
 
     const agent = {
       isRunning: false,
-      addMessage: vi.fn(),
       detachActiveRun: vi.fn(async () => undefined),
     };
     const runInFlightRef = { current: false };
-    const runAgent = vi
+    const runDirectCommand = vi
       .fn()
       .mockRejectedValueOnce(new Error('Thread is already running a task.'))
       .mockRejectedValueOnce(new Error('Thread is already running a task.'))
@@ -263,7 +263,7 @@ describe('fireAgentRun', () => {
     try {
       const ok = await fireAgentRun({
         agent,
-        runAgent,
+        runDirectCommand,
         threadId: 'thread-1',
         runInFlightRef,
         createId: () => 'msg-1',
@@ -272,13 +272,16 @@ describe('fireAgentRun', () => {
       });
 
       expect(ok).toBe(true);
-      expect(runAgent).toHaveBeenCalledTimes(1);
+      expect(runDirectCommand).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(3000);
 
-      expect(runAgent).toHaveBeenCalledTimes(4);
+      expect(runDirectCommand).toHaveBeenCalledTimes(4);
+      expectFireDispatch(runDirectCommand, 0);
+      expectFireDispatch(runDirectCommand, 1);
+      expectFireDispatch(runDirectCommand, 2);
+      expectFireDispatch(runDirectCommand, 3);
       expect(runInFlightRef.current).toBe(true);
-      expect(agent.addMessage).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -290,11 +293,10 @@ describe('fireAgentRun', () => {
     const onError = vi.fn();
     const agent = {
       isRunning: false,
-      addMessage: vi.fn(),
       detachActiveRun: vi.fn(async () => undefined),
     };
     const runInFlightRef = { current: false };
-    const runAgent = vi
+    const runDirectCommand = vi
       .fn()
       .mockRejectedValueOnce(new Error('BodyStreamBuffer was aborted'))
       .mockResolvedValueOnce(undefined);
@@ -302,7 +304,7 @@ describe('fireAgentRun', () => {
     try {
       const ok = await fireAgentRun({
         agent,
-        runAgent,
+        runDirectCommand,
         threadId: 'thread-1',
         runInFlightRef,
         createId: () => 'msg-1',
@@ -312,27 +314,28 @@ describe('fireAgentRun', () => {
       });
 
       expect(ok).toBe(true);
-      expect(runAgent).toHaveBeenCalledTimes(1);
+      expect(runDirectCommand).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(120);
 
-      expect(runAgent).toHaveBeenCalledTimes(2);
+      expect(runDirectCommand).toHaveBeenCalledTimes(2);
+      expectFireDispatch(runDirectCommand, 0);
+      expectFireDispatch(runDirectCommand, 1);
       expect(onError).not.toHaveBeenCalled();
       expect(runInFlightRef.current).toBe(true);
-      expect(agent.addMessage).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
   });
 
   it('does nothing when threadId is missing', async () => {
-    const agent = { abortRun: vi.fn(), detachActiveRun: vi.fn(), addMessage: vi.fn() };
-    const copilotkit = { runAgent: vi.fn() };
+    const agent = { abortRun: vi.fn(), detachActiveRun: vi.fn() };
+    const runDirectCommand = vi.fn();
     const runInFlightRef = { current: true };
 
     const ok = await fireAgentRun({
       agent,
-      runAgent: async (value) => copilotkit.runAgent({ agent: value }),
+      runDirectCommand,
       threadId: undefined,
       runInFlightRef,
       createId: () => 'msg-1',
@@ -341,8 +344,7 @@ describe('fireAgentRun', () => {
     expect(ok).toBe(false);
     expect(agent.abortRun).not.toHaveBeenCalled();
     expect(agent.detachActiveRun).not.toHaveBeenCalled();
-    expect(agent.addMessage).not.toHaveBeenCalled();
-    expect(copilotkit.runAgent).not.toHaveBeenCalled();
+    expect(runDirectCommand).not.toHaveBeenCalled();
   });
 
   it('waits for preemption timeout before dispatching fire when run ownership stays active', async () => {
@@ -352,17 +354,14 @@ describe('fireAgentRun', () => {
       isRunning: true,
       abortRun: vi.fn(),
       detachActiveRun: vi.fn(async () => undefined),
-      addMessage: vi.fn(),
     };
-    const copilotkit = {
-      runAgent: vi.fn(async () => undefined),
-    };
+    const runDirectCommand = vi.fn(async () => undefined);
     const runInFlightRef = { current: true };
 
     try {
       const firePromise = fireAgentRun({
         agent,
-        runAgent: async (value) => copilotkit.runAgent({ agent: value }),
+        runDirectCommand,
         preemptActiveRun: async () => undefined,
         threadId: 'thread-1',
         runInFlightRef,
@@ -372,14 +371,13 @@ describe('fireAgentRun', () => {
       });
 
       await vi.advanceTimersByTimeAsync(20);
-      expect(agent.addMessage).not.toHaveBeenCalled();
-      expect(copilotkit.runAgent).not.toHaveBeenCalled();
+      expect(runDirectCommand).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(40);
       await firePromise;
 
-      expect(agent.addMessage).toHaveBeenCalledTimes(1);
-      expect(copilotkit.runAgent).toHaveBeenCalledTimes(1);
+      expect(runDirectCommand).toHaveBeenCalledTimes(1);
+      expectFireDispatch(runDirectCommand);
     } finally {
       vi.useRealTimers();
     }

--- a/typescript/clients/web-ag-ui/apps/web/tests/gmxAllora.system.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/tests/gmxAllora.system.e2e.test.ts
@@ -87,7 +87,7 @@ describe('GMX Allora AG-UI system (web + runtime)', () => {
     expect(typeof sawConnectEvent).toBe('boolean');
   });
 
-  it('runs sync command via AG-UI run semantics only', async () => {
+  it('runs refresh command via AG-UI run semantics only', async () => {
     const webBaseUrl = requireEnv('WEB_E2E_BASE_URL');
     const agent = createRuntimeAgent({
       webBaseUrl,
@@ -116,7 +116,7 @@ describe('GMX Allora AG-UI system (web + runtime)', () => {
       {
         forwardedProps: {
           command: {
-            name: 'sync',
+            name: 'refresh',
             clientMutationId: crypto.randomUUID(),
           },
         },

--- a/typescript/clients/web-ag-ui/apps/web/tests/gmxAllora.system.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/tests/gmxAllora.system.e2e.test.ts
@@ -112,13 +112,17 @@ describe('GMX Allora AG-UI system (web + runtime)', () => {
       },
     };
 
-    agent.addMessage({
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: JSON.stringify({ command: 'sync' }),
-    });
-
-    const runResult = await agent.runAgent(undefined, subscriber);
+    const runResult = await agent.runAgent(
+      {
+        forwardedProps: {
+          command: {
+            name: 'sync',
+            clientMutationId: crypto.randomUUID(),
+          },
+        },
+      },
+      subscriber,
+    );
 
     expect(runErrorMessage).toBeNull();
     expect(sawRunFinished).toBe(true);
@@ -148,13 +152,17 @@ describe('GMX Allora AG-UI system (web + runtime)', () => {
       },
     };
 
-    agent.addMessage({
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: JSON.stringify({ command: 'hire' }),
-    });
-
-    await agent.runAgent(undefined, subscriber);
+    await agent.runAgent(
+      {
+        forwardedProps: {
+          command: {
+            name: 'hire',
+            clientMutationId: crypto.randomUUID(),
+          },
+        },
+      },
+      subscriber,
+    );
 
     const afterHire = resolveThreadView(agent.state) ?? latestThreadView;
     expect(runErrorMessage).toBeNull();

--- a/typescript/clients/web-ag-ui/apps/web/tests/piExample.system.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/tests/piExample.system.e2e.test.ts
@@ -62,7 +62,7 @@ describe('Pi example AG-UI system (web + runtime + control plane)', () => {
       {
         forwardedProps: {
           command: {
-            name: 'sync',
+            name: 'refresh',
             clientMutationId: crypto.randomUUID(),
           },
         },

--- a/typescript/clients/web-ag-ui/apps/web/tests/piExample.system.e2e.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/tests/piExample.system.e2e.test.ts
@@ -58,13 +58,17 @@ describe('Pi example AG-UI system (web + runtime + control plane)', () => {
       },
     };
 
-    runAgent.addMessage({
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: JSON.stringify({ command: 'sync' }),
-    });
-
-    const runResult = await runAgent.runAgent(undefined, runSubscriber);
+    const runResult = await runAgent.runAgent(
+      {
+        forwardedProps: {
+          command: {
+            name: 'sync',
+            clientMutationId: crypto.randomUUID(),
+          },
+        },
+      },
+      runSubscriber,
+    );
     const threadsResponse = await fetch(`${piRuntimeUrl}/control/threads`);
     const executionsResponse = await fetch(`${piRuntimeUrl}/control/executions`);
     const schedulerResponse = await fetch(`${piRuntimeUrl}/control/scheduler`);

--- a/typescript/clients/web-ag-ui/docs/adr/0006-pi-thread-execution-automation-runtime-model.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0006-pi-thread-execution-automation-runtime-model.md
@@ -42,7 +42,7 @@ These runtime records sit above the concrete Pi package foundation:
 - This initiative adds durable runtime records, persistence, automation, projection, and operator/runtime layers around that core.
 
 The foundational runtime model is intentionally lower-level than any specific agent-family lifecycle system.
-- Opinionated workflows such as hire/setup/sync/fire do not belong in the core runtime model itself.
+- Opinionated workflows such as hire/setup/refresh/fire do not belong in the core runtime model itself.
 - Those higher-level workflows belong in pluggable Pi-owned agent domain modules layered above the core runtime model, as described in ADR 0011.
 
 Additional rules:

--- a/typescript/clients/web-ag-ui/docs/adr/0007-sibling-channel-adapters-and-canonical-thread-identity.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0007-sibling-channel-adapters-and-canonical-thread-identity.md
@@ -9,7 +9,7 @@ The Pi-backed agent is intended to serve `web-ag-ui` first, but future channels 
 - AG-UI concepts become the de facto internal runtime model
 - new clients are forced to sit on top of web-specific assumptions
 - thread identity fragments per client surface
-- shared setup/hire/sync/fire flows drift across channels
+- shared setup/hire/refresh/fire flows drift across channels
 
 We also know the current web app creates deterministic threads based on wallet address plus scoped identifiers, and future product work may need multiple deterministic user-visible threads.
 
@@ -33,7 +33,7 @@ Thread visibility rules:
 - Internal operational contexts such as background task/job execution are not first-class user threads by default.
 
 Channel behavior rules:
-- Shared flows such as hire/setup/sync/fire must belong to Pi-owned agent domain modules layered above the core runtime, not only to the AG-UI adapter.
+- Shared flows such as hire/setup/refresh/fire must belong to Pi-owned agent domain modules layered above the core runtime, not only to the AG-UI adapter.
 - If autonomous work needs user input, actionable interrupts surface into the root thread so user-visible channels can resolve them.
 - Rich channel-specific rendering remains the responsibility of each adapter.
 

--- a/typescript/clients/web-ag-ui/docs/adr/0010-pluggable-agent-domain-modules-above-pi-core-runtime.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0010-pluggable-agent-domain-modules-above-pi-core-runtime.md
@@ -11,7 +11,7 @@ The Pi-backed architecture now has a clearer foundational runtime model:
 - `PiAutomation`
 - `AutomationRun`
 
-That core model is intentionally about durable execution, persistence, interrupts, automation firing, and protocol projection boundaries. It is not, by itself, the right place to encode opinionated user-facing workflows such as hire, setup, sync, or fire.
+That core model is intentionally about durable execution, persistence, interrupts, automation firing, and protocol projection boundaries. It is not, by itself, the right place to encode opinionated user-facing workflows such as hire, setup, refresh, or fire.
 
 Those flows are:
 - higher-level than the execution core
@@ -43,7 +43,7 @@ Layering:
 
 Rules:
 - The Pi core runtime must not assume one universal lifecycle vocabulary for all agent types.
-- Higher-level workflows such as hire/setup/sync/fire belong in a Pi-owned agent domain module, not in the AG-UI adapter and not in the frontend.
+- Higher-level workflows such as hire/setup/refresh/fire belong in a Pi-owned agent domain module, not in the AG-UI adapter and not in the frontend.
 - Different agent families may supply different lifecycle vocabularies, interrupt schemas, and artifact shapes while reusing the same core runtime model.
 - The reusable boundary is the domain-module contract, not a forced universal lifecycle terminology.
 - Protocol adapters project the outputs of the active agent domain module; they do not become the source of truth for domain lifecycle semantics.
@@ -61,7 +61,7 @@ Rules:
 
 ## Alternatives Considered
 
-- Put hire/setup/sync/fire directly into the core runtime model:
+- Put hire/setup/refresh/fire directly into the core runtime model:
   - Rejected because it overfits the foundational runtime to one agent family.
 - Keep lifecycle flows only in AG-UI/A2UI adapters:
   - Rejected because adapters should project domain state, not own domain truth.

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -13,7 +13,7 @@ Portfolio-manager onboarding exposed a separate contract gap on the command path
 - `agent-runtime` already supports a direct AG-UI control lane via `forwardedProps.command`
 - interrupt resumes already use that direct lane
 - some imperative web actions historically still traveled as JSON user messages and relied on the model to call `agent_runtime_domain_command`
-- workflow runtimes now translate named commands and sync/update intents from `forwardedProps.command` into internal `private.pendingCommand` state before graph execution
+- workflow runtimes now translate named commands and refresh/update intents from `forwardedProps.command` into internal `private.pendingCommand` state before graph execution
 
 That split is architecturally wrong for imperative controls. Commands such as `hire`, `fire`, `command.update`, and interrupt resume are not natural-language inputs that need interpretation. They are control-plane requests from the client to the runtime. Routing them through inference adds nondeterminism, couples business flow to prompt/tool behavior, and creates live regressions where the direct runtime path already exists and is better tested.
 
@@ -69,5 +69,5 @@ Preferred cross-runtime direction:
   - Workflow runtimes must own the extra translation layer from the public direct command lane to their internal pending-command state.
   - Existing tests and smoke helpers that asserted message-injection for imperative commands need to be updated.
 - Follow-on work:
-  - keep regression coverage that proves direct command forwarding is used for named commands, polling sync, and `command.update`
+  - keep regression coverage that proves direct command forwarding is used for named commands, polling refresh, and `command.update`
   - reject new runtime registrations that would reintroduce message-driven imperative command dispatch

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -13,18 +13,19 @@ Portfolio-manager onboarding exposed a separate contract gap on the command path
 - `agent-runtime` already supports a direct AG-UI control lane via `forwardedProps.command`
 - interrupt resumes already use that direct lane
 - some imperative web actions historically still traveled as JSON user messages and relied on the model to call `agent_runtime_domain_command`
-- LangGraph currently uses `forwardedProps.command` only for interrupt resume, not for imperative named commands or `command.update` state-write actions
+- workflow runtimes now translate named commands and sync/update intents from `forwardedProps.command` into internal `private.pendingCommand` state before graph execution
 
 That split is architecturally wrong for imperative controls. Commands such as `hire`, `fire`, `command.update`, and interrupt resume are not natural-language inputs that need interpretation. They are control-plane requests from the client to the runtime. Routing them through inference adds nondeterminism, couples business flow to prompt/tool behavior, and creates live regressions where the direct runtime path already exists and is better tested.
 
 ## Decision
 
-Adopt `forwardedProps.command` as the canonical direct command lane for `agent-runtime`.
+Adopt `forwardedProps.command` as the canonical direct command lane across current registered runtime families.
 
 The rules are:
 - when an AG-UI `run` request includes `forwardedProps.command`, `agent-runtime` must evaluate that command before any inference or model/tool routing
 - `forwardedProps.command` is an out-of-band control-plane input, not conversational message content
-- imperative client actions for `agent-runtime`, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
+- imperative client actions, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
+- workflow runtimes that execute through LangGraph must translate direct command intent into internal `private.pendingCommand` state before graph execution rather than reconstructing that intent from transcript messages
 - interrupt `resume` payloads may be structured objects and should traverse the direct command lane unchanged; only text-only runtime fallbacks may serialize them later
 - `command.update` is the canonical shared-state mutation lane: the client writes revision-guarded JSON Patch against the writable public-state slice rooted at `/shared`, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas
 - in v1, `/shared` versus `/projected` is the editability model; `command.update` does not add extra field-level mutability metadata or a second allowlist inside `/shared`
@@ -33,14 +34,12 @@ The rules are:
 - if a forwarded `command.update` run fails locally before any matching `shared-state.control` acknowledgment arrives, the web must roll back the optimistic writable-state view and clear the pending mutation instead of leaving optimistic settings stranded
 - conversational turns remain message-driven and may use inference normally
 - if a direct command is present, the runtime must not require the model to rediscover that intent via `agent_runtime_domain_command`
+- no registered agent runtime may rely on parsing the last chat message to recover explicit client control intent
 
 Preferred cross-runtime direction:
 - `forwardedProps.command` is the preferred transport for imperative client actions across runtime families, not only for `agent-runtime`
 - runtime families may keep different internal execution models, but the web should converge on one command-lane convention: conversational user input in messages, imperative control actions in `forwardedProps.command`
-- until a legacy runtime gains equivalent direct-command support, compatibility branching may remain in the web, but it is a migration state rather than the desired permanent contract
-
-Compatibility rule:
-- legacy runtime families may continue using message-driven command dispatch until they gain an equivalent direct command lane, but that compatibility path must not redefine the `agent-runtime` contract or the preferred long-term web command convention
+- runtime-specific translation into pending-command state or other internal control structures is acceptable, but those translations are implementation details rather than public transport branches
 
 ## Rationale
 
@@ -67,10 +66,8 @@ Compatibility rule:
   - Manual QA and automated tests can exercise command flows without depending on prompt/tool behavior.
   - Future migration away from LangGraph can converge on one control-lane convention instead of preserving two imperative command transports forever.
 - Tradeoffs:
-  - The web app must distinguish between direct command-capable runtimes and legacy message-driven runtimes during the migration period.
-  - Existing tests that assert message-injection for imperative `agent-runtime` commands need to be updated.
+  - Workflow runtimes must own the extra translation layer from the public direct command lane to their internal pending-command state.
+  - Existing tests and smoke helpers that asserted message-injection for imperative commands need to be updated.
 - Follow-on work:
-  - update web command dispatch so PI-runtime imperative actions use `forwardedProps.command`
-  - keep LangGraph compatibility isolated until it gains an equivalent direct command lane for imperative actions
-  - add regression coverage that proves direct command forwarding is used for `agent-runtime` named commands and `command.update`
-  - when LangGraph is retired or replaced, remove the remaining message-driven imperative-command compatibility path rather than preserving it as a permanent dual-mode convention
+  - keep regression coverage that proves direct command forwarding is used for named commands, polling sync, and `command.update`
+  - reject new runtime registrations that would reintroduce message-driven imperative command dispatch

--- a/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0013-direct-forwarded-command-lane-precedes-inference.md
@@ -25,6 +25,7 @@ The rules are:
 - when an AG-UI `run` request includes `forwardedProps.command`, `agent-runtime` must evaluate that command before any inference or model/tool routing
 - `forwardedProps.command` is an out-of-band control-plane input, not conversational message content
 - imperative client actions, including named commands, `command.update`, and interrupt resume, must use `forwardedProps.command` rather than synthesizing JSON chat messages
+- observability provenance is not part of the public command contract and should travel in sibling forwarded-props metadata (for example `forwardedProps.source`) rather than inside `forwardedProps.command`
 - workflow runtimes that execute through LangGraph must translate direct command intent into internal `private.pendingCommand` state before graph execution rather than reconstructing that intent from transcript messages
 - interrupt `resume` payloads may be structured objects and should traverse the direct command lane unchanged; only text-only runtime fallbacks may serialize them later
 - `command.update` is the canonical shared-state mutation lane: the client writes revision-guarded JSON Patch against the writable public-state slice rooted at `/shared`, and the runtime answers with authoritative `shared-state.control` acknowledgments plus any resulting `/shared` and `/projected` state deltas

--- a/typescript/clients/web-ag-ui/docs/adr/0016-ag-ui-state-message-and-control-plane-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0016-ag-ui-state-message-and-control-plane-boundaries.md
@@ -85,7 +85,7 @@ Adopt one explicit three-plane AG-UI contract for the public web-facing payload:
 - Public state snapshots and deltas must not include transcript fields such as `thread.messages`.
 - The authoritative transcript snapshot is `MESSAGES_SNAPSHOT`, and the authoritative incremental transcript updates are the AG-UI message events.
 - Imperative control intent is not transcript data.
-- Synthetic JSON user messages such as `{"command":"sync"}` are invalid as a public command/control transport and must not be emitted just to steer runtime behavior.
+- Synthetic JSON user messages such as `{"command":"refresh"}` are invalid as a public command/control transport and must not be emitted just to steer runtime behavior.
 
 ### Control plane rule
 

--- a/typescript/clients/web-ag-ui/docs/adr/0016-ag-ui-state-message-and-control-plane-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0016-ag-ui-state-message-and-control-plane-boundaries.md
@@ -84,6 +84,8 @@ Adopt one explicit three-plane AG-UI contract for the public web-facing payload:
 - Messages must not be duplicated into the state plane.
 - Public state snapshots and deltas must not include transcript fields such as `thread.messages`.
 - The authoritative transcript snapshot is `MESSAGES_SNAPSHOT`, and the authoritative incremental transcript updates are the AG-UI message events.
+- Imperative control intent is not transcript data.
+- Synthetic JSON user messages such as `{"command":"sync"}` are invalid as a public command/control transport and must not be emitted just to steer runtime behavior.
 
 ### Control plane rule
 
@@ -97,6 +99,7 @@ Adopt one explicit three-plane AG-UI contract for the public web-facing payload:
   - `thread.domainProjection`
   - top-level `settings`
   - `thread.messages`
+  - synthetic JSON transcript messages used to smuggle imperative command intent
   - fallback interpretation of legacy `domainProjection` as `/projected`
 - If older snapshots need temporary defensive handling, that handling is a migration fallback in consumers and not part of the supported runtime contract.
 

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -107,7 +107,9 @@ These rules complement the C4 target architecture and make runtime behavior dete
   - other commands: explicit policy (reject-on-busy or constrained retry)
 - `AgentStatusPoller`:
   - dispatch one-shot poll `run` per non-active-detail agent on configured cadence
-  - express poll intent on the real command lane via `forwardedProps.command.name = 'sync'` so observability does not need to parse synthetic user-message JSON
+  - use the per-agent imperative command transport contract for poll runs:
+    - Pi-backed agents use `forwardedProps.command.name = 'sync'`
+    - LangGraph workflow agents remain message-driven for `sync` until an equivalent direct lane exists there
   - avoid persistent `connect` ownership in polling codepaths
 - central `AgentProjectionReducer`:
   - dedupe by run/event identity

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -79,6 +79,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
    - Conversational user input belongs in AG-UI messages.
    - Imperative client controls belong in `forwardedProps.command`.
 - Current direct-command set includes named commands such as `hire`, `fire`, `cycle`, and `refresh`, shared-state `update`, and interrupt resume.
+   - Observability provenance belongs in sibling forwarded-props metadata such as `forwardedProps.source`, not inside the public command envelope.
    - Workflow runtimes may translate `forwardedProps.command` into internal `private.pendingCommand`/`activeCommand` state before graph execution, but that translation is runtime-internal and not a second public transport.
    - Interrupt `resume` payloads may be structured objects and should flow through the direct command lane unchanged until a text-only runtime boundary explicitly needs serialization.
    - Synthetic JSON user messages must not be used to carry imperative command intent.
@@ -109,6 +110,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
 - `AgentStatusPoller`:
   - dispatch one-shot poll `run` per non-active-detail agent on configured cadence
 - use `forwardedProps.command.name = 'refresh'` for poll runs across current registered agents
+  - if poll provenance needs tracing, carry it in sibling observability metadata such as `forwardedProps.source = 'agent-list-poll'`
   - workflow runtimes translate that direct lane into internal pending-command state before entering `runCommand`
   - avoid persistent `connect` ownership in polling codepaths
 - central `AgentProjectionReducer`:

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -35,7 +35,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
 2. State write path:
    - Client-to-agent state mutation must flow through AG-UI `run` input (`RunAgentInput.state`).
    - `connect` is attach/replay for projection continuity and is not a mutation write channel.
-   - Practical client pattern: update local agent state/message model, then dispatch `run`.
+   - Practical client pattern: update local writable/shared view or local transient control state, then dispatch `run`.
    - For Pi-backed flows, the visible writable-state model must rehydrate from authoritative `STATE_SNAPSHOT` and `STATE_DELTA` events, not from acknowledgments alone.
 
 3. Stream ownership:
@@ -77,10 +77,11 @@ These rules complement the C4 target architecture and make runtime behavior dete
 
 10. Imperative command transport policy:
    - Conversational user input belongs in AG-UI messages.
-   - Imperative client controls belong in `forwardedProps.command` whenever the target runtime supports a direct command lane.
-   - Current preferred direct-command set is named commands such as `hire` and `fire`, shared-state `update`, and interrupt resume.
+   - Imperative client controls belong in `forwardedProps.command`.
+   - Current direct-command set includes named commands such as `hire`, `fire`, `cycle`, and `sync`, shared-state `update`, and interrupt resume.
+   - Workflow runtimes may translate `forwardedProps.command` into internal `private.pendingCommand`/`activeCommand` state before graph execution, but that translation is runtime-internal and not a second public transport.
    - Interrupt `resume` payloads may be structured objects and should flow through the direct command lane unchanged until a text-only runtime boundary explicitly needs serialization.
-   - Compatibility note: LangGraph currently uses `forwardedProps.command` for resume only; imperative `hire`/`fire` remain message-driven there until an equivalent direct lane exists.
+   - Synthetic JSON user messages must not be used to carry imperative command intent.
 
 11. Confirmation semantics:
    - “Saved/synced” UX should complete only when AG-UI state confirms application (e.g., task state, version, or acknowledged projection).
@@ -107,9 +108,8 @@ These rules complement the C4 target architecture and make runtime behavior dete
   - other commands: explicit policy (reject-on-busy or constrained retry)
 - `AgentStatusPoller`:
   - dispatch one-shot poll `run` per non-active-detail agent on configured cadence
-  - use the per-agent imperative command transport contract for poll runs:
-    - Pi-backed agents use `forwardedProps.command.name = 'sync'`
-    - LangGraph workflow agents remain message-driven for `sync` until an equivalent direct lane exists there
+  - use `forwardedProps.command.name = 'sync'` for poll runs across current registered agents
+  - workflow runtimes translate that direct lane into internal pending-command state before entering `runCommand`
   - avoid persistent `connect` ownership in polling codepaths
 - central `AgentProjectionReducer`:
   - dedupe by run/event identity

--- a/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
+++ b/typescript/clients/web-ag-ui/docs/ag-ui-client-runtime-invariants.md
@@ -78,13 +78,13 @@ These rules complement the C4 target architecture and make runtime behavior dete
 10. Imperative command transport policy:
    - Conversational user input belongs in AG-UI messages.
    - Imperative client controls belong in `forwardedProps.command`.
-   - Current direct-command set includes named commands such as `hire`, `fire`, `cycle`, and `sync`, shared-state `update`, and interrupt resume.
+- Current direct-command set includes named commands such as `hire`, `fire`, `cycle`, and `refresh`, shared-state `update`, and interrupt resume.
    - Workflow runtimes may translate `forwardedProps.command` into internal `private.pendingCommand`/`activeCommand` state before graph execution, but that translation is runtime-internal and not a second public transport.
    - Interrupt `resume` payloads may be structured objects and should flow through the direct command lane unchanged until a text-only runtime boundary explicitly needs serialization.
    - Synthetic JSON user messages must not be used to carry imperative command intent.
 
 11. Confirmation semantics:
-   - “Saved/synced” UX should complete only when AG-UI state confirms application (e.g., task state, version, or acknowledged projection).
+- “Saved/refreshed” UX should complete only when AG-UI state confirms application (e.g., task state, version, or acknowledged projection).
    - Current handshake for Pi-backed shared-state writes: client sends `forwardedProps.command.update` with `clientMutationId` and `baseRevision`; runtime emits `shared-state.control` `update-ack`; UI clears pending state only when ids match.
    - Malformed Pi `command.update` requests that omit `clientMutationId` are boundary-invalid and must be rejected before `update-ack`; the acknowledgment lane is reserved for writes that already have a real correlation key.
    - Accepted Pi-backed writes must reconcile the visible state from the authoritative `STATE_DELTA` payload that arrives before the matching `shared-state.control` `update-ack`.
@@ -108,7 +108,7 @@ These rules complement the C4 target architecture and make runtime behavior dete
   - other commands: explicit policy (reject-on-busy or constrained retry)
 - `AgentStatusPoller`:
   - dispatch one-shot poll `run` per non-active-detail agent on configured cadence
-  - use `forwardedProps.command.name = 'sync'` for poll runs across current registered agents
+- use `forwardedProps.command.name = 'refresh'` for poll runs across current registered agents
   - workflow runtimes translate that direct lane into internal pending-command state before entering `runCommand`
   - avoid persistent `connect` ownership in polling codepaths
 - central `AgentProjectionReducer`:

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -237,7 +237,7 @@ Definitions:
 
 Examples:
 
-- DeFi agents may use domain modules with lifecycle terms such as hire/setup/sync/fire.
+- DeFi agents may use domain modules with lifecycle terms such as hire/setup/refresh/fire.
 - Other agent types may define different lifecycle vocabularies without changing the core runtime model.
 
 ### Domain-Module SPI
@@ -262,11 +262,11 @@ For the first DeFi lifecycle module, the boundary is:
 
 | Owned by DeFi domain module | Owned by core Pi runtime |
 | --- | --- |
-| `hire/setup/sync/fire` command vocabulary | `PiThread`, `PiExecution`, `PiAutomation`, `AutomationRun` |
+| `hire/setup/refresh/fire` command vocabulary | `PiThread`, `PiExecution`, `PiAutomation`, `AutomationRun` |
 | DeFi lifecycle phases and transitions | durable persistence and restart boundaries |
 | DeFi-specific interrupt schemas and policy | interrupt delivery and resurfacing plumbing |
 | dynamic system context and adapter-neutral domain outputs | canonical execution identity and protocol projections |
-| sync automation policy decisions | scheduler, outbox/dedupe, and operator control-plane infrastructure |
+| refresh command / automation policy decisions | scheduler, outbox/dedupe, and operator control-plane infrastructure |
 
 ## 6. Projection model
 

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -118,7 +118,7 @@ Explicit non-goal container:
 - `AgentStatusPoller` (refactored list polling):
   - Every 15s, performs one-shot AG-UI `run` status refresh for agents whose detail page is not currently active.
   - Poll runs are bounded lifecycle invocations (`run` start -> snapshot/events -> terminal), not persistent `connect` loops.
-  - Poll intent stays on `forwardedProps.command` for route tracing and runtime observability instead of synthetic JSON user messages.
+  - Poll intent stays on `forwardedProps.command`, while observability provenance such as `agent-list-poll` rides in sibling `forwardedProps.source` metadata instead of the public command contract.
   - Uses protocol-compliant calls only; no direct thread endpoints.
   - Writes normalized status to shared projection store.
 
@@ -154,7 +154,7 @@ Explicit non-goal container:
 - `CopilotKit Runtime Route` (`/api/copilotkit`):
   - The only server route used by web for agent communication.
   - Exposes AG-UI `connect`, `run`, and `stop` semantics used by web.
-  - Request metadata and debug traces should read command intent from `forwardedProps.command` and related control-lane fields, not by parsing the last chat message.
+  - Request metadata and debug traces should read command intent from `forwardedProps.command`, provenance from sibling fields such as `forwardedProps.source`, and never infer either by parsing the last chat message.
   - Workflow-runtime adapters may translate `forwardedProps.command` into internal `private.pendingCommand` state updates before graph execution, but that is runtime-private implementation detail rather than a second web contract.
   - Structured interrupt-resume tracing should log full serialized `resumePayloadLength` separately from the truncated `resumePayloadPreview`.
   - For standalone Pi-backed agents, imports runtime-owned transport helpers rather than defining Pi-specific transport behavior locally.

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -116,7 +116,7 @@ Explicit non-goal container:
   - Enforces a hard cap of active streams (target: `<= 1` long-lived detail stream).
 
 - `AgentStatusPoller` (refactored list polling):
-  - Every 15s, performs one-shot AG-UI `run` status sync for agents whose detail page is not currently active.
+  - Every 15s, performs one-shot AG-UI `run` status refresh for agents whose detail page is not currently active.
   - Poll runs are bounded lifecycle invocations (`run` start -> snapshot/events -> terminal), not persistent `connect` loops.
   - Poll intent stays on `forwardedProps.command` for route tracing and runtime observability instead of synthetic JSON user messages.
   - Uses protocol-compliant calls only; no direct thread endpoints.
@@ -363,7 +363,7 @@ sequenceDiagram
 
 ### Slice 3: Sidebar projection refactor
 
-- Replace `AgentListContext` direct sync with bounded AG-UI one-shot `run` status polling.
+- Replace `AgentListContext` direct status refresh with bounded AG-UI one-shot `run` status polling.
 - Share reducer/state model between sidebar and detail.
 
 ### Slice 4: Metrics UI decomposition
@@ -387,13 +387,13 @@ sequenceDiagram
   `@ag-ui/langgraph@0.0.25-alpha.0` do not expose `connect` on `LangGraphAgent` in `dist/index.d.ts`.
 - Exit criteria for this exception:
   - Upstream package exposes `connect` on `LangGraphAgent` (types and runtime),
-  - Behavior parity is validated against detail-page open/leave and sidebar sync scenarios,
+  - Behavior parity is validated against detail-page open/leave and sidebar refresh scenarios,
   - Local patch can be removed without regressing stream lifecycle correctness.
 
 ## 10. Success criteria for target architecture
 
 - Web has zero direct LangGraph thread API calls.
-- AG-UI events are the only source for UI state sync.
+- AG-UI events are the only source for UI state refresh.
 - Hidden persistent streams are eliminated.
 - Agent apps share one state-machine contract and lifecycle rules.
 - Sidebar and detail are consistent under load and navigation churn.

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -132,6 +132,7 @@ Explicit non-goal container:
 
 - `AgentCommandBus`:
   - Sends named commands such as `hire`/`fire`, interrupt responses, and shared-state `command.update` intents via AG-UI `run` payloads.
+  - Uses `forwardedProps.command` for imperative control intent instead of synthetic JSON chat messages.
   - `fire` may invoke AG-UI `stop` as a pre-dispatch preemption control.
   - No out-of-band command mutation.
 
@@ -154,6 +155,7 @@ Explicit non-goal container:
   - The only server route used by web for agent communication.
   - Exposes AG-UI `connect`, `run`, and `stop` semantics used by web.
   - Request metadata and debug traces should read command intent from `forwardedProps.command` and related control-lane fields, not by parsing the last chat message.
+  - Workflow-runtime adapters may translate `forwardedProps.command` into internal `private.pendingCommand` state updates before graph execution, but that is runtime-private implementation detail rather than a second web contract.
   - Structured interrupt-resume tracing should log full serialized `resumePayloadLength` separately from the truncated `resumePayloadPreview`.
   - For standalone Pi-backed agents, imports runtime-owned transport helpers rather than defining Pi-specific transport behavior locally.
 
@@ -181,7 +183,7 @@ Each `apps/agent*` uses a standard graph shape:
 Target factorization:
 
 - `@web-ag-ui/agent-workflow-core` (new shared internal package):
-  - Canonical command parsing
+  - Canonical direct-command envelope parsing and pending-command state-update helpers
   - Canonical onboarding + task state machine
   - Shared `ThreadState` schema + versioning
   - Shared event/status helpers

--- a/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/source-traced-portfolio-manager-ember-lending-sequence.mdd
@@ -81,7 +81,7 @@ sequenceDiagram
 
 ## Notes
 
-- The model never sees `read_portfolio_state` or a refresh/sync bootstrap tool.
+- The model never sees `read_portfolio_state` or a refresh/bootstrap tool.
 - Blocked execution responses preserve the already-hydrated mandate and wallet context even when the blocked portfolio payload is sparse.
 - Nested raw `handoff` payloads, planner-owned `payload_builder_output`, and reasoning-trace fields are not forwarded on planning calls.
 - Escalation calls still forward only the bounded escalation handoff fields plus the blocked result.

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-execution-signing-sequence.mdd
@@ -143,7 +143,7 @@ sequenceDiagram
 ## Notes
 
 - There is still no model-visible `read_portfolio_state` tool.
-- There is still no model-visible onboarding-context read or manual sync/bootstrap step.
+- There is still no model-visible onboarding-context read or manual refresh/bootstrap step.
 - By default, the runtime-facing result should include only:
   - final `status`
   - `transaction_hash` when available

--- a/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
+++ b/typescript/clients/web-ag-ui/docs/target-state-portfolio-manager-ember-lending-sequence.mdd
@@ -94,7 +94,7 @@ sequenceDiagram
 ## Notes
 
 - There is no model-visible `read_portfolio_state` tool.
-- There is no model-visible onboarding-context read or manual sync/bootstrap step.
+- There is no model-visible onboarding-context read or manual refresh/bootstrap step.
 - `request_transaction_execution` must surface admit-and-execute, blocked, and denied admission outcomes explicitly in status and artifacts.
 - Portfolio-manager and Ember Lending startup must both fail closed when Shared Ember does not echo back the confirmed durable service identity for the current OWS-resolved `agent_id`, `role`, and wallet.
 - The managed lending mandate supplied at bootstrap should carry `managed_onboarding` so Shared Ember can derive the initial lane and delegation inputs from structured mandate data.


### PR DESCRIPTION
## Summary
- translate canonical `forwardedProps.command` envelopes into workflow `private.pendingCommand` state before graph execution
- remove synthetic JSON command-message routing from workflow cron/e2e/web control flows and render detail-page transcripts in raw AG-UI order
- finish the audit cleanup by aligning the starter-agent refresh path and moving poll provenance from `forwardedProps.command.source` to sibling `forwardedProps.source`
- align invariants, C4 docs, and ADRs with the direct command lane plus separate observability metadata

## Testing
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent exec vitest run src/workflow/nodes/runCommand.unit.test.ts tests/runGraphOnce.int.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui/apps/web test:unit -- src/contexts/agentListPolling.unit.test.ts src/app/api/copilotkit/route.unit.test.ts src/hooks/useAgentConnection.unit.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui/apps/web test:int -- src/hooks/useAgentConnection.int.test.tsx`
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent lint:fix`
- `pnpm --dir typescript/clients/web-ag-ui/apps/web lint:fix`

## Issue Links
Closes #590
Closes #591
Related to #602
