### PR TITLE
fix(agent-ember-lending): refresh redelegation work

### DIFF
--- a/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
@@ -941,6 +941,326 @@ describe('pi gateway service integration', () => {
     ]);
   });
 
+  it('rebuilds assistant tool-call history against the active responses model for replay', async () => {
+    const agent = new ScriptedPiAgent([
+      { type: 'agent_start' },
+      { type: 'turn_start' },
+      { type: 'agent_end', messages: [] },
+    ]);
+    (agent.state as { model?: unknown }).model = {
+      id: 'openai/gpt-5.4-mini',
+      name: 'openai/gpt-5.4-mini',
+      api: 'openai-responses',
+      provider: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      reasoning: true,
+      input: ['text'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8192,
+      maxTokens: 2048,
+    };
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      now: () => 123,
+      getSession: () => ({
+        thread: { id: 'thread-openrouter-tool-history' },
+        execution: { id: 'exec-openrouter-tool-history', status: 'working' },
+        messages: [],
+      }),
+      updateSession: (_threadId, update) =>
+        update({
+          thread: { id: 'thread-openrouter-tool-history' },
+          execution: { id: 'exec-openrouter-tool-history', status: 'working' },
+          messages: [],
+        }),
+    });
+
+    await collectEventSource(
+      await runtime.run({
+        threadId: 'thread-openrouter-tool-history',
+        runId: 'run-openrouter-tool-history',
+        messages: [
+          {
+            id: 'user-msg',
+            role: 'user',
+            content: 'withdraw all aArbUSDCn',
+          },
+          {
+            id: 'assistant-msg',
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              {
+                id: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+                type: 'function',
+                function: {
+                  name: 'agent_runtime_domain_command',
+                  arguments:
+                    '{"name":"create_transaction","inputJson":"{\\"control_path\\":\\"lending.withdraw\\",\\"asset\\":\\"aArbUSDCn\\",\\"protocol_system\\":\\"aave\\",\\"network\\":\\"arbitrum\\",\\"quantity\\":{\\"kind\\":\\"exact\\",\\"value\\":\\"3\\"}}"}',
+                },
+              },
+            ],
+          },
+          {
+            id: 'tool-msg',
+            role: 'tool',
+            toolCallId: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+            content:
+              '{"content":[{"type":"text","text":"create_transaction requires JSON with control_path, asset, protocol_system, network, and quantity."}]}',
+          },
+        ],
+      }),
+    );
+
+    expect(agent.promptCalls).toEqual([
+      [
+        {
+          role: 'user',
+          content: 'withdraw all aArbUSDCn',
+          timestamp: 123,
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolCall',
+              id: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+              name: 'agent_runtime_domain_command',
+              arguments: {
+                name: 'create_transaction',
+                inputJson:
+                  '{"control_path":"lending.withdraw","asset":"aArbUSDCn","protocol_system":"aave","network":"arbitrum","quantity":{"kind":"exact","value":"3"}}',
+              },
+            },
+          ],
+          api: 'openai-responses',
+          provider: 'openrouter',
+          model: 'openai/gpt-5.4-mini',
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: 'stop',
+          timestamp: 123,
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+          toolName: 'ag-ui-tool',
+          content: [
+            {
+              type: 'text',
+              text:
+                '{"content":[{"type":"text","text":"create_transaction requires JSON with control_path, asset, protocol_system, network, and quantity."}]}',
+            },
+          ],
+          isError: false,
+          timestamp: 123,
+        },
+      ],
+    ]);
+  });
+
+  it('rehydrates persisted tool-call history into the agent state before replaying the next turn', async () => {
+    class StatefulReplayPiAgent extends ScriptedPiAgent {
+      public replaceMessagesCalls: unknown[] = [];
+
+      replaceMessages(messages: unknown): void {
+        this.replaceMessagesCalls.push(messages);
+        this.state.messages = Array.isArray(messages) ? [...messages] : [];
+      }
+
+      override async prompt(messages: unknown): Promise<void> {
+        this.promptCalls.push(messages);
+
+        const stateMessages = this.state.messages;
+        const replayedAssistantMessage = stateMessages.find(
+          (message): message is {
+            role: string;
+            api?: string;
+            provider?: string;
+            model?: string;
+            content?: Array<{ type?: string; id?: string }>;
+          } =>
+            typeof message === 'object' &&
+            message !== null &&
+            'role' in message &&
+            message.role === 'assistant',
+        );
+        const replayedToolResultMessage = stateMessages.find(
+          (message): message is { role: string; toolCallId?: string } =>
+            typeof message === 'object' &&
+            message !== null &&
+            'role' in message &&
+            message.role === 'toolResult',
+        );
+
+        const hasReplayedToolCall = replayedAssistantMessage?.content?.some(
+          (part) =>
+            part.type === 'toolCall' &&
+            part.id === 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+        );
+        const hasReplayedToolResult =
+          replayedToolResultMessage?.toolCallId ===
+          'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85';
+        const hasActiveModelIdentity =
+          replayedAssistantMessage?.api === 'openai-responses' &&
+          replayedAssistantMessage?.provider === 'openrouter' &&
+          replayedAssistantMessage?.model === 'openai/gpt-5.4-mini';
+
+        if (!hasReplayedToolCall || !hasReplayedToolResult || !hasActiveModelIdentity) {
+          throw new Error('missing rehydrated tool-call replay state');
+        }
+
+        this.emit({ type: 'agent_start' });
+        this.emit({ type: 'turn_start' });
+        this.emit({ type: 'agent_end', messages: [] });
+      }
+    }
+
+    const agent = new StatefulReplayPiAgent([]);
+    (agent.state as { model?: unknown }).model = {
+      id: 'openai/gpt-5.4-mini',
+      name: 'openai/gpt-5.4-mini',
+      api: 'openai-responses',
+      provider: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      reasoning: true,
+      input: ['text'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8192,
+      maxTokens: 2048,
+    };
+
+    const persistedMessages = [
+      {
+        id: 'user-msg',
+        role: 'user' as const,
+        content: 'withdraw all aArbUSDCn',
+      },
+      {
+        id: 'assistant-msg',
+        role: 'assistant' as const,
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+            type: 'function' as const,
+            function: {
+              name: 'agent_runtime_domain_command',
+              arguments:
+                '{"name":"create_transaction","inputJson":"{\\"control_path\\":\\"lending.withdraw\\",\\"asset\\":\\"aArbUSDCn\\",\\"protocol_system\\":\\"aave\\",\\"network\\":\\"arbitrum\\",\\"quantity\\":{\\"kind\\":\\"exact\\",\\"value\\":\\"3\\"}}"}',
+            },
+          },
+        ],
+      },
+      {
+        id: 'tool-msg',
+        role: 'tool' as const,
+        toolCallId: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+        content:
+          '{"content":[{"type":"text","text":"create_transaction requires JSON with control_path, asset, protocol_system, network, and quantity."}]}',
+      },
+    ];
+
+    let session = {
+      thread: { id: 'thread-openrouter-rehydration' },
+      execution: { id: 'exec-openrouter-rehydration', status: 'working' as const },
+      messages: persistedMessages,
+    };
+
+    const runtime = createPiRuntimeGatewayRuntime({
+      agent,
+      now: () => 123,
+      getSession: () => session,
+      updateSession: (_threadId, update) => {
+        session = update(session);
+        return session;
+      },
+    });
+
+    await collectEventSource(
+      await runtime.run({
+        threadId: 'thread-openrouter-rehydration',
+        runId: 'run-openrouter-rehydration',
+        messages: [
+          ...persistedMessages,
+          {
+            id: 'user-retry',
+            role: 'user',
+            content: 'one more time',
+          },
+        ],
+      }),
+    );
+
+    expect(agent.replaceMessagesCalls).toEqual([
+      [
+        {
+          role: 'user',
+          content: 'withdraw all aArbUSDCn',
+          timestamp: 123,
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolCall',
+              id: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+              name: 'agent_runtime_domain_command',
+              arguments: {
+                name: 'create_transaction',
+                inputJson:
+                  '{"control_path":"lending.withdraw","asset":"aArbUSDCn","protocol_system":"aave","network":"arbitrum","quantity":{"kind":"exact","value":"3"}}',
+              },
+            },
+          ],
+          api: 'openai-responses',
+          provider: 'openrouter',
+          model: 'openai/gpt-5.4-mini',
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: 'stop',
+          timestamp: 123,
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'call_iHEyccPxt8Yo99N9o7d62EfN|fc_tmp_ub0wnczh85',
+          toolName: 'ag-ui-tool',
+          content: [
+            {
+              type: 'text',
+              text:
+                '{"content":[{"type":"text","text":"create_transaction requires JSON with control_path, asset, protocol_system, network, and quantity."}]}',
+            },
+          ],
+          isError: false,
+          timestamp: 123,
+        },
+      ],
+    ]);
+    expect(agent.promptCalls).toEqual([
+      [
+        {
+          role: 'user',
+          content: 'one more time',
+          timestamp: 123,
+        },
+      ],
+    ]);
+  });
+
   it('emits a canonical request-message snapshot before streamed assistant output on run', async () => {
     const assistantMessage = {
       role: 'assistant',

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -222,6 +222,7 @@ export type PiRuntimeGatewayAgent = Pick<Agent, 'subscribe' | 'prompt' | 'contin
   sessionId?: string;
   steer?: (message: AgentMessage) => void;
   followUp?: (message: AgentMessage) => void;
+  replaceMessages?: (messages: AgentMessage[]) => void;
 };
 
 export type PiRuntimeGatewayFoundation = {
@@ -1265,7 +1266,41 @@ export const convertPiRuntimeGatewayMessagesToLlm = (
   return delegate ? delegate(preprocessedMessages) : preprocessedMessages.filter(isLlmCompatibleMessage);
 };
 
-const convertAgUiMessagesToPiMessages = (messages: AgUiMessage[], now: () => number): AgentMessage[] =>
+const readReplayAssistantModelIdentity = (
+  model: unknown,
+): {
+  api: string;
+  provider: string;
+  model: string;
+} | null => {
+  if (!isRecord(model)) {
+    return null;
+  }
+
+  const api = typeof model.api === 'string' ? model.api : null;
+  const provider = typeof model.provider === 'string' ? model.provider : null;
+  const modelId = typeof model.id === 'string' ? model.id : null;
+
+  if (!api || !provider || !modelId) {
+    return null;
+  }
+
+  return {
+    api,
+    provider,
+    model: modelId,
+  };
+};
+
+const convertAgUiMessagesToPiMessages = (
+  messages: AgUiMessage[],
+  now: () => number,
+  assistantModelIdentity?: {
+    api: string;
+    provider: string;
+    model: string;
+  } | null,
+): AgentMessage[] =>
   messages.flatMap((message): AgentMessage[] => {
     switch (message.role) {
       case 'user': {
@@ -1313,9 +1348,9 @@ const convertAgUiMessagesToPiMessages = (messages: AgUiMessage[], now: () => num
           {
             role: 'assistant',
             content,
-            api: 'responses' as never,
-            provider: 'openai' as never,
-            model: 'ag-ui-projected',
+            api: (assistantModelIdentity?.api ?? 'responses') as never,
+            provider: (assistantModelIdentity?.provider ?? 'openai') as never,
+            model: assistantModelIdentity?.model ?? 'ag-ui-projected',
             usage: EMPTY_USAGE,
             stopReason: 'stop',
             timestamp: now(),
@@ -1891,6 +1926,22 @@ export const createPiRuntimeGatewayRuntime = (params: {
   const syncAgentSessionId = (threadId: string): void => {
     params.agent.sessionId = threadId;
   };
+  const syncAgentMessagesFromSession = (session: PiRuntimeGatewaySession): void => {
+    if (typeof params.agent.replaceMessages !== 'function') {
+      return;
+    }
+
+    const replayAssistantModelIdentity = readReplayAssistantModelIdentity(
+      (params.agent.state as { model?: unknown } | undefined)?.model,
+    );
+    params.agent.replaceMessages(
+      convertAgUiMessagesToPiMessages(
+        session.messages ?? [],
+        now,
+        replayAssistantModelIdentity,
+      ),
+    );
+  };
 
   const buildMessagesSnapshotEvent = (session: PiRuntimeGatewaySession): MessagesSnapshotEvent | null =>
     session.messages
@@ -2147,11 +2198,20 @@ export const createPiRuntimeGatewayRuntime = (params: {
         });
 
         try {
+          syncAgentMessagesFromSession(initialSession);
+
           if (promptRequestMessages.length > 0 || requestHasResumePayload) {
+            const replayAssistantModelIdentity = readReplayAssistantModelIdentity(
+              (params.agent.state as { model?: unknown } | undefined)?.model,
+            );
             const promptMessages =
               requestHasResumePayload
                 ? buildResumePromptMessages(resumePayload, now)
-                : convertAgUiMessagesToPiMessages(promptRequestMessages, now);
+                : convertAgUiMessagesToPiMessages(
+                    promptRequestMessages,
+                    now,
+                    replayAssistantModelIdentity,
+                  );
             if (params.agent.state.isStreaming) {
               if (params.agent.steer) {
                 for (const message of promptMessages) {

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -1893,7 +1893,7 @@ describe('agent-runtime integration', () => {
       },
     });
 
-    const resumeEvents = await collectEventSource(
+    const resumeEvents = await collectQueuedEvents(
       await runtime.service.run({
         threadId: 'thread-resume-after-artifact-overwrite',
         runId: 'run-resume-after-artifact-overwrite',
@@ -2018,7 +2018,7 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const resumeEvents = await collectEventSource(
+    const resumeEvents = await collectQueuedEvents(
       await runtime.service.run({
         threadId: 'thread-resume-with-client-scaffolding',
         runId: 'run-resume-with-client-scaffolding',

--- a/typescript/agent-runtime/src/internal.ts
+++ b/typescript/agent-runtime/src/internal.ts
@@ -404,16 +404,18 @@ function parseTypedDataSigningPayload(
   signerRef: AgentRuntimeSignerRef,
   payload: Record<string, unknown>,
 ): TypedDataSigningPayload {
+  const serializeTypedDataBigInt = (value: bigint): string =>
+    value >= MAX_DECIMAL_TYPED_DATA_BIGINT
+      ? `0x${value
+          .toString(16)
+          .padStart(value.toString(16).length + (value.toString(16).length % 2), '0')}`
+      : value.toString();
   const chain = readString(payload['chain']);
   const typedDataJson =
     readString(payload['typedDataJson']) ??
     (isRecord(payload['typedData'])
       ? JSON.stringify(payload['typedData'], (_key, value: unknown) =>
-          typeof value === 'bigint'
-            ? value >= MAX_DECIMAL_TYPED_DATA_BIGINT
-              ? `0x${value.toString(16)}`
-              : value.toString()
-            : value,
+          typeof value === 'bigint' ? serializeTypedDataBigInt(value) : value,
         )
       : null);
 

--- a/typescript/agent-runtime/src/internal.unit.test.ts
+++ b/typescript/agent-runtime/src/internal.unit.test.ts
@@ -471,6 +471,67 @@ describe('agent-runtime internal signing surface', () => {
     });
   });
 
+  it('signs typed-data payloads when large uint256 fields require an even-length hex string', async () => {
+    const fixture = createOwsTestSignerEnv();
+    cleanupFns.add(fixture.cleanup);
+
+    const signing = createSigningService(fixture.env);
+
+    await expect(
+      signing.signPayload({
+        signerRef: TEST_SIGNER_REF,
+        expectedAddress: TEST_EVM_ADDRESS,
+        payloadKind: 'typed-data',
+        payload: {
+          chain: 'evm',
+          typedData: {
+            domain: {
+              chainId: 42161,
+              name: 'DelegationManager',
+              version: '1',
+              verifyingContract: '0x00000000000000000000000000000000000000d1',
+            },
+            types: {
+              EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' },
+              ],
+              Caveat: [
+                { name: 'enforcer', type: 'address' },
+                { name: 'terms', type: 'bytes' },
+              ],
+              Delegation: [
+                { name: 'delegate', type: 'address' },
+                { name: 'delegator', type: 'address' },
+                { name: 'authority', type: 'bytes32' },
+                { name: 'caveats', type: 'Caveat[]' },
+                { name: 'salt', type: 'uint256' },
+              ],
+            },
+            primaryType: 'Delegation',
+            message: {
+              delegate: TEST_EVM_ADDRESS,
+              delegator: TEST_EVM_ADDRESS,
+              authority: '0x1111111111111111111111111111111111111111111111111111111111111111',
+              caveats: [],
+              salt: BigInt(
+                '0x0123cfc6857440d382efe0305654d580915753ffcf728bd20d06cbe48c2d7eac',
+              ),
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      confirmedAddress: TEST_EVM_ADDRESS,
+      signedPayload: {
+        signature: expect.stringMatching(/^0x[0-9a-f]+$/),
+        recoveryId: expect.any(Number),
+      },
+    });
+  });
+
   it('fails closed when the expected address does not match the configured OWS wallet', async () => {
     const fixture = createOwsTestSignerEnv();
     cleanupFns.add(fixture.cleanup);

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/.env.example
@@ -24,6 +24,11 @@ OPENROUTER_API_KEY=
 # ready.
 # SHARED_EMBER_BASE_URL=http://127.0.0.1:4010
 
+# Optional: override the portfolio-manager runtime URL that the lending service
+# uses for non-LLM redelegation refresh commands when Shared Ember returns
+# `ready_for_redelegation`.
+# PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL=http://127.0.0.1:3420/ag-ui
+
 # Optional: override the Onchain Actions API origin the live lending service
 # uses to anchor planner payload refs behind the service boundary and later
 # resolve ordered transaction steps during execution signing.

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -1400,14 +1400,23 @@ describe('agent-ember-lending AG-UI integration', () => {
       },
     });
 
-    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      3,
       expect.objectContaining({
         method: 'subagent.createTransaction.v1',
         params: expect.objectContaining({
-          handoff: expect.objectContaining({
-            agent_id: 'ember-lending',
-            mandate_ref: 'mandate-ember-lending-001',
-          }),
+          agent_id: 'ember-lending',
+          expected_revision: 11,
+          request: {
+            control_path: 'lending.supply',
+            asset: 'USDC',
+            protocol_system: 'aave',
+            network: 'arbitrum',
+            quantity: {
+              kind: 'exact',
+              value: '10',
+            },
+          },
         }),
       }),
     );
@@ -1434,9 +1443,7 @@ describe('agent-ember-lending AG-UI integration', () => {
       expect.objectContaining({
         method: 'subagent.createTransaction.v1',
         params: expect.objectContaining({
-          handoff: expect.objectContaining({
-            payload_builder_output: expect.anything(),
-          }),
+          handoff: expect.anything(),
         }),
       }),
     );

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/emberLendingFoundation.ts
@@ -16,6 +16,10 @@ import {
   createEmberLendingSharedEmberHttpHost,
   resolveEmberLendingSharedEmberBaseUrl,
 } from './sharedEmberHttpHost.js';
+import {
+  createPortfolioManagerRedelegationRefresher,
+  resolvePortfolioManagerAgentDeploymentUrl,
+} from './redelegationCoordinator.js';
 
 const DEFAULT_EMBER_LENDING_MODEL = 'openai/gpt-5.4';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
@@ -27,6 +31,7 @@ export type EmberLendingGatewayEnv = NodeJS.ProcessEnv & {
   EMBER_LENDING_MODEL?: string;
   DATABASE_URL?: string;
   SHARED_EMBER_BASE_URL?: string;
+  PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL?: string;
   ONCHAIN_ACTIONS_API_URL?: string;
   ARBITRUM_RPC_URL?: string;
   ETHEREUM_RPC_URL?: string;
@@ -47,6 +52,7 @@ type EmberLendingGatewayModel = EmberLendingAgentConfig['model'];
 export type EmberLendingGatewayDependencies = {
   protocolHost: ReturnType<typeof createEmberLendingSharedEmberHttpHost> | undefined;
   anchoredPayloadResolver: EmberLendingAnchoredPayloadResolver;
+  requestRedelegationRefresh: (input: { rootWalletAddress: string }) => Promise<void>;
 };
 
 type CreateEmberLendingAgentConfigOptions = {
@@ -93,7 +99,7 @@ export function createEmberLendingAgentConfig(
 ): EmberLendingAgentConfig {
   const apiKey = requireEnvValue(env.OPENROUTER_API_KEY, 'OPENROUTER_API_KEY');
   const modelId = env.EMBER_LENDING_MODEL?.trim() || DEFAULT_EMBER_LENDING_MODEL;
-  const { protocolHost, anchoredPayloadResolver } =
+  const { protocolHost, anchoredPayloadResolver, requestRedelegationRefresh } =
     options.dependencies ?? resolveEmberLendingGatewayDependencies(env);
 
   return {
@@ -106,6 +112,7 @@ export function createEmberLendingAgentConfig(
       runtimeSigning: options.runtimeSigning,
       anchoredPayloadResolver,
       runtimeSignerRef: options.runtimeSignerRef,
+      requestRedelegationRefresh,
     }),
     agentOptions: {
       initialState: {
@@ -131,6 +138,9 @@ export function resolveEmberLendingGatewayDependencies(
     anchoredPayloadResolver: createEmberLendingOnchainActionsAnchoredPayloadResolver({
       baseUrl: onchainActionsApiUrl,
       env,
+    }),
+    requestRedelegationRefresh: createPortfolioManagerRedelegationRefresher({
+      runtimeUrl: resolvePortfolioManagerAgentDeploymentUrl(env),
     }),
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
@@ -406,10 +406,6 @@ function resolveAmountForOnchainActions(input: {
   }
 
   const normalizedAmount = input.amount.trim();
-  if (/^\d+$/u.test(normalizedAmount)) {
-    return normalizedAmount;
-  }
-
   return parseUnits(normalizedAmount, input.decimals).toString();
 }
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.ts
@@ -234,16 +234,27 @@ function resolvePlannerAssetAlias(input: {
 
   switch (input.network.trim().toLowerCase()) {
     case 'arbitrum':
-      if (normalizedAsset.startsWith('variabledebtarb')) {
-        return normalizedAsset.slice('variabledebtarb'.length) || null;
-      }
-      if (normalizedAsset.startsWith('aarb')) {
-        return normalizedAsset.slice('aarb'.length) || null;
-      }
-      return null;
+      return resolveArbitrumAaveAssetAlias(normalizedAsset);
     default:
       return null;
   }
+}
+
+function resolveArbitrumAaveAssetAlias(normalizedAsset: string): string | null {
+  for (const prefix of ['variabledebtarb', 'aarb']) {
+    if (!normalizedAsset.startsWith(prefix)) {
+      continue;
+    }
+
+    const suffix = normalizedAsset.slice(prefix.length);
+    if (suffix.length === 0) {
+      return null;
+    }
+
+    return suffix.endsWith('n') && suffix.length > 1 ? suffix.slice(0, -1) : suffix;
+  }
+
+  return null;
 }
 
 function resolveRpcUrl(

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
@@ -394,7 +394,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         compactPlanSummary: {
           control_path: 'lending.withdraw',
           asset: 'aArbWETH',
-          amount: '1500000000000',
+          amount: '0.0000015',
           summary: 'withdraw WETH collateral from Aave back to idle WETH',
         },
       }),
@@ -501,7 +501,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         compactPlanSummary: {
           control_path: 'lending.withdraw',
           asset: 'aArbUSDCn',
-          amount: '1500000',
+          amount: '1.5',
           summary: 'withdraw USDC collateral from Aave back to idle USDC',
         },
       }),
@@ -529,6 +529,113 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
             address: '0x00000000000000000000000000000000000000c9',
           },
           amount: '1500000',
+        }),
+      }),
+    );
+  });
+
+  it('converts exact integer human quantities into token base units using OCA token decimals', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c9',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000da',
+                value: '0',
+                data: '0xa415bcad',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+    });
+
+    await expect(
+      resolver.anchorCandidatePlanPayload({
+        agentId: 'ember-lending',
+        threadId: 'thread-1',
+        transactionPlanId: 'txplan-ember-lending-wrapper-alias-usdcn-integer-001',
+        walletAddress: '0x00000000000000000000000000000000000000ba',
+        rootUserWalletAddress: '0x00000000000000000000000000000000000000ba',
+        payloadBuilderOutput: {
+          transaction_payload_ref: 'txpayload-ember-lending-wrapper-alias-usdcn-integer-001',
+          required_control_path: 'lending.withdraw',
+          network: 'arbitrum',
+        },
+        compactPlanSummary: {
+          control_path: 'lending.withdraw',
+          asset: 'aArbUSDCn',
+          amount: '1',
+          summary: 'withdraw 1 USDC collateral from Aave back to idle USDC',
+        },
+      }),
+    ).resolves.toMatchObject({
+      transactionRequests: [
+        {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000da',
+          value: '0',
+          data: '0xa415bcad',
+          chainId: '42161',
+        },
+      ],
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.emberai.xyz/lending/withdraw',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: '0x00000000000000000000000000000000000000ba',
+          tokenUidToWidthraw: {
+            chainId: '42161',
+            address: '0x00000000000000000000000000000000000000c9',
+          },
+          amount: '1000000',
         }),
       }),
     );
@@ -901,7 +1008,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
         compactPlanSummary: {
           control_path: 'lending.supply',
           asset: 'USDC',
-          amount: '10000000',
+          amount: '10',
           summary: 'supply reserved USDC on Aave',
         },
       }),
@@ -1212,7 +1319,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
       compactPlanSummary: {
         control_path: 'lending.repay',
         asset: 'variableDebtArbUSDCn',
-        amount: '2500000',
+        amount: '2.5',
         summary: 'repay an exact partial USDC debt amount on Aave',
       },
     });
@@ -1311,7 +1418,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
       compactPlanSummary: {
         control_path: 'lending.repay',
         asset: 'WETH',
-        amount: '20000000000000000',
+        amount: '0.02',
         summary: 'repay an exact partial WETH debt amount on Aave',
       },
     });
@@ -1409,7 +1516,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
       compactPlanSummary: {
         control_path: 'lending.supply',
         asset: 'WETH',
-        amount: '5000000000000000',
+        amount: '0.005',
         summary: 'supply reserved WETH on Aave',
       },
     });
@@ -1646,7 +1753,7 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
       compactPlanSummary: {
         control_path: 'lending.supply',
         asset: 'USDC',
-        amount: '10000000',
+        amount: '10',
         summary: 'supply reserved USDC on Aave',
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/onchainActionsPayloadResolver.unit.test.ts
@@ -427,6 +427,113 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
     );
   });
 
+  it('maps Arbitrum native-USDC wrapper symbols back to canonical USDC when anchoring payloads', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c9',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d9',
+                value: '0',
+                data: '0xa415bcad',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+    });
+
+    await expect(
+      resolver.anchorCandidatePlanPayload({
+        agentId: 'ember-lending',
+        threadId: 'thread-1',
+        transactionPlanId: 'txplan-ember-lending-wrapper-alias-usdcn-001',
+        walletAddress: '0x00000000000000000000000000000000000000b9',
+        rootUserWalletAddress: '0x00000000000000000000000000000000000000b9',
+        payloadBuilderOutput: {
+          transaction_payload_ref: 'txpayload-ember-lending-wrapper-alias-usdcn-001',
+          required_control_path: 'lending.withdraw',
+          network: 'arbitrum',
+        },
+        compactPlanSummary: {
+          control_path: 'lending.withdraw',
+          asset: 'aArbUSDCn',
+          amount: '1500000',
+          summary: 'withdraw USDC collateral from Aave back to idle USDC',
+        },
+      }),
+    ).resolves.toMatchObject({
+      transactionRequests: [
+        {
+          type: 'EVM_TX',
+          to: '0x00000000000000000000000000000000000000d9',
+          value: '0',
+          data: '0xa415bcad',
+          chainId: '42161',
+        },
+      ],
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.emberai.xyz/lending/withdraw',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: '0x00000000000000000000000000000000000000b9',
+          tokenUidToWidthraw: {
+            chainId: '42161',
+            address: '0x00000000000000000000000000000000000000c9',
+          },
+          amount: '1500000',
+        }),
+      }),
+    );
+  });
+
   it('wraps the anchored request in a delegated redeemDelegations transaction using the canonical signing package', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
@@ -1026,6 +1133,105 @@ describe('createEmberLendingOnchainActionsAnchoredPayloadResolver', () => {
             address: '0x00000000000000000000000000000000000000a1',
           },
           amount: MAX_UINT256,
+        }),
+      },
+    );
+  });
+
+  it('maps Arbitrum native-USDC debt wrapper symbols back to canonical USDC when anchoring repay payloads', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tokens: [
+              {
+                tokenUid: {
+                  chainId: '42161',
+                  address: '0x00000000000000000000000000000000000000c9',
+                },
+                name: 'USD Coin',
+                symbol: 'USDC',
+                isNative: false,
+                decimals: 6,
+                iconUri: null,
+                isVetted: true,
+              },
+            ],
+            cursor: null,
+            currentPage: 1,
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transactions: [
+              {
+                type: 'EVM_TX',
+                to: '0x00000000000000000000000000000000000000d2',
+                value: '0',
+                data: '0x573ade81',
+                chainId: '42161',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+    const resolver = createEmberLendingOnchainActionsAnchoredPayloadResolver({
+      baseUrl: 'https://api.emberai.xyz',
+      fetch: fetchImpl,
+    });
+
+    await resolver.anchorCandidatePlanPayload({
+      agentId: 'ember-lending',
+      threadId: 'thread-rooted-repay-usdcn-1',
+      transactionPlanId: 'txplan-ember-lending-rooted-repay-usdcn-001',
+      walletAddress: '0x00000000000000000000000000000000000000b9',
+      rootUserWalletAddress: '0x00000000000000000000000000000000000000b9',
+      useMaxRepayAmount: false,
+      payloadBuilderOutput: {
+        transaction_payload_ref: 'txpayload-ember-lending-rooted-repay-usdcn-001',
+        required_control_path: 'lending.repay',
+        network: 'arbitrum',
+      },
+      compactPlanSummary: {
+        control_path: 'lending.repay',
+        asset: 'variableDebtArbUSDCn',
+        amount: '2500000',
+        summary: 'repay an exact partial USDC debt amount on Aave',
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.emberai.xyz/lending/repay',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          walletAddress: '0x00000000000000000000000000000000000000b9',
+          repayTokenUid: {
+            chainId: '42161',
+            address: '0x00000000000000000000000000000000000000c9',
+          },
+          amount: '2500000',
         }),
       },
     );

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/redelegationCoordinator.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/redelegationCoordinator.ts
@@ -1,0 +1,110 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { createAgentRuntimeHttpAgent } from 'agent-runtime';
+
+const PORTFOLIO_MANAGER_AGENT_ID = 'agent-portfolio-manager';
+const PORTFOLIO_MANAGER_THREAD_NAMESPACE = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+const DEFAULT_PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL = 'http://127.0.0.1:3420/ag-ui';
+
+type RunResult = {
+  subscribe: (observer: {
+    complete?: () => void;
+    error?: (error: unknown) => void;
+  }) => { unsubscribe?: () => void };
+};
+
+type RuntimeHttpAgent = {
+  run: (input: {
+    threadId: string;
+    runId: string;
+    messages: unknown[];
+    state: Record<string, unknown>;
+    tools: unknown[];
+    context: unknown[];
+    forwardedProps: {
+      command: {
+        name: string;
+      };
+    };
+  }) => RunResult;
+};
+
+function normalizeWalletAddress(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function decodeUuid(uuid: string): Uint8Array {
+  const normalized = uuid.replace(/-/g, '');
+  const bytes = new Uint8Array(16);
+  for (let index = 0; index < 16; index += 1) {
+    bytes[index] = Number.parseInt(normalized.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function encodeUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function buildPortfolioManagerThreadId(rootWalletAddress: string): string {
+  const hash = createHash('sha1')
+    .update(decodeUuid(PORTFOLIO_MANAGER_THREAD_NAMESPACE))
+    .update(`copilotkit:${PORTFOLIO_MANAGER_AGENT_ID}:${normalizeWalletAddress(rootWalletAddress)}`)
+    .digest();
+  const bytes = new Uint8Array(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  return encodeUuid(bytes);
+}
+
+export function resolvePortfolioManagerAgentDeploymentUrl(
+  env:
+    | NodeJS.ProcessEnv
+    | {
+        PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL?: string;
+      } = process.env,
+): string {
+  return (
+    env.PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL?.trim() ||
+    DEFAULT_PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL
+  );
+}
+
+export function createPortfolioManagerRedelegationRefresher(input: {
+  runtimeUrl: string;
+  createHttpAgent?: (config: {
+    agentId: string;
+    runtimeUrl: string;
+  }) => RuntimeHttpAgent;
+}): (params: { rootWalletAddress: string }) => Promise<void> {
+  const createHttpAgent = input.createHttpAgent ?? createAgentRuntimeHttpAgent;
+
+  return async ({ rootWalletAddress }) => {
+    const agent = createHttpAgent({
+      agentId: PORTFOLIO_MANAGER_AGENT_ID,
+      runtimeUrl: input.runtimeUrl,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      agent
+        .run({
+          threadId: buildPortfolioManagerThreadId(rootWalletAddress),
+          runId: randomUUID(),
+          messages: [],
+          state: {},
+          tools: [],
+          context: [],
+          forwardedProps: {
+            command: {
+              name: 'refresh_redelegation_work',
+            },
+          },
+        })
+        .subscribe({
+          complete: resolve,
+          error: reject,
+        });
+    });
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/redelegationCoordinator.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/redelegationCoordinator.unit.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildPortfolioManagerThreadId,
+  createPortfolioManagerRedelegationRefresher,
+  resolvePortfolioManagerAgentDeploymentUrl,
+} from './redelegationCoordinator.js';
+
+describe('redelegationCoordinator', () => {
+  it('derives the same PM thread id for the same rooted wallet address', () => {
+    expect(
+      buildPortfolioManagerThreadId('0x00000000000000000000000000000000000000A1'),
+    ).toBe(
+      buildPortfolioManagerThreadId('0x00000000000000000000000000000000000000a1'),
+    );
+    expect(
+      buildPortfolioManagerThreadId('0x00000000000000000000000000000000000000a1'),
+    ).not.toBe(
+      buildPortfolioManagerThreadId('0x00000000000000000000000000000000000000a2'),
+    );
+  });
+
+  it('runs refresh_redelegation_work against the PM direct command lane', async () => {
+    const run = vi.fn(() => ({
+      subscribe(observer: {
+        complete?: () => void;
+        error?: (error: unknown) => void;
+      }) {
+        observer.complete?.();
+        return {
+          unsubscribe() {
+            return undefined;
+          },
+        };
+      },
+    }));
+    const createHttpAgent = vi.fn(() => ({
+      run,
+    }));
+
+    const refresh = createPortfolioManagerRedelegationRefresher({
+      runtimeUrl: 'http://127.0.0.1:3420/ag-ui',
+      createHttpAgent,
+    });
+
+    await refresh({
+      rootWalletAddress: '0x00000000000000000000000000000000000000A1',
+    });
+
+    expect(createHttpAgent).toHaveBeenCalledWith({
+      agentId: 'agent-portfolio-manager',
+      runtimeUrl: 'http://127.0.0.1:3420/ag-ui',
+    });
+    expect(run).toHaveBeenCalledWith({
+      threadId: buildPortfolioManagerThreadId(
+        '0x00000000000000000000000000000000000000a1',
+      ),
+      runId: expect.any(String),
+      messages: [],
+      state: {},
+      tools: [],
+      context: [],
+      forwardedProps: {
+        command: {
+          name: 'refresh_redelegation_work',
+        },
+      },
+    });
+  });
+
+  it('resolves the PM runtime url from env with a local default', () => {
+    expect(resolvePortfolioManagerAgentDeploymentUrl({})).toBe(
+      'http://127.0.0.1:3420/ag-ui',
+    );
+    expect(
+      resolvePortfolioManagerAgentDeploymentUrl({
+        PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL: 'http://pm.example.test/ag-ui',
+      }),
+    ).toBe('http://pm.example.test/ag-ui');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/runtimePrep.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/runtimePrep.unit.test.ts
@@ -34,7 +34,15 @@ describe('managed Shared Ember harness bootstrap', () => {
             };
           },
           createManagedOnboardingIssuers: async () => undefined,
-          createSubagentRuntimes: async () => undefined,
+          createSubagentRuntimes: async () => ({
+            'ember-lending': {
+              submissionBackend: {
+                submitSignedTransaction: async () => ({
+                  execution: { status: 'submitted' },
+                }),
+              },
+            },
+          }),
           startServer: async ({ bootstrap }) => {
             capturedBootstrap = bootstrap;
             return {
@@ -59,5 +67,37 @@ describe('managed Shared Ember harness bootstrap', () => {
         process.env.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS = previousPlannerAgentIds;
       }
     }
+  });
+
+  it('fails fast when the managed subagent runtime binding is missing', async () => {
+    await expect(
+      startManagedSharedEmberHarness(
+        {
+          specRoot: '/spec-root',
+          vibekitRoot: '/vibekit-root',
+          managedAgentId: 'ember-lending',
+          host: '127.0.0.1',
+          port: 4010,
+        },
+        {
+          resolveReferenceBootstrap: async () => ({
+            emberSkillPlanners: {
+              'ember-lending': {
+                planLendingSupply: async () => ({
+                  transaction_plan_id: 'txplan-test',
+                }),
+              },
+            },
+          }),
+          createManagedOnboardingIssuers: async () => undefined,
+          createSubagentRuntimes: async () => undefined,
+          startServer: async () => {
+            throw new Error('startServer should not be called without a runtime binding');
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      'Managed Shared Ember bootstrap requires a seeded subagent runtime binding for ember-lending.',
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/runtimePrep.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/runtimePrep.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { startManagedSharedEmberHarness } from '../../../scripts/smoke/support/runtimePrep.ts';
+
+describe('managed Shared Ember harness bootstrap', () => {
+  it('passes the managed planner agent env through startManagedSharedEmberHarness', async () => {
+    const previousPlannerAgentIds = process.env.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS;
+    process.env.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS = 'alpha';
+
+    let capturedBootstrapEnv: NodeJS.ProcessEnv | undefined;
+    let capturedBootstrap: Record<string, unknown> | undefined;
+
+    try {
+      const server = await startManagedSharedEmberHarness(
+        {
+          specRoot: '/spec-root',
+          vibekitRoot: '/vibekit-root',
+          managedAgentId: 'ember-lending',
+          host: '127.0.0.1',
+          port: 4010,
+        },
+        {
+          resolveReferenceBootstrap: async (env) => {
+            capturedBootstrapEnv = env;
+
+            return {
+              emberSkillPlanners: {
+                [env?.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS ?? 'missing']: {
+                  planLendingSupply: async () => ({
+                    transaction_plan_id: 'txplan-test',
+                  }),
+                },
+              },
+            };
+          },
+          createManagedOnboardingIssuers: async () => undefined,
+          createSubagentRuntimes: async () => undefined,
+          startServer: async ({ bootstrap }) => {
+            capturedBootstrap = bootstrap;
+            return {
+              baseUrl: 'http://127.0.0.1:4010',
+              close: async () => {},
+            };
+          },
+        },
+      );
+
+      expect(server.baseUrl).toBe('http://127.0.0.1:4010');
+      expect(
+        capturedBootstrapEnv?.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS?.split(','),
+      ).toEqual(['alpha', 'ember-lending']);
+      expect(
+        Object.keys((capturedBootstrap?.emberSkillPlanners as Record<string, unknown>) ?? {}),
+      ).toEqual(['alpha,ember-lending']);
+    } finally {
+      if (previousPlannerAgentIds === undefined) {
+        delete process.env.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS;
+      } else {
+        process.env.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS = previousPlannerAgentIds;
+      }
+    }
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -66,6 +66,12 @@ type CreateEmberLendingDomainOptions = {
   anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
   runtimeSignerRef?: string;
   agentId?: string;
+  requestRedelegationRefresh?: (input: {
+    rootWalletAddress: string;
+    threadId: string;
+    transactionPlanId: string;
+    requestId: string;
+  }) => Promise<void>;
 };
 
 type RequestTransactionExecutionResponse = {
@@ -3309,6 +3315,12 @@ async function runPreparedExecutionFlow(input: {
   runtimeSigning?: AgentRuntimeSigningService;
   anchoredPayloadResolver?: EmberLendingAnchoredPayloadResolver;
   runtimeSignerRef?: string;
+  requestRedelegationRefresh?: (input: {
+    rootWalletAddress: string;
+    threadId: string;
+    transactionPlanId: string;
+    requestId: string;
+  }) => Promise<void>;
   threadId: string;
   agentId: string;
   currentState: EmberLendingLifecycleState;
@@ -3388,6 +3400,18 @@ async function runPreparedExecutionFlow(input: {
         agentId: input.agentId,
         requestId,
       });
+      if (currentProgress !== null && input.currentState.rootUserWalletAddress) {
+        try {
+          await input.requestRedelegationRefresh?.({
+            rootWalletAddress: input.currentState.rootUserWalletAddress,
+            threadId: input.threadId,
+            transactionPlanId: input.transactionPlanId,
+            requestId,
+          });
+        } catch {
+          // Best-effort PM-side redelegation should not block the existing wait path.
+        }
+      }
       const latestProgress =
         currentProgress === null
           ? null
@@ -4038,6 +4062,7 @@ export function createEmberLendingDomain(
                     runtimeSigning: options.runtimeSigning,
                     anchoredPayloadResolver: options.anchoredPayloadResolver,
                     runtimeSignerRef: options.runtimeSignerRef,
+                    requestRedelegationRefresh: options.requestRedelegationRefresh,
                     threadId,
                     agentId,
                     currentState,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -37,6 +37,8 @@ const PLANNING_PM_ONBOARDING_BLOCKED_MESSAGE =
   'Portfolio Manager onboarding must complete before lending can plan transactions for this thread.';
 const CREATE_TRANSACTION_INPUT_BLOCKED_MESSAGE =
   'create_transaction requires JSON with control_path, asset, protocol_system, network, and quantity. quantity must be {"kind":"exact","value":"1.25"} or {"kind":"percent","value":50}.';
+const CREATE_TRANSACTION_CONTROL_PATH_BLOCKED_MESSAGE =
+  'create_transaction control_path must be one of "lending.supply", "lending.withdraw", "lending.borrow", or "lending.repay". Do not pass a position-scope id like "position-scope-aave-arbitrum-...". Exact quantity strings like {"kind":"exact","value":"3"} are valid.';
 
 export type EmberLendingLifecycleState = {
   phase: 'prehire' | 'onboarding' | 'active' | 'firing' | 'inactive';
@@ -2872,22 +2874,76 @@ function readSemanticQuantityInput(value: unknown): SemanticQuantity | null {
   return null;
 }
 
-function readSemanticTransactionRequestInput(value: unknown): SemanticTransactionRequest | null {
-  if (!isRecord(value)) {
+function readJsonObjectInput(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) {
+    return value;
+  }
+
+  const serialized = readString(value)?.trim();
+  if (!serialized) {
     return null;
   }
 
-  const controlPath = readString(value['control_path']);
-  const asset = readString(value['asset']);
-  const protocolSystem = readString(value['protocol_system']);
-  const network = readString(value['network']);
-  const quantity = readSemanticQuantityInput(value['quantity']);
+  const parseCandidates = [serialized];
+  const fencedJsonMatch = serialized.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  if (fencedJsonMatch?.[1]) {
+    parseCandidates.unshift(fencedJsonMatch[1].trim());
+  }
+
+  for (const candidate of parseCandidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (isRecord(parsed)) {
+        return parsed;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function isSemanticTransactionControlPath(
+  value: string,
+): value is SemanticTransactionRequest['control_path'] {
+  return (
+    value === 'lending.supply' ||
+    value === 'lending.withdraw' ||
+    value === 'lending.borrow' ||
+    value === 'lending.repay'
+  );
+}
+
+function readSemanticTransactionRequestBlockedMessage(value: unknown): string {
+  const input = readJsonObjectInput(value);
+  if (!input) {
+    return CREATE_TRANSACTION_INPUT_BLOCKED_MESSAGE;
+  }
+
+  const controlPath = readString(input['control_path']);
+  if (controlPath && !isSemanticTransactionControlPath(controlPath)) {
+    return CREATE_TRANSACTION_CONTROL_PATH_BLOCKED_MESSAGE;
+  }
+
+  return CREATE_TRANSACTION_INPUT_BLOCKED_MESSAGE;
+}
+
+function readSemanticTransactionRequestInput(value: unknown): SemanticTransactionRequest | null {
+  const input = readJsonObjectInput(value);
+  if (!input) {
+    return null;
+  }
+
+  const controlPath = readString(input['control_path']);
+  const asset = readString(input['asset']);
+  const protocolSystem = readString(input['protocol_system']);
+  const network = readString(input['network']);
+  const quantity = readSemanticQuantityInput(input['quantity']);
 
   if (
-    (controlPath !== 'lending.supply' &&
-      controlPath !== 'lending.withdraw' &&
-      controlPath !== 'lending.borrow' &&
-      controlPath !== 'lending.repay') ||
+    !controlPath ||
+    !isSemanticTransactionControlPath(controlPath) ||
     !asset ||
     !protocolSystem ||
     !network ||
@@ -2920,12 +2976,11 @@ function resolveManagedPlanningReadiness(input: {
     };
   }
 
-  const commandInput = isRecord(input.operationInput) ? input.operationInput : {};
-  const request = readSemanticTransactionRequestInput(commandInput);
+  const request = readSemanticTransactionRequestInput(input.operationInput);
   if (!request) {
     return {
       status: 'blocked',
-      statusMessage: CREATE_TRANSACTION_INPUT_BLOCKED_MESSAGE,
+      statusMessage: readSemanticTransactionRequestBlockedMessage(input.operationInput),
       reason: 'invalid_request',
     };
   }
@@ -3100,7 +3155,7 @@ function buildEscalationHandoff(input: {
     return null;
   }
 
-  const commandInput = isRecord(input.operationInput) ? input.operationInput : {};
+  const commandInput = readJsonObjectInput(input.operationInput) ?? {};
   const source =
     'handoff' in commandInput && isRecord(commandInput['handoff']) ? commandInput['handoff'] : commandInput;
   const intent = resolveManagedPlanningIntent(source, input.state.lastPortfolioState);
@@ -3585,11 +3640,12 @@ async function resumePendingExecutionSubmission(input: {
 }
 
 function readEscalationResult(operationInput: unknown): unknown {
-  if (isRecord(operationInput) && 'result' in operationInput) {
-    return operationInput['result'];
+  const commandInput = readJsonObjectInput(operationInput);
+  if (commandInput && 'result' in commandInput) {
+    return commandInput['result'];
   }
 
-  return operationInput;
+  return commandInput ?? operationInput;
 }
 
 export function createEmberLendingDomain(
@@ -3614,7 +3670,7 @@ export function createEmberLendingDomain(
         {
           name: 'create_transaction',
           description:
-            'Create or refresh a candidate transaction plan for the managed lending position. Reason from mandate_context, wallet_contents, active_position_scopes, active_reservations, and the current candidate plan. mandate_context is the exact managed mandate policy envelope; use wallet_contents, active_position_scopes, active_reservations, and the current candidate plan for live quantities and values. wallet_contents and active_position_scopes describe rooted user wallet context, not balances held in subagent_wallet_address. active_reservations surface the current reservation-backed execution envelope. When active_reservations are surfaced for lending.supply, use that reservation-backed quantity instead of the full idle wallet amount. subagent_wallet_address is the dedicated execution wallet and only reflects balances explicitly surfaced for that wallet. Keep the action families distinct: lending.supply adds collateral, lending.withdraw removes collateral, lending.borrow increases debt, and lending.repay pays down debt. Do not answer a repay request with a supply plan, do not answer a withdraw request with a repay or supply plan, and do not answer a borrow request with a collateral-add plan. When the user asks to create, refresh, or retry a plan, call this tool in the current turn instead of only describing the last plan. Pass JSON with control_path, asset, protocol_system, network, and quantity. quantity must be either { "kind": "exact", "value": "1.25" } using asset-unit decimal strings or { "kind": "percent", "value": 50 } using percent of the relevant base for that action. asset is the actionable observed asset; active_position_scopes expose economic_exposures when the asset is a wrapper or synthetic token.',
+            'Create or refresh a candidate transaction plan for the managed lending position. Reason from mandate_context, wallet_contents, active_position_scopes, active_reservations, and the current candidate plan. mandate_context is the exact managed mandate policy envelope; use wallet_contents, active_position_scopes, active_reservations, and the current candidate plan for live quantities and values. wallet_contents and active_position_scopes describe rooted user wallet context, not balances held in subagent_wallet_address. active_reservations surface the current reservation-backed execution envelope. When active_reservations are surfaced for lending.supply, use that reservation-backed quantity instead of the full idle wallet amount. subagent_wallet_address is the dedicated execution wallet and only reflects balances explicitly surfaced for that wallet. Keep the action families distinct: lending.supply adds collateral, lending.withdraw removes collateral, lending.borrow increases debt, and lending.repay pays down debt. Do not answer a repay request with a supply plan, do not answer a withdraw request with a repay or supply plan, and do not answer a borrow request with a collateral-add plan. When the user asks to create, refresh, or retry a plan, call this tool in the current turn instead of only describing the last plan. Pass JSON with control_path, asset, protocol_system, network, and quantity. control_path must be one of lending.supply, lending.withdraw, lending.borrow, or lending.repay; never pass a position-scope id there. quantity must be either { "kind": "exact", "value": "3" } or { "kind": "exact", "value": "1.25" } using asset-unit decimal strings, or { "kind": "percent", "value": 50 } using percent of the relevant base for that action. asset is the actionable observed asset; active_position_scopes expose economic_exposures when the asset is a wrapper or synthetic token.',
         },
         {
           name: 'request_execution',
@@ -3784,7 +3840,7 @@ export function createEmberLendingDomain(
                 status: {
                   executionStatus: 'failed',
                   statusMessage:
-                    CREATE_TRANSACTION_INPUT_BLOCKED_MESSAGE,
+                    readSemanticTransactionRequestBlockedMessage(operation.input),
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -5807,11 +5807,13 @@ describe('createEmberLendingDomain', () => {
         },
       })),
     );
+    const requestRedelegationRefresh = vi.fn(async () => undefined);
     const domain = createEmberLendingDomain({
       protocolHost,
       runtimeSigning,
       runtimeSignerRef: 'service-wallet',
       agentId: 'ember-lending',
+      requestRedelegationRefresh,
     });
 
     const result = await domain.handleOperation?.({
@@ -5849,6 +5851,12 @@ describe('createEmberLendingDomain', () => {
         limit: 100,
         timeout_ms: 1000,
       },
+    });
+    expect(requestRedelegationRefresh).toHaveBeenCalledWith({
+      rootWalletAddress: '0x00000000000000000000000000000000000000a1',
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-ember-lending-001',
+      requestId: 'req-ember-lending-execution-001',
     });
     expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
       jsonrpc: '2.0',

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -3008,6 +3008,186 @@ describe('createEmberLendingDomain', () => {
     );
   });
 
+  it('accepts stringified JSON when create_transaction is called with a wrapper-backed withdraw request', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (input: unknown) => {
+        const request = input as { method?: unknown; params?: { request?: unknown } };
+
+        switch (request.method) {
+          case 'subagent.readPortfolioState.v1':
+            return createPortfolioStateResponse();
+          case 'subagent.readExecutionContext.v1':
+            return createExecutionContextResponse();
+          case 'subagent.createTransaction.v1':
+            expect(request.params?.request).toMatchObject({
+              control_path: 'lending.withdraw',
+              asset: 'aArbUSDCn',
+              protocol_system: 'aave',
+              network: 'arbitrum',
+              quantity: {
+                kind: 'exact',
+                value: '3',
+              },
+            });
+
+            return {
+              jsonrpc: '2.0',
+              id: 'shared-ember-thread-1-create-transaction',
+              result: {
+                protocol_version: 'v1',
+                revision: 8,
+                committed_event_ids: ['event-ember-lending-plan-created-001'],
+                candidate_plan: {
+                  planning_kind: 'subagent_handoff',
+                  transaction_plan_id: 'txplan-ember-lending-001',
+                  payload_builder_output: {
+                    transaction_payload_ref: 'txpayload-ember-lending-001',
+                    required_control_path: 'lending.withdraw',
+                    network: 'arbitrum',
+                  },
+                  compact_plan_summary: {
+                    control_path: 'lending.withdraw',
+                    asset: 'aArbUSDCn',
+                    amount: '3',
+                    summary: 'withdraw reserved aArbUSDCn on Aave',
+                  },
+                },
+              },
+            };
+          default:
+            throw new Error(`Unexpected JSON-RPC method: ${String(request.method)}`);
+        }
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+      anchoredPayloadResolver: createAnchoredPayloadResolverStub(),
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction',
+        input: JSON.stringify(
+          createSemanticRequest({
+            control_path: 'lending.withdraw',
+            asset: 'aArbUSDCn',
+            quantity: {
+              kind: 'exact',
+              value: '3',
+            },
+          }),
+        ),
+      },
+    });
+
+    expect(result).toMatchObject({
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Candidate lending plan created through the Shared Ember planner.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.createTransaction.v1',
+      }),
+    );
+  });
+
+  it('reports invalid control_path values without blaming exact quantity strings', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (input: unknown) => {
+        const request = input as { method?: unknown };
+
+        switch (request.method) {
+          case 'subagent.readPortfolioState.v1':
+            return createPortfolioStateResponse();
+          case 'subagent.readExecutionContext.v1':
+            return createExecutionContextResponse();
+          case 'orchestrator.readOnboardingState.v1':
+            return {
+              jsonrpc: '2.0',
+              id: 'shared-ember-thread-1-read-onboarding-state',
+              result: {
+                protocol_version: 'v1',
+                revision: 8,
+                state: {
+                  status: 'completed',
+                },
+              },
+            };
+          default:
+            throw new Error(`Unexpected JSON-RPC method: ${String(request.method)}`);
+        }
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: createManagedLifecycleState(),
+      operation: {
+        source: 'tool',
+        name: 'create_transaction',
+        input: {
+          ...createSemanticRequest(),
+          control_path: 'position-scope-aave-arbitrum-0xad53ec51a70e9a17df6752fda80cd465457c258d',
+          quantity: {
+            kind: 'exact',
+            value: '3',
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'create_transaction control_path must be one of "lending.supply", "lending.withdraw", "lending.borrow", or "lending.repay". Do not pass a position-scope id like "position-scope-aave-arbitrum-...". Exact quantity strings like {"kind":"exact","value":"3"} are valid.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.createTransaction.v1',
+      }),
+    );
+  });
+
   it('fails closed when semantic percent quantity is malformed', async () => {
     const protocolHost = {
       handleJsonRpc: vi.fn(async (input: unknown) => {
@@ -7302,6 +7482,96 @@ describe('createEmberLendingDomain', () => {
         },
       },
     });
+  });
+
+  it('accepts stringified JSON when create_escalation_request is called with a blocked execution result', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (input: unknown) => {
+        const request = input as { method?: string };
+        if (request.method === 'subagent.readPortfolioState.v1') {
+          return createPortfolioStateResponse();
+        }
+
+        if (request.method === 'subagent.readExecutionContext.v1') {
+          return createExecutionContextResponse();
+        }
+
+        if (request.method === 'subagent.createEscalationRequest.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-create-escalation-request',
+            result: {
+              protocol_version: 'v1',
+              revision: 9,
+              escalation_request: {
+                request_kind: 'release_or_transfer_request',
+                request_id: 'req-ember-lending-escalation-001',
+                status: 'pending',
+              },
+            },
+          };
+        }
+
+        throw new Error(`Unexpected JSON-RPC method: ${String(request.method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlanSummary: 'supply reserved USDC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'create_escalation_request',
+        input: JSON.stringify(createEscalationRequestInput()),
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastEscalationSummary:
+          'release_or_transfer_request escalation req-ember-lending-escalation-001 created from blocked lending execution.',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending escalation request created through Shared Ember.',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'subagent.createEscalationRequest.v1',
+        params: expect.objectContaining({
+          handoff: expect.objectContaining({
+            handoff_id: 'handoff-ember-lending-escalation-001',
+          }),
+          result: expect.objectContaining({
+            phase: 'blocked',
+            request_id: 'req-ember-lending-blocked-001',
+          }),
+        }),
+      }),
+    );
   });
 
   it('fails escalation when lean runtime state omits authoritative handoff fields', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/runtimePrep.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/runtimePrep.unit.test.ts
@@ -64,7 +64,13 @@ describe('resolveManagedSharedEmberBootstrap', () => {
       {
         resolveReferenceBootstrap,
         createManagedOnboardingIssuers: vi.fn().mockResolvedValue(undefined),
-        createSubagentRuntimes: vi.fn().mockResolvedValue(undefined),
+        createSubagentRuntimes: vi.fn().mockResolvedValue({
+          'ember-lending': {
+            submissionBackend: {
+              submitSignedTransaction: vi.fn(),
+            },
+          },
+        }),
       },
     );
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -347,6 +347,8 @@ function readNextReadyForRedelegationWork(
   events: unknown[],
   acknowledgedThroughSequence: number,
 ): SharedEmberRedelegationWork | null {
+  let latestWork: SharedEmberRedelegationWork | null = null;
+
   for (const rawEvent of events) {
     const event = readCommittedEvent(rawEvent);
     if (
@@ -374,7 +376,7 @@ function readNextReadyForRedelegationWork(
       continue;
     }
 
-    return {
+    latestWork = {
       eventId: event.event_id,
       sequence: event.sequence,
       requestId,
@@ -384,7 +386,7 @@ function readNextReadyForRedelegationWork(
     };
   }
 
-  return null;
+  return latestWork;
 }
 
 function isSharedEmberRevisionConflict(error: unknown): boolean {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -3608,6 +3608,182 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
+  it('prefers the newest unacknowledged redelegation work item when older work is stale', async () => {
+    const rootSignedDelegation = createSignedRootDelegation(
+      '0x00000000000000000000000000000000000000c1',
+    );
+    const rootDelegationArtifactRef = encodeDelegationArtifactRef(rootSignedDelegation);
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-register-signed-redelegation',
+        result: {
+          protocol_version: 'v1',
+          revision: 10,
+          committed_event_ids: ['evt-request-execution-7'],
+          execution_result: {
+            phase: 'ready_for_execution_signing',
+            request_id: 'req-ember-lending-execution-002',
+            transaction_plan_id: 'txplan-ember-lending-002',
+          },
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        acknowledged_through_sequence: 4,
+        next_cursor: 6,
+        has_more: false,
+        events: [
+          {
+            protocol_version: 'v1',
+            event_id: 'evt-request-execution-5',
+            sequence: 5,
+            aggregate: 'request',
+            aggregate_id: 'req-ember-lending-execution-001',
+            event_type: 'requestExecution.prepared.v1',
+            committed_at: '2026-04-01T06:19:00Z',
+            payload: {
+              request_id: 'req-ember-lending-execution-001',
+              transaction_plan_id: 'txplan-ember-lending-001',
+              phase: 'ready_for_redelegation',
+              redelegation_signing_package: {
+                execution_preparation_id: 'execprep-ember-lending-001',
+                transaction_plan_id: 'txplan-ember-lending-001',
+                request_id: 'req-ember-lending-execution-001',
+                redelegation_intent_id: 'ri-req-ember-lending-execution-001',
+                active_delegation_id: 'del-ember-lending-001',
+                delegation_id: 'del-req-ember-lending-execution-001',
+                delegation_plan_id:
+                  'plan-req-ember-lending-execution-001-del-req-ember-lending-execution-001',
+                root_delegation_id: 'root-user-protocol-001',
+                root_delegation_artifact_ref: rootDelegationArtifactRef,
+                delegator_address: '0x00000000000000000000000000000000000000a1',
+                agent_id: 'ember-lending',
+                agent_wallet: '0x00000000000000000000000000000000000000b1',
+                network: 'arbitrum',
+                reservation_ids: ['reservation-ember-lending-001'],
+                unit_ids: ['unit-ember-lending-001'],
+                control_paths: ['lending.withdraw'],
+                zero_capacity: false,
+                policy_snapshot_ref: 'pol-ember-lending-001',
+                canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-001',
+              },
+            },
+          },
+          {
+            protocol_version: 'v1',
+            event_id: 'evt-request-execution-6',
+            sequence: 6,
+            aggregate: 'request',
+            aggregate_id: 'req-ember-lending-execution-002',
+            event_type: 'requestExecution.prepared.v1',
+            committed_at: '2026-04-01T06:20:00Z',
+            payload: {
+              request_id: 'req-ember-lending-execution-002',
+              transaction_plan_id: 'txplan-ember-lending-002',
+              phase: 'ready_for_redelegation',
+              redelegation_signing_package: {
+                execution_preparation_id: 'execprep-ember-lending-002',
+                transaction_plan_id: 'txplan-ember-lending-002',
+                request_id: 'req-ember-lending-execution-002',
+                redelegation_intent_id: 'ri-req-ember-lending-execution-002',
+                active_delegation_id: 'del-ember-lending-002',
+                delegation_id: 'del-req-ember-lending-execution-002',
+                delegation_plan_id:
+                  'plan-req-ember-lending-execution-002-del-req-ember-lending-execution-002',
+                root_delegation_id: 'root-user-protocol-001',
+                root_delegation_artifact_ref: rootDelegationArtifactRef,
+                delegator_address: '0x00000000000000000000000000000000000000a1',
+                agent_id: 'ember-lending',
+                agent_wallet: '0x00000000000000000000000000000000000000b2',
+                network: 'arbitrum',
+                reservation_ids: ['reservation-ember-lending-002'],
+                unit_ids: ['unit-ember-lending-002', 'unit-ember-lending-003'],
+                control_paths: ['lending.withdraw'],
+                zero_capacity: false,
+                policy_snapshot_ref: 'pol-ember-lending-002',
+                canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-002',
+              },
+            },
+          },
+        ],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'portfolio-manager-redelegation',
+        acknowledged_through_sequence: 6,
+      })),
+    };
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000c1' as const,
+        signedPayload: {
+          signature: TEST_REDELEGATION_SIGNATURE,
+        },
+      })),
+    );
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+      controllerWalletAddress: '0x00000000000000000000000000000000000000c2',
+      controllerSignerAddress: '0x00000000000000000000000000000000000000c1',
+      runtimeSigning,
+      runtimeSignerRef: 'controller-wallet',
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: {
+            root_delegation_id: 'root-user-protocol-001',
+          },
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+        },
+        operation: {
+          source: 'command',
+          name: 'refresh_redelegation_work',
+        },
+      }),
+    ).resolves.toMatchObject({
+      outputs: {
+        artifacts: [
+          {
+            data: expect.objectContaining({
+              eventId: 'evt-request-execution-6',
+              sequence: 6,
+              requestId: 'req-ember-lending-execution-002',
+              transactionPlanId: 'txplan-ember-lending-002',
+              acknowledgedThroughSequence: 6,
+            }),
+          },
+        ],
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          transaction_plan_id: 'txplan-ember-lending-002',
+        }),
+      }),
+    );
+    expect(protocolHost.acknowledgeCommittedEventOutbox).toHaveBeenCalledWith({
+      protocol_version: 'v1',
+      consumer_id: 'portfolio-manager-redelegation',
+      delivered_through_sequence: 6,
+    });
+  });
+
   it('fails closed when redelegation work arrives without a configured controller signer address', async () => {
     const rootSignedDelegation = createSignedRootDelegation(TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS);
     const rootDelegationArtifactRef = encodeDelegationArtifactRef(rootSignedDelegation);

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/startupIdentityPreflight.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/startupIdentityPreflight.int.test.ts
@@ -237,6 +237,7 @@ describe('portfolio-manager startup identity preflight integration', () => {
       __internalDeriveControllerSmartAccountAddress: vi.fn(
         async () => TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS,
       ),
+      __internalEnsureControllerSmartAccountDeployed: vi.fn(async () => undefined),
       __internalPostgres: createInternalPostgresHooks(),
     } as never);
 
@@ -333,6 +334,7 @@ describe('portfolio-manager startup identity preflight integration', () => {
         __internalDeriveControllerSmartAccountAddress: vi.fn(
           async () => TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS,
         ),
+        __internalEnsureControllerSmartAccountDeployed: vi.fn(async () => undefined),
         __internalPostgres: createInternalPostgresHooks(),
       } as never),
     ).rejects.toThrow(

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/tsconfig.json
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/tsconfig.json
@@ -9,6 +9,9 @@
     "src/**/*.ts"
   ],
   "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
     "src/managedOnboardingIdentitySmoke.ts",
     "src/managedOnboardingIdentitySmokeSupport.ts",
     "src/managedIdentitySmokeSupport.unit.test.ts"

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
@@ -113,7 +113,16 @@ async function readFirstConnectSnapshot(params: {
 }): Promise<Record<string, unknown> | null> {
   try {
     const snapshot = await firstValueFrom(
-      params.agent.connect({ threadId: params.threadId }).pipe(
+      params.agent
+        .connect({
+          threadId: params.threadId,
+          runId: randomUUID(),
+          messages: [],
+          state: {},
+          tools: [],
+          context: [],
+        })
+        .pipe(
         verifyEvents(false),
         filter(
           (
@@ -124,8 +133,8 @@ async function readFirstConnectSnapshot(params: {
           } => event.type === EventType.STATE_SNAPSHOT && isRecord((event as { snapshot?: unknown }).snapshot),
         ),
         map((event) => event.snapshot as Record<string, unknown>),
-        take(1),
-      ),
+          take(1),
+        ),
     );
 
     return snapshot;

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
@@ -368,9 +368,15 @@ describe('POST /api/agent-command', () => {
       }),
     );
 
-    expect(connectMock).toHaveBeenCalledWith({
-      threadId: 'thread-1',
-    });
+    expect(connectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'thread-1',
+        messages: [],
+        state: {},
+        tools: [],
+        context: [],
+      }),
+    );
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({
       ok: false,

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.ts
@@ -6,6 +6,7 @@ export type AgentRuntimeHttpAgentConfig = Omit<HttpAgentConfig, 'url'> & {
 };
 
 export type AgentRuntimeHttpAgent = HttpAgent & {
+  connect: (input: RunAgentInput) => ReturnType<HttpAgent['connect']>;
   runtimeUrl: string;
   clone: () => AgentRuntimeHttpAgent;
 };

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.tsx
@@ -29,6 +29,7 @@ import { selectRuntimeTaskState } from '@/utils/selectRuntimeTaskState';
 import { collectUniqueChainNames, collectUniqueTokenSymbols } from '@/utils/agentCollections';
 import { extractTaskStatusMessage } from '@/utils/extractTaskStatusMessage';
 import { PROTOCOL_TOKEN_FALLBACK } from '@/constants/protocolTokenFallback';
+import { isPrivyConfigured } from '@/utils/privyConfig';
 import {
   normalizeNameKey,
   proxyIconUri,
@@ -70,6 +71,7 @@ export function AppSidebar() {
   const addressPopoverRef = useRef<HTMLDivElement | null>(null);
   const copyResetTimeoutRef = useRef<number | null>(null);
   const addressPopoverId = useId();
+  const privyConfigured = isPrivyConfigured();
 
   const { ready, authenticated } = usePrivy();
   const { login } = useLogin();
@@ -334,7 +336,8 @@ export function AppSidebar() {
     router.push(getSidebarAgentHref(agentId));
   };
 
-  const canSelectChain = ready && authenticated && Boolean(privyWallet) && !isWalletLoading;
+  const canSelectChain =
+    privyConfigured && ready && authenticated && Boolean(privyWallet) && !isWalletLoading;
 
   const isPortfolioAgentActive = pathname?.startsWith(`/hire-agents/${PORTFOLIO_AGENT_ID}`);
   const isHireAgentsActive =
@@ -549,7 +552,7 @@ export function AppSidebar() {
         </button>
 
         {/* Smart Account Upgrade */}
-        {authenticated && privyWallet && !walletError && (
+        {privyConfigured && authenticated && privyWallet && !walletError && (
           <>
             {isSmartAccountLoading ? (
               <div className="w-full px-3 py-2 rounded-lg bg-[#252525] text-xs text-gray-300">
@@ -673,6 +676,10 @@ export function AppSidebar() {
                 )}
               </div>
             )}
+          </div>
+        ) : !privyConfigured ? (
+          <div className="w-full px-3 py-2 rounded-lg bg-[#252525] text-xs text-gray-400">
+            Privy auth unavailable
           </div>
         ) : (
           <button

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.unit.test.ts
@@ -5,6 +5,16 @@ import { arbitrum, mainnet, polygon } from 'viem/chains';
 
 import { AppSidebar, getSidebarAgentHref, getWalletSelectorChains } from './AppSidebar';
 
+const privyMocks = vi.hoisted(() => ({
+  ready: true,
+  authenticated: true,
+  login: vi.fn(),
+  logout: vi.fn(),
+  walletAddress: '0x1111111111111111111111111111111111111111' as string | null,
+  chainId: 42161 as number | null,
+  switchChain: vi.fn(),
+}));
+
 const pushMock = vi.fn();
 const useAgentListMock = vi.fn();
 const getAllAgentsMock = vi.fn();
@@ -33,20 +43,18 @@ vi.mock('next/image', () => {
 
 vi.mock('@privy-io/react-auth', () => {
   return {
-    usePrivy: () => ({ ready: true, authenticated: true }),
-    useLogin: () => ({ login: vi.fn() }),
-    useLogout: () => ({ logout: vi.fn() }),
+    usePrivy: () => ({ ready: privyMocks.ready, authenticated: privyMocks.authenticated }),
+    useLogin: () => ({ login: privyMocks.login }),
+    useLogout: () => ({ logout: privyMocks.logout }),
   };
 });
 
 vi.mock('@/hooks/usePrivyWalletClient', () => {
   return {
     usePrivyWalletClient: () => ({
-      privyWallet: {
-        address: '0x1111111111111111111111111111111111111111',
-      },
-      chainId: 42161,
-      switchChain: vi.fn(),
+      privyWallet: privyMocks.walletAddress ? { address: privyMocks.walletAddress } : null,
+      chainId: privyMocks.chainId,
+      switchChain: privyMocks.switchChain,
       isLoading: false,
       error: null,
     }),
@@ -110,6 +118,14 @@ describe('AppSidebar wallet actions', () => {
     getAllAgentsMock.mockReset();
     getVisibleAgentsMock.mockReset();
     pathnameMock = '/hire-agents';
+    privyMocks.ready = true;
+    privyMocks.authenticated = true;
+    privyMocks.walletAddress = '0x1111111111111111111111111111111111111111';
+    privyMocks.chainId = 42161;
+    privyMocks.login.mockReset();
+    privyMocks.logout.mockReset();
+    privyMocks.switchChain.mockReset();
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'test-privy-app-id';
 
     useAgentListMock.mockReturnValue({ agents: {} });
     getAllAgentsMock.mockReturnValue([]);
@@ -216,5 +232,18 @@ describe('AppSidebar wallet actions', () => {
       '/hire-agents/agent-portfolio-manager?tab=chat',
     );
     expect(getSidebarAgentHref('agent-ember-lending')).toBe('/hire-agents/agent-ember-lending');
+  });
+
+  it('shows a non-interactive fallback instead of a broken login CTA when Privy is not configured', () => {
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID = '';
+    privyMocks.ready = false;
+    privyMocks.authenticated = false;
+    privyMocks.walletAddress = null;
+    privyMocks.chainId = null;
+
+    const html = renderToStaticMarkup(React.createElement(AppSidebar));
+
+    expect(html).toContain('Privy auth unavailable');
+    expect(html).not.toContain('Login / Connect');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/PrivyClientProvider.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/PrivyClientProvider.tsx
@@ -2,9 +2,10 @@
 
 import { PrivyProvider } from '@privy-io/react-auth';
 import type React from 'react';
+import { getPrivyAppId } from '@/utils/privyConfig';
 
 export function PrivyClientProvider({ children }: { children: React.ReactNode }) {
-  const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+  const appId = getPrivyAppId();
 
   if (!appId) {
     // Privy is optional for CI builds and local dev. If it's not configured, we render

--- a/typescript/clients/web-ag-ui/apps/web/src/components/PrivyGateBanner.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/PrivyGateBanner.tsx
@@ -4,6 +4,7 @@ import { AlertCircle } from 'lucide-react';
 import { useLogin } from '@privy-io/react-auth';
 import { usePrivyWalletClient } from '@/hooks/usePrivyWalletClient';
 import { resolveAgentThreadWalletAddress, supportsAnonymousAgentThread } from '@/utils/agentThread';
+import { isPrivyConfigured } from '@/utils/privyConfig';
 import { usePathname } from 'next/navigation';
 
 function resolveRouteAgentId(pathname: string | null): string | null {
@@ -21,6 +22,14 @@ function resolveRouteAgentId(pathname: string | null): string | null {
 }
 
 export function PrivyGateBanner() {
+  if (!isPrivyConfigured()) {
+    return null;
+  }
+
+  return <ConfiguredPrivyGateBanner />;
+}
+
+function ConfiguredPrivyGateBanner() {
   const { login } = useLogin();
   const { privyWallet } = usePrivyWalletClient();
   const pathname = usePathname();

--- a/typescript/clients/web-ag-ui/apps/web/src/components/PrivyGateBanner.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/PrivyGateBanner.unit.test.ts
@@ -31,6 +31,7 @@ describe('PrivyGateBanner', () => {
     mocks.pathname = '/hire-agents/agent-clmm';
     mocks.privyWalletAddress = null;
     mocks.login.mockReset();
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'test-privy-app-id';
   });
 
   it('hides the sign-in banner for the Pi example hire route without a wallet', () => {
@@ -45,5 +46,13 @@ describe('PrivyGateBanner', () => {
     const html = renderToStaticMarkup(React.createElement(PrivyGateBanner));
 
     expect(html).toContain('Sign in with Privy to create a thread and interact with agents.');
+  });
+
+  it('hides the sign-in banner when Privy is not configured', () => {
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID = '';
+
+    const html = renderToStaticMarkup(React.createElement(PrivyGateBanner));
+
+    expect(html).toBe('');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/privyConfig.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/privyConfig.ts
@@ -1,0 +1,8 @@
+export function getPrivyAppId(): string | null {
+  const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim();
+  return appId && appId.length > 0 ? appId : null;
+}
+
+export function isPrivyConfigured(): boolean {
+  return getPrivyAppId() !== null;
+}

--- a/typescript/clients/web-ag-ui/scripts/smoke/support/runtimePrep.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/support/runtimePrep.ts
@@ -28,6 +28,14 @@ type ResolveManagedSharedEmberBootstrapDependencies = {
   createManagedOnboardingIssuers?: typeof maybeCreateManagedOnboardingIssuers;
   createSubagentRuntimes?: typeof maybeCreateSubagentRuntimes;
 };
+type StartManagedSharedEmberHarnessDependencies =
+  ResolveManagedSharedEmberBootstrapDependencies & {
+    startServer?: (input: {
+      bootstrap: Record<string, unknown>;
+      host?: string;
+      port?: number;
+    }) => Promise<StartedServer>;
+  };
 
 const DEFAULT_MANAGED_AGENT_ID = 'ember-lending';
 const DEFAULT_OWS_CHAIN = 'evm';
@@ -698,30 +706,41 @@ export async function startManagedSharedEmberHarness(input: {
   managedAgentId?: string;
   host?: string;
   port?: number;
-}): Promise<StartedServer> {
+}, dependencies: StartManagedSharedEmberHarnessDependencies = {}): Promise<StartedServer> {
   const managedAgentId = input.managedAgentId ?? DEFAULT_MANAGED_AGENT_ID;
   const host = input.host ?? '127.0.0.1';
   const port = input.port ?? 0;
 
-  const harnessModule = (await import(
-    pathToFileURL(path.join(input.specRoot, 'scripts/shared-domain-service-repo-harness.ts')).href
-  )) as {
-    startRepoLocalSharedEmberDomainProtocolHttpServer: (input: {
-      bootstrap: Record<string, unknown>;
-      host?: string;
-      port?: number;
-    }) => Promise<StartedServer>;
-  };
-  const bootstrapModule = (await import(
-    pathToFileURL(
-      path.join(
-        input.specRoot,
-        'packages/orchestration-domain-integration/src/reference-server-bootstrap.ts',
-      ),
-    ).href
-  )) as {
-    resolveSharedEmberReferenceBootstrapFromEnv: () => Promise<SharedEmberReferenceBootstrap>;
-  };
+  const startServer =
+    dependencies.startServer ??
+    (
+      (await import(
+        pathToFileURL(path.join(input.specRoot, 'scripts/shared-domain-service-repo-harness.ts'))
+          .href
+      )) as {
+        startRepoLocalSharedEmberDomainProtocolHttpServer: (input: {
+          bootstrap: Record<string, unknown>;
+          host?: string;
+          port?: number;
+        }) => Promise<StartedServer>;
+      }
+    ).startRepoLocalSharedEmberDomainProtocolHttpServer;
+  const resolveReferenceBootstrap =
+    dependencies.resolveReferenceBootstrap ??
+    (
+      (await import(
+        pathToFileURL(
+          path.join(
+            input.specRoot,
+            'packages/orchestration-domain-integration/src/reference-server-bootstrap.ts',
+          ),
+        ).href
+      )) as {
+        resolveSharedEmberReferenceBootstrapFromEnv: (
+          env?: NodeJS.ProcessEnv,
+        ) => Promise<SharedEmberReferenceBootstrap>;
+      }
+    ).resolveSharedEmberReferenceBootstrapFromEnv;
 
   const bootstrap = await resolveManagedSharedEmberBootstrap(
     {
@@ -730,12 +749,12 @@ export async function startManagedSharedEmberHarness(input: {
       managedAgentId,
     },
     {
-      resolveReferenceBootstrap: () =>
-        bootstrapModule.resolveSharedEmberReferenceBootstrapFromEnv(),
+      ...dependencies,
+      resolveReferenceBootstrap,
     },
   );
 
-  return harnessModule.startRepoLocalSharedEmberDomainProtocolHttpServer({
+  return startServer({
     bootstrap,
     host,
     port,

--- a/typescript/clients/web-ag-ui/scripts/smoke/support/runtimePrep.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/support/runtimePrep.ts
@@ -76,6 +76,23 @@ function withDefaultManagedPlannerAgentId(input: {
   };
 }
 
+function hasManagedSubmissionBinding(input: {
+  bootstrap: SharedEmberReferenceBootstrap;
+  managedAgentId: string;
+}): boolean {
+  const subagentRuntimes = input.bootstrap.subagentRuntimes as
+    | Record<string, unknown>
+    | undefined;
+  if (subagentRuntimes?.[input.managedAgentId] !== undefined) {
+    return true;
+  }
+
+  const submissionBackends = input.bootstrap.signedTransactionSubmissionBackends as
+    | Record<string, unknown>
+    | undefined;
+  return submissionBackends?.[input.managedAgentId] !== undefined;
+}
+
 export function parseDotEnvFile(filePath: string): Record<string, string> {
   if (!fs.existsSync(filePath)) {
     return {};
@@ -807,7 +824,7 @@ export async function resolveManagedSharedEmberBootstrap(
     managedAgentId,
   });
 
-  return {
+  const mergedBootstrap = {
     ...bootstrap,
     ...(managedOnboardingIssuers === undefined
       ? {}
@@ -827,6 +844,19 @@ export async function resolveManagedSharedEmberBootstrap(
           },
         }),
   };
+
+  if (
+    !hasManagedSubmissionBinding({
+      bootstrap: mergedBootstrap,
+      managedAgentId,
+    })
+  ) {
+    throw new Error(
+      `Managed Shared Ember bootstrap requires a seeded subagent runtime binding for ${managedAgentId}.`,
+    );
+  }
+
+  return mergedBootstrap;
 }
 
 async function readRequestBody(request: http.IncomingMessage): Promise<Buffer> {


### PR DESCRIPTION
## Summary
- trigger PM redelegation refresh from ember-lending when Shared Ember returns `ready_for_redelegation`
- add a direct-command redelegation coordinator for deterministic PM thread addressing
- document the optional PM runtime URL override for local QA and managed bring-up

## Testing
- `pnpm test:unit -- src/redelegationCoordinator.unit.test.ts src/sharedEmberAdapter.unit.test.ts src/emberLendingFoundation.unit.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui exec eslint apps/agent-ember-lending/src/emberLendingFoundation.ts apps/agent-ember-lending/src/sharedEmberAdapter.ts apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts apps/agent-ember-lending/src/redelegationCoordinator.ts apps/agent-ember-lending/src/redelegationCoordinator.unit.test.ts --ext .ts --fix`
- `pnpm --dir typescript/clients/web-ag-ui --filter agent-ember-lending build`

## Related
- EmberAGI/ember-orchestration-v1-spec#270
- EmberAGI/ember-orchestration-v1-spec#273
