### PR TITLE
fix(web-ag-ui): hide lending execution behind pm dispatch

### DIFF
--- a/typescript/clients/web-ag-ui/README.md
+++ b/typescript/clients/web-ag-ui/README.md
@@ -20,9 +20,10 @@ It includes:
 - When a concrete agent app consumes a runtime-agnostic upstream domain service, the app owns the thin adapter between `agent-runtime` domain hooks and that external service protocol.
 - Neither `apps/web` nor `agent-runtime` should absorb service-specific translation logic for downstream domain integrations such as the Shared Ember Domain Service.
 - Agent-family lifecycle behavior belongs in pluggable domain modules above the Pi core runtime.
-- The first concrete managed downstream path is `agent-portfolio-manager` -> `agent-ember-lending` -> Shared Ember Domain Service:
-  - Portfolio Manager owns managed onboarding, mandate approval, reservation creation, activation, and deactivation.
-  - Ember Lending owns the bounded managed-subagent surface for portfolio-state reads, candidate-plan materialization, transaction execution, and escalation requests.
+- The first concrete managed downstream path is `agent-portfolio-manager` -> hidden execution worker (`agent-ember-lending`) -> Shared Ember Domain Service:
+  - Portfolio Manager owns the user-visible managed onboarding, mandate approval, activation, deactivation, and adhoc execution control plane.
+  - `agent-ember-lending` remains a separate runtime, but it is a PM-owned hidden executor rather than a model-visible web/CopilotKit agent.
+  - The hidden execution worker still owns the bounded managed-subagent surface for portfolio-state reads, candidate-plan materialization, transaction execution, and escalation requests.
 
 ## Workspace Notes
 

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/runtimePrep.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/runtimePrep.unit.test.ts
@@ -26,7 +26,7 @@ describe('managed Shared Ember harness bootstrap', () => {
             return {
               emberSkillPlanners: {
                 [env?.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS ?? 'missing']: {
-                  planLendingSupply: async () => ({
+                  planExecutionTransaction: async () => ({
                     transaction_plan_id: 'txplan-test',
                   }),
                 },
@@ -83,7 +83,7 @@ describe('managed Shared Ember harness bootstrap', () => {
           resolveReferenceBootstrap: async () => ({
             emberSkillPlanners: {
               'ember-lending': {
-                planLendingSupply: async () => ({
+                planExecutionTransaction: async () => ({
                   transaction_plan_id: 'txplan-test',
                 }),
               },

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/serviceIdentityPreflight.ts
@@ -1,4 +1,9 @@
 import {
+  ensureAgentServiceIdentity,
+  type AgentServiceIdentity,
+} from '../../agent-workflow-core/src/index.js';
+
+import {
   EMBER_LENDING_SHARED_EMBER_AGENT_ID,
   type EmberLendingSharedEmberProtocolHost,
 } from './sharedEmberAdapter.js';
@@ -9,16 +14,7 @@ type EnsureEmberLendingServiceIdentityInput = {
   now?: () => Date;
 };
 
-type AgentServiceIdentity = {
-  identity_ref: string;
-  agent_id: string;
-  role: 'subagent';
-  wallet_address: `0x${string}`;
-  wallet_source: string;
-  capability_metadata: Record<string, unknown>;
-  registration_version: number;
-  registered_at: string;
-};
+type EmberLendingServiceIdentity = AgentServiceIdentity<'subagent'>;
 
 const EMBER_LENDING_SERVICE_ROLE = 'subagent';
 const EMBER_LENDING_WALLET_SOURCE = 'ember_local_write';
@@ -29,178 +25,21 @@ const EMBER_LENDING_CAPABILITY_METADATA = {
 const UNCONFIRMED_SUBAGENT_IDENTITY_ERROR =
   'Lending startup identity preflight failed because Shared Ember did not confirm the expected subagent identity.';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function readString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value : null;
-}
-
-function readHexAddress(value: unknown): `0x${string}` | null {
-  const normalized = readString(value);
-  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
-}
-
-function readInt(value: unknown): number | null {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
-}
-
-function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const identityRef = readString(value['identity_ref']);
-  const agentId = readString(value['agent_id']);
-  const walletAddress = readHexAddress(value['wallet_address']);
-  const walletSource = readString(value['wallet_source']);
-  const registrationVersion = readInt(value['registration_version']);
-  const registeredAt = readString(value['registered_at']);
-  const capabilityMetadata = isRecord(value['capability_metadata'])
-    ? value['capability_metadata']
-    : null;
-
-  if (
-    identityRef === null ||
-    agentId === null ||
-    walletAddress === null ||
-    walletSource === null ||
-    registrationVersion === null ||
-    registeredAt === null ||
-    capabilityMetadata === null
-  ) {
-    return null;
-  }
-
-  if (agentId !== EMBER_LENDING_SHARED_EMBER_AGENT_ID) {
-    return null;
-  }
-
-  if (readString(value['role']) !== EMBER_LENDING_SERVICE_ROLE) {
-    return null;
-  }
-
-  return {
-    identity_ref: identityRef,
-    agent_id: agentId,
-    role: EMBER_LENDING_SERVICE_ROLE,
-    wallet_address: walletAddress,
-    wallet_source: walletSource,
-    capability_metadata: capabilityMetadata,
-    registration_version: registrationVersion,
-    registered_at: registeredAt,
-  };
-}
-
-async function readCurrentIdentity(input: {
-  protocolHost: EmberLendingSharedEmberProtocolHost;
-}): Promise<{
-  revision: number;
-  identity: AgentServiceIdentity | null;
-}> {
-  const response = await input.protocolHost.handleJsonRpc({
-    jsonrpc: '2.0',
-    id: 'rpc-agent-service-identity-read',
-    method: 'orchestrator.readAgentServiceIdentity.v1',
-    params: {
-      agent_id: EMBER_LENDING_SHARED_EMBER_AGENT_ID,
-      role: EMBER_LENDING_SERVICE_ROLE,
-    },
-  });
-  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
-
-  return {
-    revision: readInt(result?.['revision']) ?? 0,
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
-  };
-}
-
-async function writeIdentity(input: {
-  protocolHost: EmberLendingSharedEmberProtocolHost;
-  expectedRevision: number;
-  identity: AgentServiceIdentity;
-}): Promise<{
-  revision: number | null;
-  identity: AgentServiceIdentity | null;
-}> {
-  const response = await input.protocolHost.handleJsonRpc({
-    jsonrpc: '2.0',
-    id: 'rpc-agent-service-identity-write',
-    method: 'orchestrator.writeAgentServiceIdentity.v1',
-    params: {
-      idempotency_key: `idem-agent-service-identity-${input.identity.identity_ref}`,
-      expected_revision: input.expectedRevision,
-      agent_service_identity: input.identity,
-    },
-  });
-  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
-
-  return {
-    revision: readInt(result?.['revision']),
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
-  };
-}
-
-function requireConfirmedIdentity(input: {
-  expectedIdentity: Pick<AgentServiceIdentity, 'agent_id' | 'role' | 'wallet_address'>;
-  identity: AgentServiceIdentity | null;
-}): AgentServiceIdentity {
-  if (
-    input.identity?.agent_id !== input.expectedIdentity.agent_id ||
-    input.identity?.role !== input.expectedIdentity.role ||
-    input.identity?.wallet_address !== input.expectedIdentity.wallet_address
-  ) {
-    throw new Error(UNCONFIRMED_SUBAGENT_IDENTITY_ERROR);
-  }
-
-  return input.identity;
-}
-
 export async function ensureEmberLendingServiceIdentity(
   input: EnsureEmberLendingServiceIdentityInput,
 ): Promise<{
   revision: number | null;
   wroteIdentity: boolean;
-  identity: AgentServiceIdentity;
+  identity: EmberLendingServiceIdentity;
 }> {
-  const walletAddress = await input.readSignerWalletAddress();
-  const current = await readCurrentIdentity({
+  return ensureAgentServiceIdentity({
     protocolHost: input.protocolHost,
-  });
-
-  if (current.identity?.wallet_address === walletAddress) {
-    return {
-      revision: current.revision,
-      wroteIdentity: false,
-      identity: current.identity,
-    };
-  }
-
-  const registrationVersion = (current.identity?.registration_version ?? 0) + 1;
-  const identity: AgentServiceIdentity = {
-    identity_ref: `agent-service-identity-${EMBER_LENDING_SHARED_EMBER_AGENT_ID}-${EMBER_LENDING_SERVICE_ROLE}-${registrationVersion}`,
-    agent_id: EMBER_LENDING_SHARED_EMBER_AGENT_ID,
+    agentId: EMBER_LENDING_SHARED_EMBER_AGENT_ID,
     role: EMBER_LENDING_SERVICE_ROLE,
-    wallet_address: walletAddress,
-    wallet_source: EMBER_LENDING_WALLET_SOURCE,
-    capability_metadata: EMBER_LENDING_CAPABILITY_METADATA,
-    registration_version: registrationVersion,
-    registered_at: (input.now ?? (() => new Date()))().toISOString(),
-  };
-  const written = await writeIdentity({
-    protocolHost: input.protocolHost,
-    expectedRevision: current.revision,
-    identity,
+    walletSource: EMBER_LENDING_WALLET_SOURCE,
+    capabilityMetadata: EMBER_LENDING_CAPABILITY_METADATA,
+    readWalletAddress: input.readSignerWalletAddress,
+    ...(input.now ? { now: input.now } : {}),
+    unconfirmedIdentityErrorMessage: UNCONFIRMED_SUBAGENT_IDENTITY_ERROR,
   });
-  const confirmedIdentity = requireConfirmedIdentity({
-    expectedIdentity: identity,
-    identity: written.identity,
-  });
-
-  return {
-    revision: written.revision,
-    wroteIdentity: true,
-    identity: confirmedIdentity,
-  };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -355,6 +355,7 @@ async function readSharedEmberExecutionContext(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
   threadId: string;
   agentId: string;
+  rootedWalletContextId?: string | null;
 }): Promise<SharedEmberExecutionContextEnvelope> {
   const response = (await input.protocolHost.handleJsonRpc({
     jsonrpc: '2.0',
@@ -362,6 +363,11 @@ async function readSharedEmberExecutionContext(input: {
     method: 'subagent.readExecutionContext.v1',
     params: {
       agent_id: input.agentId,
+      ...(input.rootedWalletContextId
+        ? {
+            rooted_wallet_context_id: input.rootedWalletContextId,
+          }
+        : {}),
     },
   })) as ExecutionContextResponse;
 
@@ -1039,6 +1045,7 @@ async function hydrateManagedProjectionFromSharedEmber(input: {
       protocolHost: input.protocolHost,
       threadId: input.threadId,
       agentId: input.agentId,
+      rootedWalletContextId: input.state.rootedWalletContextId,
     });
   } catch {
     executionContextEnvelope = null;
@@ -3720,6 +3727,7 @@ export function createEmberLendingDomain(
           protocolHost: options.protocolHost,
           threadId,
           agentId,
+          rootedWalletContextId: currentState.rootedWalletContextId,
         });
         return buildSharedEmberExecutionContextXml({
           status: 'live',
@@ -3901,6 +3909,11 @@ export function createEmberLendingDomain(
                   idempotency_key: idempotencyKey,
                   expected_revision: expectedRevision,
                   agent_id: agentId,
+                  ...(planningState.rootedWalletContextId
+                    ? {
+                        rooted_wallet_context_id: planningState.rootedWalletContextId,
+                      }
+                    : {}),
                   request: semanticRequest,
                 },
               }),

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -1275,6 +1275,7 @@ describe('createEmberLendingDomain', () => {
       method: 'subagent.readExecutionContext.v1',
       params: {
         agent_id: 'ember-lending',
+        rooted_wallet_context_id: 'rwc-ember-lending-thread-001',
       },
     });
 
@@ -3883,6 +3884,7 @@ describe('createEmberLendingDomain', () => {
         ),
         expected_revision: 7,
         agent_id: 'ember-lending',
+        rooted_wallet_context_id: 'rwc-ember-lending-thread-001',
         request: createSemanticRequest({
           control_path: 'lending.borrow',
           asset: 'USDC',
@@ -4096,6 +4098,7 @@ describe('createEmberLendingDomain', () => {
         ),
         expected_revision: 7,
         agent_id: 'ember-lending',
+        rooted_wallet_context_id: 'rwc-ember-lending-thread-001',
         request: expect.objectContaining({
           control_path: 'lending.supply',
           asset: 'USDC',
@@ -4490,6 +4493,7 @@ describe('createEmberLendingDomain', () => {
         ),
         expected_revision: 7,
         agent_id: 'ember-lending',
+        rooted_wallet_context_id: 'rwc-ember-lending-thread-001',
         request: {
           control_path: 'lending.supply',
           asset: 'USDC',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/.env.example
@@ -23,6 +23,10 @@ OPENROUTER_API_KEY=
 # controller wallet and confirm or rewrite the durable orchestrator identity.
 # SHARED_EMBER_BASE_URL=http://127.0.0.1:4010
 
+# Optional: override the hidden execution-worker AG-UI runtime URL used for
+# PM-owned adhoc execution dispatch.
+# EMBER_LENDING_AGENT_DEPLOYMENT_URL=http://127.0.0.1:3430/ag-ui
+
 # Optional: select the direct OWS wallet the runtime should use for startup
 # identity proof. Required whenever `SHARED_EMBER_BASE_URL` is set for live
 # onboarding.

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/adhocExecutionDispatcher.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/adhocExecutionDispatcher.ts
@@ -1,0 +1,249 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { createAgentRuntimeHttpAgent } from 'agent-runtime';
+
+const HIDDEN_EXECUTION_WORKER_AGENT_ID = 'agent-ember-lending';
+const DEFAULT_HIDDEN_EXECUTION_WORKER_RUNTIME_URL = 'http://127.0.0.1:3430/ag-ui';
+
+type AdhocExecutionQuantity =
+  | {
+      kind: 'exact';
+      value: string;
+    }
+  | {
+      kind: 'percent';
+      value: number;
+    };
+
+export type PortfolioManagerAdhocExecutionRequest = {
+  control_path: 'lending.supply' | 'lending.withdraw' | 'lending.borrow' | 'lending.repay';
+  asset: string;
+  protocol_system: string;
+  network: string;
+  quantity: AdhocExecutionQuantity;
+};
+
+export type PortfolioManagerAdhocExecutionDispatcherInput = {
+  pmThreadId: string;
+  instruction: string;
+  request: PortfolioManagerAdhocExecutionRequest;
+  reservationConflictHandling: string | null;
+};
+
+type ObservableLike<T> = {
+  subscribe: (observer: {
+    next?: (value: T) => void;
+    error?: (error: unknown) => void;
+    complete?: () => void;
+  }) => { unsubscribe?: () => void } | void;
+};
+
+type RuntimeEvent = {
+  type?: string;
+  snapshot?: unknown;
+};
+
+type RuntimeHttpAgent = ReturnType<typeof createAgentRuntimeHttpAgent>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readTaskStatusMessage(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return readString(value['content']);
+}
+
+function deriveHiddenWorkerThreadId(pmThreadId: string): string {
+  const digest = createHash('sha256').update(pmThreadId).digest('hex');
+  return `pm-hidden-worker-${digest.slice(0, 24)}`;
+}
+
+async function collectRuntimeEvents(stream: ObservableLike<RuntimeEvent>): Promise<RuntimeEvent[]> {
+  return await new Promise<RuntimeEvent[]>((resolve, reject) => {
+    const events: RuntimeEvent[] = [];
+    stream.subscribe({
+      next: (event) => {
+        events.push(event);
+      },
+      error: reject,
+      complete: () => {
+        resolve(events);
+      },
+    });
+  });
+}
+
+function readLatestSnapshot(events: readonly RuntimeEvent[]): Record<string, unknown> | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event.type === 'STATE_SNAPSHOT' && isRecord(event.snapshot)) {
+      return event.snapshot;
+    }
+  }
+
+  return null;
+}
+
+async function readFirstConnectSnapshot(input: {
+  agent: RuntimeHttpAgent;
+  threadId: string;
+}): Promise<Record<string, unknown> | null> {
+  return await new Promise<Record<string, unknown> | null>((resolve) => {
+    const subscription = input.agent
+      .connect({
+        threadId: input.threadId,
+        runId: randomUUID(),
+        messages: [],
+        state: {},
+        tools: [],
+        context: [],
+      })
+      .subscribe({
+        next: (event: RuntimeEvent) => {
+          if (event.type === 'STATE_SNAPSHOT' && isRecord(event.snapshot)) {
+            subscription?.unsubscribe?.();
+            resolve(event.snapshot);
+          }
+        },
+        error: () => {
+          resolve(null);
+        },
+        complete: () => {
+          resolve(null);
+        },
+      });
+  });
+}
+
+function readFailureMessage(snapshot: Record<string, unknown> | null): string | null {
+  const thread = isRecord(snapshot?.['thread']) ? snapshot['thread'] : null;
+  const task = isRecord(thread?.['task']) ? thread['task'] : null;
+  const taskStatus = isRecord(task?.['taskStatus']) ? task['taskStatus'] : null;
+  const execution = isRecord(thread?.['execution']) ? thread['execution'] : null;
+  const taskState = readString(taskStatus?.['state']);
+  const executionStatus = readString(execution?.['status']);
+  const statusMessage = readTaskStatusMessage(taskStatus?.['message']);
+  const executionStatusMessage = readString(execution?.['statusMessage']);
+  const executionError = readString(thread?.['executionError']);
+  const haltReason = readString(thread?.['haltReason']);
+
+  if (
+    taskState === 'failed' ||
+    taskState === 'canceled' ||
+    executionStatus === 'failed' ||
+    executionStatus === 'canceled' ||
+    executionError ||
+    haltReason
+  ) {
+    return (
+      executionError ??
+      haltReason ??
+      executionStatusMessage ??
+      statusMessage ??
+      'Hidden execution worker command failed.'
+    );
+  }
+
+  return null;
+}
+
+async function runNamedCommand(input: {
+  agent: RuntimeHttpAgent;
+  threadId: string;
+  name: string;
+  commandInput?: unknown;
+}): Promise<void> {
+  const events = await collectRuntimeEvents(
+    input.agent.run({
+      threadId: input.threadId,
+      runId: randomUUID(),
+      messages: [],
+      state: {},
+      tools: [],
+      context: [],
+      forwardedProps: {
+        command: {
+          name: input.name,
+          ...(input.commandInput !== undefined ? { input: input.commandInput } : {}),
+        },
+      },
+    }),
+  );
+  const snapshot = readLatestSnapshot(events) ?? (await readFirstConnectSnapshot(input));
+  const failureMessage = readFailureMessage(snapshot);
+  if (failureMessage) {
+    throw new Error(failureMessage);
+  }
+}
+
+export function resolvePortfolioManagerHiddenExecutorRuntimeUrl(
+  env:
+    | NodeJS.ProcessEnv
+    | {
+        EMBER_LENDING_AGENT_DEPLOYMENT_URL?: string;
+      } = process.env,
+): string {
+  return (
+    env.EMBER_LENDING_AGENT_DEPLOYMENT_URL?.trim() || DEFAULT_HIDDEN_EXECUTION_WORKER_RUNTIME_URL
+  );
+}
+
+export function createPortfolioManagerAdhocExecutionDispatcher(input: {
+  runtimeUrl: string;
+  createHttpAgent?: typeof createAgentRuntimeHttpAgent;
+  createWorkerThreadId?: (pmThreadId: string) => string;
+}) {
+  const createHttpAgent = input.createHttpAgent ?? createAgentRuntimeHttpAgent;
+  const createWorkerThreadId = input.createWorkerThreadId ?? deriveHiddenWorkerThreadId;
+
+  return async (dispatch: PortfolioManagerAdhocExecutionDispatcherInput) => {
+    const workerThreadId = createWorkerThreadId(dispatch.pmThreadId);
+    const agent = createHttpAgent({
+      agentId: HIDDEN_EXECUTION_WORKER_AGENT_ID,
+      runtimeUrl: input.runtimeUrl,
+    });
+
+    await runNamedCommand({
+      agent,
+      threadId: workerThreadId,
+      name: 'create_transaction',
+      commandInput: dispatch.request,
+    });
+    await runNamedCommand({
+      agent,
+      threadId: workerThreadId,
+      name: 'request_execution',
+    });
+
+    return {
+      status: {
+        executionStatus: 'completed' as const,
+        statusMessage: 'Adhoc execution dispatched through the hidden execution worker.',
+      },
+      artifacts: [
+        {
+          data: {
+            type: 'pm-hidden-execution-dispatch',
+            workerAgentId: HIDDEN_EXECUTION_WORKER_AGENT_ID,
+            workerThreadId,
+            instruction: dispatch.instruction,
+            request: dispatch.request,
+            reservationConflictHandling: dispatch.reservationConflictHandling,
+          },
+        },
+      ],
+    };
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -744,6 +744,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
         method: 'subagent.readExecutionContext.v1',
         params: {
           agent_id: 'ember-lending',
+          rooted_wallet_context_id: 'rwc-thread10x00000000000000000000000000000000000000a1',
         },
       }),
     );
@@ -1271,6 +1272,7 @@ describe('agent-portfolio-manager AG-UI integration', () => {
         method: 'subagent.readExecutionContext.v1',
         params: {
           agent_id: 'ember-lending',
+          rooted_wallet_context_id: 'rwc-thread10x00000000000000000000000000000000000000a1',
         },
       }),
     );

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/managedOnboardingIdentitySmoke.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/managedOnboardingIdentitySmoke.ts
@@ -207,6 +207,12 @@ export async function runManagedOnboardingIdentitySmoke() {
     if (!signingResult?.state || !('phase' in signingResult.state) || signingResult.state.phase !== 'active') {
       throw new Error('Portfolio-manager rooted bootstrap did not promote the thread to active.');
     }
+    const rootedWalletContextId = signingResult.state.lastRootedWalletContextId;
+    if (typeof rootedWalletContextId !== 'string' || rootedWalletContextId.length === 0) {
+      throw new Error(
+        'Portfolio-manager rooted bootstrap did not return a rooted wallet context id.',
+      );
+    }
 
     const executionContext = await postJsonRpc<{
       revision?: number;
@@ -218,6 +224,7 @@ export async function runManagedOnboardingIdentitySmoke() {
       method: 'subagent.readExecutionContext.v1',
       params: {
         agent_id: 'ember-lending',
+        rooted_wallet_context_id: rootedWalletContextId,
       },
     });
     const hydratedSubagentWallet =

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -6,6 +6,10 @@ import {
   type PortfolioManagerLifecycleState,
 } from './sharedEmberAdapter.js';
 import {
+  createPortfolioManagerAdhocExecutionDispatcher,
+  resolvePortfolioManagerHiddenExecutorRuntimeUrl,
+} from './adhocExecutionDispatcher.js';
+import {
   createPortfolioManagerSharedEmberHttpHost,
   resolvePortfolioManagerSharedEmberBaseUrl,
 } from './sharedEmberHttpHost.js';
@@ -24,6 +28,7 @@ export type PortfolioManagerGatewayEnv = NodeJS.ProcessEnv & {
   PORTFOLIO_MANAGER_ENABLE_DIAGNOSTIC_TOOLS?: string;
   DATABASE_URL?: string;
   SHARED_EMBER_BASE_URL?: string;
+  EMBER_LENDING_AGENT_DEPLOYMENT_URL?: string;
   PORTFOLIO_MANAGER_OWS_WALLET_NAME?: string;
   PORTFOLIO_MANAGER_OWS_PASSPHRASE?: string;
   PORTFOLIO_MANAGER_OWS_VAULT_PATH?: string;
@@ -40,6 +45,7 @@ type PortfolioManagerGatewayModel = PortfolioManagerAgentConfig['model'];
 
 export type PortfolioManagerGatewayDependencies = {
   protocolHost: ReturnType<typeof createPortfolioManagerSharedEmberHttpHost> | null;
+  adhocExecutionDispatcher: ReturnType<typeof createPortfolioManagerAdhocExecutionDispatcher>;
 };
 
 type CreatePortfolioManagerAgentConfigOptions = {
@@ -88,7 +94,7 @@ export function createPortfolioManagerAgentConfig(
   const apiKey = requireEnvValue(env.OPENROUTER_API_KEY, 'OPENROUTER_API_KEY');
   const modelId = env.PORTFOLIO_MANAGER_MODEL?.trim() || DEFAULT_PORTFOLIO_MANAGER_MODEL;
   const enableDiagnosticTools = env.PORTFOLIO_MANAGER_ENABLE_DIAGNOSTIC_TOOLS?.trim() === '1';
-  const { protocolHost } = resolvePortfolioManagerGatewayDependencies(env);
+  const { protocolHost, adhocExecutionDispatcher } = resolvePortfolioManagerGatewayDependencies(env);
 
   return {
     model: createOpenRouterModel(modelId),
@@ -106,6 +112,7 @@ export function createPortfolioManagerAgentConfig(
       ...(enableDiagnosticTools ? [createPortfolioManagerDiagnosticTool()] : []),
     ],
     domain: createPortfolioManagerDomain({
+      adhocExecutionDispatcher,
       ...(protocolHost
         ? {
             protocolHost,
@@ -145,6 +152,7 @@ export function resolvePortfolioManagerGatewayDependencies(
   env: PortfolioManagerGatewayEnv = process.env,
 ): PortfolioManagerGatewayDependencies {
   const sharedEmberBaseUrl = resolvePortfolioManagerSharedEmberBaseUrl(env);
+  const hiddenExecutorRuntimeUrl = resolvePortfolioManagerHiddenExecutorRuntimeUrl(env);
 
   return {
     protocolHost: sharedEmberBaseUrl
@@ -152,5 +160,8 @@ export function resolvePortfolioManagerGatewayDependencies(
           baseUrl: sharedEmberBaseUrl,
         })
       : null,
+    adhocExecutionDispatcher: createPortfolioManagerAdhocExecutionDispatcher({
+      runtimeUrl: hiddenExecutorRuntimeUrl,
+    }),
   };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -54,6 +54,9 @@ describe('createPortfolioManagerAgentConfig', () => {
           name: 'refresh_redelegation_work',
         },
         {
+          name: 'dispatch_adhoc_execution',
+        },
+        {
           name: 'complete_rooted_bootstrap_from_user_signing',
         },
       ],

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
@@ -1,4 +1,9 @@
 import {
+  ensureAgentServiceIdentity,
+  type AgentServiceIdentity,
+} from '../../agent-workflow-core/src/index.js';
+
+import {
   PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
   type PortfolioManagerSharedEmberProtocolHost,
 } from './sharedEmberAdapter.js';
@@ -9,16 +14,7 @@ type EnsurePortfolioManagerServiceIdentityInput = {
   now?: () => Date;
 };
 
-type AgentServiceIdentity = {
-  identity_ref: string;
-  agent_id: string;
-  role: 'orchestrator';
-  wallet_address: `0x${string}`;
-  wallet_source: string;
-  capability_metadata: Record<string, unknown>;
-  registration_version: number;
-  registered_at: string;
-};
+type PortfolioManagerServiceIdentity = AgentServiceIdentity<'orchestrator'>;
 
 const PORTFOLIO_MANAGER_SERVICE_ROLE = 'orchestrator';
 const PORTFOLIO_MANAGER_WALLET_SOURCE = 'ember_local_write';
@@ -29,178 +25,21 @@ const PORTFOLIO_MANAGER_CAPABILITY_METADATA = {
 const UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR =
   'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function readString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value : null;
-}
-
-function readHexAddress(value: unknown): `0x${string}` | null {
-  const normalized = readString(value);
-  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
-}
-
-function readInt(value: unknown): number | null {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
-}
-
-function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const identityRef = readString(value['identity_ref']);
-  const agentId = readString(value['agent_id']);
-  const walletAddress = readHexAddress(value['wallet_address']);
-  const walletSource = readString(value['wallet_source']);
-  const registrationVersion = readInt(value['registration_version']);
-  const registeredAt = readString(value['registered_at']);
-  const capabilityMetadata = isRecord(value['capability_metadata'])
-    ? value['capability_metadata']
-    : null;
-
-  if (
-    identityRef === null ||
-    agentId === null ||
-    walletAddress === null ||
-    walletSource === null ||
-    registrationVersion === null ||
-    registeredAt === null ||
-    capabilityMetadata === null
-  ) {
-    return null;
-  }
-
-  if (agentId !== PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID) {
-    return null;
-  }
-
-  if (readString(value['role']) !== PORTFOLIO_MANAGER_SERVICE_ROLE) {
-    return null;
-  }
-
-  return {
-    identity_ref: identityRef,
-    agent_id: agentId,
-    role: PORTFOLIO_MANAGER_SERVICE_ROLE,
-    wallet_address: walletAddress,
-    wallet_source: walletSource,
-    capability_metadata: capabilityMetadata,
-    registration_version: registrationVersion,
-    registered_at: registeredAt,
-  };
-}
-
-async function readCurrentIdentity(input: {
-  protocolHost: PortfolioManagerSharedEmberProtocolHost;
-}): Promise<{
-  revision: number;
-  identity: AgentServiceIdentity | null;
-}> {
-  const response = await input.protocolHost.handleJsonRpc({
-    jsonrpc: '2.0',
-    id: 'rpc-agent-service-identity-read',
-    method: 'orchestrator.readAgentServiceIdentity.v1',
-    params: {
-      agent_id: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
-      role: PORTFOLIO_MANAGER_SERVICE_ROLE,
-    },
-  });
-  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
-
-  return {
-    revision: readInt(result?.['revision']) ?? 0,
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
-  };
-}
-
-async function writeIdentity(input: {
-  protocolHost: PortfolioManagerSharedEmberProtocolHost;
-  expectedRevision: number;
-  identity: AgentServiceIdentity;
-}): Promise<{
-  revision: number | null;
-  identity: AgentServiceIdentity | null;
-}> {
-  const response = await input.protocolHost.handleJsonRpc({
-    jsonrpc: '2.0',
-    id: 'rpc-agent-service-identity-write',
-    method: 'orchestrator.writeAgentServiceIdentity.v1',
-    params: {
-      idempotency_key: `idem-agent-service-identity-${input.identity.identity_ref}`,
-      expected_revision: input.expectedRevision,
-      agent_service_identity: input.identity,
-    },
-  });
-  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
-
-  return {
-    revision: readInt(result?.['revision']),
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
-  };
-}
-
-function requireConfirmedIdentity(input: {
-  expectedIdentity: Pick<AgentServiceIdentity, 'agent_id' | 'role' | 'wallet_address'>;
-  identity: AgentServiceIdentity | null;
-}): AgentServiceIdentity {
-  if (
-    input.identity?.agent_id !== input.expectedIdentity.agent_id ||
-    input.identity?.role !== input.expectedIdentity.role ||
-    input.identity?.wallet_address !== input.expectedIdentity.wallet_address
-  ) {
-    throw new Error(UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR);
-  }
-
-  return input.identity;
-}
-
 export async function ensurePortfolioManagerServiceIdentity(
   input: EnsurePortfolioManagerServiceIdentityInput,
 ): Promise<{
   revision: number | null;
   wroteIdentity: boolean;
-  identity: AgentServiceIdentity;
+  identity: PortfolioManagerServiceIdentity;
 }> {
-  const walletAddress = await input.readControllerWalletAddress();
-  const current = await readCurrentIdentity({
+  return ensureAgentServiceIdentity({
     protocolHost: input.protocolHost,
-  });
-
-  if (current.identity?.wallet_address === walletAddress) {
-    return {
-      revision: current.revision,
-      wroteIdentity: false,
-      identity: current.identity,
-    };
-  }
-
-  const registrationVersion = (current.identity?.registration_version ?? 0) + 1;
-  const identity: AgentServiceIdentity = {
-    identity_ref: `agent-service-identity-${PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID}-${PORTFOLIO_MANAGER_SERVICE_ROLE}-${registrationVersion}`,
-    agent_id: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
+    agentId: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
     role: PORTFOLIO_MANAGER_SERVICE_ROLE,
-    wallet_address: walletAddress,
-    wallet_source: PORTFOLIO_MANAGER_WALLET_SOURCE,
-    capability_metadata: PORTFOLIO_MANAGER_CAPABILITY_METADATA,
-    registration_version: registrationVersion,
-    registered_at: (input.now ?? (() => new Date()))().toISOString(),
-  };
-  const written = await writeIdentity({
-    protocolHost: input.protocolHost,
-    expectedRevision: current.revision,
-    identity,
+    walletSource: PORTFOLIO_MANAGER_WALLET_SOURCE,
+    capabilityMetadata: PORTFOLIO_MANAGER_CAPABILITY_METADATA,
+    readWalletAddress: input.readControllerWalletAddress,
+    ...(input.now ? { now: input.now } : {}),
+    unconfirmedIdentityErrorMessage: UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR,
   });
-  const confirmedIdentity = requireConfirmedIdentity({
-    expectedIdentity: identity,
-    identity: written.identity,
-  });
-
-  return {
-    revision: written.revision,
-    wroteIdentity: true,
-    identity: confirmedIdentity,
-  };
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.int.test.ts
@@ -507,6 +507,8 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
         ],
       },
     });
+    const rootedWalletContextId = signingResult?.state?.lastRootedWalletContextId;
+    expect(rootedWalletContextId).toEqual(expect.any(String));
 
     await expect(
       protocolHost.handleJsonRpc({
@@ -550,6 +552,7 @@ describeSharedEmberIntegration('portfolio-manager Shared Ember sidecar integrati
         method: 'subagent.readExecutionContext.v1',
         params: {
           agent_id: 'ember-lending',
+          rooted_wallet_context_id: rootedWalletContextId,
         },
       }),
     ).resolves.toMatchObject({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -551,6 +551,7 @@ async function readSharedEmberAgentServiceIdentity(input: {
 async function readSharedEmberSubagentWalletAddress(input: {
   protocolHost: PortfolioManagerSharedEmberProtocolHost;
   agentId: string;
+  rootedWalletContextId?: string | null;
 }): Promise<{
   revision: number | null;
   walletAddress: `0x${string}` | null;
@@ -561,6 +562,11 @@ async function readSharedEmberSubagentWalletAddress(input: {
     method: 'subagent.readExecutionContext.v1',
     params: {
       agent_id: input.agentId,
+      ...(input.rootedWalletContextId
+        ? {
+            rooted_wallet_context_id: input.rootedWalletContextId,
+          }
+        : {}),
     },
   });
   const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
@@ -1949,12 +1955,15 @@ export function createPortfolioManagerDomain(
             revision: response.result?.revision ?? null,
             rootedWalletContextId: response.result?.rooted_wallet_context_id ?? null,
           });
+          const rootedWalletContextId =
+            response.result?.rooted_wallet_context_id ?? currentState.lastRootedWalletContextId;
           tracePmSigning('reading-managed-subagent-wallet', {
             managedAgentId: FIRST_MANAGED_AGENT_TYPE,
           });
           const managedSubagentExecutionContext = await readSharedEmberSubagentWalletAddress({
             protocolHost: options.protocolHost,
             agentId: FIRST_MANAGED_AGENT_TYPE,
+            rootedWalletContextId,
           });
           tracePmSigning('read-managed-subagent-wallet', {
             revision: managedSubagentExecutionContext.revision ?? null,
@@ -1993,7 +2002,7 @@ export function createPortfolioManagerDomain(
               lastSharedEmberRevision: nextRevision,
               lastRootDelegation: response.result?.root_delegation ?? currentState.lastRootDelegation,
               lastOnboardingBootstrap: onboarding,
-              lastRootedWalletContextId: response.result?.rooted_wallet_context_id ?? null,
+              lastRootedWalletContextId: rootedWalletContextId,
               activeWalletAddress: walletAddress,
               pendingOnboardingWalletAddress: walletAddress,
               pendingApprovedSetup: approvedSetup,
@@ -2030,7 +2039,7 @@ export function createPortfolioManagerDomain(
               lastRootDelegation:
                 response.result?.root_delegation ?? currentState.lastRootDelegation,
               lastOnboardingBootstrap: onboarding,
-              lastRootedWalletContextId: response.result?.rooted_wallet_context_id ?? null,
+              lastRootedWalletContextId: rootedWalletContextId,
               activeWalletAddress: walletAddress,
               pendingOnboardingWalletAddress: walletAddress,
               pendingApprovedSetup: approvedSetup,
@@ -2067,7 +2076,7 @@ export function createPortfolioManagerDomain(
             lastSharedEmberRevision: nextRevision,
             lastRootDelegation: response.result?.root_delegation ?? currentState.lastRootDelegation,
             lastOnboardingBootstrap: onboarding,
-            lastRootedWalletContextId: response.result?.rooted_wallet_context_id ?? null,
+            lastRootedWalletContextId: rootedWalletContextId,
             activeWalletAddress: walletAddress,
             pendingOnboardingWalletAddress: null,
             pendingApprovedSetup: null,

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -12,6 +12,10 @@ import {
   resolvePortfolioManagerAccountingAgentId,
   readPortfolioManagerOnboardingState,
 } from './sharedEmberOnboardingState.js';
+import type {
+  PortfolioManagerAdhocExecutionDispatcherInput,
+  PortfolioManagerAdhocExecutionRequest,
+} from './adhocExecutionDispatcher.js';
 
 export type PortfolioManagerSharedEmberProtocolHost = {
   handleJsonRpc: (input: unknown) => Promise<unknown>;
@@ -41,6 +45,17 @@ type CreatePortfolioManagerDomainOptions = {
   controllerSignerAddress?: `0x${string}`;
   runtimeSigning?: AgentRuntimeSigningService;
   runtimeSignerRef?: string;
+  adhocExecutionDispatcher?: (
+    input: PortfolioManagerAdhocExecutionDispatcherInput,
+  ) => Promise<{
+    status: {
+      executionStatus: 'completed' | 'failed' | 'canceled' | 'interrupted' | 'working';
+      statusMessage: string;
+    };
+    artifacts?: Array<{
+      data: Record<string, unknown>;
+    }>;
+  }>;
 };
 
 type SharedEmberRevisionResponse = {
@@ -526,6 +541,7 @@ async function readSharedEmberAgentServiceIdentity(input: {
 }): Promise<{
   revision: number;
   identity: AgentServiceIdentity | null;
+  hadIdentityRecord: boolean;
 }> {
   const response = await input.protocolHost.handleJsonRpc({
     jsonrpc: '2.0',
@@ -545,6 +561,7 @@ async function readSharedEmberAgentServiceIdentity(input: {
       input.agentId,
       input.role,
     ),
+    hadIdentityRecord: result?.['agent_service_identity'] !== null,
   };
 }
 
@@ -698,6 +715,12 @@ type PortfolioManagerSetupInput = PortfolioManagerApprovedSetup & {
 type ManagedMandateUpdateInput = {
   targetAgentId: typeof FIRST_MANAGED_AGENT_TYPE;
   managedMandate: ManagedMandate;
+};
+
+type AdhocExecutionDispatchInput = {
+  instruction: string;
+  request: PortfolioManagerAdhocExecutionRequest;
+  reservationConflictHandling: string | null;
 };
 
 type PortfolioManagerUnsignedDelegation = {
@@ -858,6 +881,38 @@ function readManagedMandate(input: unknown): ManagedMandate | null {
   };
 }
 
+function readSemanticQuantityInput(
+  value: unknown,
+): PortfolioManagerAdhocExecutionRequest['quantity'] | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const kind = readString(value['kind']);
+  if (kind === 'exact') {
+    const exactValue = readString(value['value']);
+    return exactValue ? { kind, value: exactValue } : null;
+  }
+
+  if (kind === 'percent') {
+    const percentValue = readFiniteNumber(value['value']);
+    return percentValue === null ? null : { kind, value: percentValue };
+  }
+
+  return null;
+}
+
+function isAdhocExecutionControlPath(
+  value: string,
+): value is PortfolioManagerAdhocExecutionRequest['control_path'] {
+  return (
+    value === 'lending.supply' ||
+    value === 'lending.withdraw' ||
+    value === 'lending.borrow' ||
+    value === 'lending.repay'
+  );
+}
+
 function parsePortfolioMandate(input: unknown): PortfolioManagerPortfolioMandate | null {
   if (typeof input !== 'object' || input === null) {
     return null;
@@ -943,6 +998,51 @@ function parseManagedMandateUpdateInput(input: unknown): ManagedMandateUpdateInp
   return {
     targetAgentId: FIRST_MANAGED_AGENT_TYPE,
     managedMandate,
+  };
+}
+
+function parseAdhocExecutionDispatchInput(input: unknown): AdhocExecutionDispatchInput | null {
+  if (!isRecord(input)) {
+    return null;
+  }
+
+  const requestSource = isRecord(input['request']) ? input['request'] : input;
+  const instruction = readString(input['instruction']);
+  const controlPath = readString(requestSource['control_path']);
+  const asset = readString(requestSource['asset']);
+  const protocolSystem = readString(requestSource['protocol_system']);
+  const network = readString(requestSource['network']);
+  const quantity = readSemanticQuantityInput(requestSource['quantity']);
+  const reservationConflictHandling =
+    readString(input['reservationConflictHandling']) ??
+    readString(input['reservation_conflict_handling']) ??
+    (isRecord(input['request'])
+      ? readString(requestSource['reservationConflictHandling']) ??
+        readString(requestSource['reservation_conflict_handling'])
+      : null);
+
+  if (
+    instruction === null ||
+    controlPath === null ||
+    !isAdhocExecutionControlPath(controlPath) ||
+    asset === null ||
+    protocolSystem === null ||
+    network === null ||
+    quantity === null
+  ) {
+    return null;
+  }
+
+  return {
+    instruction,
+    request: {
+      control_path: controlPath,
+      asset,
+      protocol_system: protocolSystem,
+      network,
+      quantity,
+    },
+    reservationConflictHandling,
   };
 }
 
@@ -1502,6 +1602,11 @@ export function createPortfolioManagerDomain(
             'Read committed redelegation work from the Shared Ember outbox for the portfolio-manager orchestrator.',
         },
         {
+          name: 'dispatch_adhoc_execution',
+          description:
+            'Dispatch an adhoc lending execution request through the hidden PM-owned execution worker.',
+        },
+        {
           name: 'complete_rooted_bootstrap_from_user_signing',
           description:
             'Complete the rooted bootstrap in one Shared Ember command using onboarding data and the signing handoff.',
@@ -1894,7 +1999,10 @@ export function createPortfolioManagerDomain(
             hasIdentity: managedSubagentIdentity.identity !== null,
             walletAddress: managedSubagentIdentity.identity?.wallet_address ?? null,
           });
-          if (!managedSubagentIdentity.identity) {
+          if (
+            managedSubagentIdentity.identity === null &&
+            managedSubagentIdentity.hadIdentityRecord
+          ) {
             return {
               state: currentState,
               outputs: {
@@ -1995,42 +2103,6 @@ export function createPortfolioManagerDomain(
             response.result?.revision ??
             null;
 
-          if (!managedSubagentExecutionContext.walletAddress) {
-            const nextState: PortfolioManagerLifecycleState = {
-              phase: 'onboarding',
-              lastPortfolioState: currentState.lastPortfolioState,
-              lastSharedEmberRevision: nextRevision,
-              lastRootDelegation: response.result?.root_delegation ?? currentState.lastRootDelegation,
-              lastOnboardingBootstrap: onboarding,
-              lastRootedWalletContextId: rootedWalletContextId,
-              activeWalletAddress: walletAddress,
-              pendingOnboardingWalletAddress: walletAddress,
-              pendingApprovedSetup: approvedSetup,
-            };
-
-            return {
-              state: nextState,
-              outputs: {
-                status: {
-                  executionStatus: 'failed',
-                  statusMessage:
-                    'Portfolio manager onboarding is blocked because ember-lending did not expose a non-null subagent wallet in Shared Ember execution context after rooted bootstrap.',
-                },
-                artifacts: [
-                  {
-                    data: {
-                      type: 'shared-ember-rooted-bootstrap',
-                      revision: nextState.lastSharedEmberRevision,
-                      committedEventIds: response.result?.committed_event_ids ?? [],
-                      rootedWalletContextId: nextState.lastRootedWalletContextId,
-                      rootDelegation: nextState.lastRootDelegation,
-                    },
-                  },
-                ],
-              },
-            };
-          }
-
           if (!onboardingState.proofs.agent_active) {
             const nextState: PortfolioManagerLifecycleState = {
               phase: 'onboarding',
@@ -2109,6 +2181,66 @@ export function createPortfolioManagerDomain(
                   },
                 },
               ],
+            },
+          };
+        }
+        case 'dispatch_adhoc_execution': {
+          const dispatchInput = parseAdhocExecutionDispatchInput(operation.input);
+          if (!dispatchInput) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Adhoc execution dispatch requires instruction, control_path, asset, protocol_system, network, and quantity.',
+                },
+              },
+            };
+          }
+
+          if (currentState.phase !== 'active') {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Portfolio manager must be active before adhoc execution can be dispatched.',
+                },
+              },
+            };
+          }
+
+          if (!options.adhocExecutionDispatcher) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Portfolio manager hidden execution worker is not configured for adhoc dispatch.',
+                },
+              },
+            };
+          }
+
+          const dispatchResult = await options.adhocExecutionDispatcher({
+            pmThreadId: threadId,
+            instruction: dispatchInput.instruction,
+            request: dispatchInput.request,
+            reservationConflictHandling: dispatchInput.reservationConflictHandling,
+          });
+
+          return {
+            state: currentState,
+            outputs: {
+              status: dispatchResult.status,
+              ...(dispatchResult.artifacts
+                ? {
+                    artifacts: dispatchResult.artifacts,
+                  }
+                : {}),
             },
           };
         }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -724,6 +724,7 @@ describe('createPortfolioManagerDomain', () => {
         method: 'subagent.readExecutionContext.v1',
         params: {
           agent_id: 'ember-lending',
+          rooted_wallet_context_id: 'rwc-user-protocol-001',
         },
       }),
     );
@@ -2266,6 +2267,7 @@ describe('createPortfolioManagerDomain', () => {
       method: 'subagent.readExecutionContext.v1',
       params: {
         agent_id: 'ember-lending',
+        rooted_wallet_context_id: 'rwc-user-protocol-001',
       },
     });
     expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(6, {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -988,50 +988,28 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
-  it('fails fast before rooted bootstrap when the managed ember-lending identity is missing', async () => {
-    const signedDelegation = {
-      delegate: '0x00000000000000000000000000000000000000c1',
-      delegator: '0x00000000000000000000000000000000000000a1',
-      authority: ROOT_AUTHORITY,
-      caveats: [],
-      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      signature: '0x1234',
-    };
+  it('does not block portfolio-manager activation when the hidden worker identity is still missing', async () => {
+    const signedDelegation = createSignedRootDelegation(
+      '0x00000000000000000000000000000000000000c1',
+    );
     const protocolHost = {
       handleJsonRpc: vi.fn(async (request: unknown) => {
         const jsonRpcRequest =
-          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+          typeof request === 'object' && request !== null
+            ? (request as Record<string, unknown>)
+            : null;
+        const params =
+          typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
+            ? (jsonRpcRequest['params'] as Record<string, unknown>)
+            : null;
 
         if (jsonRpcRequest?.['method'] === 'orchestrator.readAgentServiceIdentity.v1') {
-          const params =
-            typeof jsonRpcRequest['params'] === 'object' && jsonRpcRequest['params'] !== null
-              ? (jsonRpcRequest['params'] as Record<string, unknown>)
-              : null;
-
-          if (
-            params?.['agent_id'] === 'portfolio-manager' &&
-            params['role'] === 'orchestrator'
-          ) {
-            return {
-              jsonrpc: '2.0',
-              id: 'rpc-agent-service-identity-read',
-              result: {
-                revision: 2,
-                agent_service_identity: {
-                  identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-1',
-                  agent_id: 'portfolio-manager',
-                  role: 'orchestrator',
-                  wallet_address: '0x00000000000000000000000000000000000000c1',
-                  wallet_source: 'ember_local_write',
-                  capability_metadata: {
-                    onboarding: true,
-                    root_registration: true,
-                  },
-                  registration_version: 1,
-                  registered_at: '2026-04-01T00:00:00.000Z',
-                },
-              },
-            };
+          if (params?.['agent_id'] === 'portfolio-manager' && params['role'] === 'orchestrator') {
+            return createAgentServiceIdentityResponse({
+              agentId: 'portfolio-manager',
+              role: 'orchestrator',
+              walletAddress: '0x00000000000000000000000000000000000000c1',
+            });
           }
 
           if (params?.['agent_id'] === 'ember-lending' && params['role'] === 'subagent') {
@@ -1046,6 +1024,75 @@ describe('createPortfolioManagerDomain', () => {
           }
         }
 
+        if (jsonRpcRequest?.['method'] === 'orchestrator.completeRootedBootstrapFromUserSigning.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-complete-rooted-bootstrap',
+            result: {
+              protocol_version: 'v1',
+              revision: 3,
+              committed_event_ids: ['evt-rooted-bootstrap-1'],
+              rooted_wallet_context_id: 'rwc-user-protocol-001',
+              root_delegation: {
+                root_delegation_id: 'root-user-protocol-001',
+                user_wallet: '0x00000000000000000000000000000000000000a1',
+                status: 'active',
+              },
+            },
+          };
+        }
+
+        if (jsonRpcRequest?.['method'] === 'subagent.readExecutionContext.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-read-managed-subagent-execution-context',
+            result: {
+              protocol_version: 'v1',
+              revision: 4,
+              execution_context: {
+                rooted_wallet_context_id: 'rwc-user-protocol-001',
+                subagent_wallet_address: null,
+              },
+            },
+          };
+        }
+
+        if (jsonRpcRequest?.['method'] === 'orchestrator.readOnboardingState.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-wallet-accounting-ember-lending-0x00000000000000000000000000000000000000a1',
+            result: {
+              revision: 5,
+              onboarding_state: {
+                wallet_address: '0x00000000000000000000000000000000000000a1',
+                network: 'arbitrum',
+                phase: 'active',
+                proofs: {
+                  rooted_wallet_context_registered: true,
+                  root_delegation_registered: true,
+                  root_authority_active: true,
+                  wallet_baseline_observed: true,
+                  accounting_units_seeded: true,
+                  mandate_inputs_configured: true,
+                  reserve_policy_configured: true,
+                  capital_reserved_for_agent: true,
+                  policy_snapshot_recorded: true,
+                  initial_subagent_delegation_issued: false,
+                  agent_active: true,
+                },
+                rooted_wallet_context: {
+                  rooted_wallet_context_id: 'rwc-user-protocol-001',
+                },
+                root_delegation: {
+                  root_delegation_id: 'root-user-protocol-001',
+                },
+                owned_units: [],
+                reservations: [],
+              },
+            },
+          };
+        }
+
         return {
           jsonrpc: '2.0',
           id: 'unexpected',
@@ -1054,12 +1101,12 @@ describe('createPortfolioManagerDomain', () => {
       }),
       readCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
-        revision: 2,
+        revision: 5,
         events: [],
       })),
       acknowledgeCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
-        revision: 2,
+        revision: 5,
         consumer_id: 'portfolio-manager',
         acknowledged_through_sequence: 0,
       })),
@@ -1099,42 +1146,19 @@ describe('createPortfolioManagerDomain', () => {
       }),
     ).resolves.toMatchObject({
       state: {
-        phase: 'onboarding',
+        phase: 'active',
+        lastSharedEmberRevision: 5,
+        lastRootedWalletContextId: 'rwc-user-protocol-001',
         activeWalletAddress: '0x00000000000000000000000000000000000000a1',
-        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: null,
       },
       outputs: {
         status: {
-          executionStatus: 'failed',
-          statusMessage:
-            'Portfolio manager onboarding is blocked until the ember-lending service registers its subagent identity in Shared Ember.',
+          executionStatus: 'completed',
+          statusMessage: 'Portfolio manager onboarding complete. Agent is active.',
         },
       },
     });
-
-    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
-      jsonrpc: '2.0',
-      id: 'rpc-agent-service-identity-read',
-      method: 'orchestrator.readAgentServiceIdentity.v1',
-      params: {
-        agent_id: 'portfolio-manager',
-        role: 'orchestrator',
-      },
-    });
-    expect(protocolHost.handleJsonRpc).toHaveBeenCalledWith({
-      jsonrpc: '2.0',
-      id: 'rpc-agent-service-identity-read',
-      method: 'orchestrator.readAgentServiceIdentity.v1',
-      params: {
-        agent_id: 'ember-lending',
-        role: 'subagent',
-      },
-    });
-    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: 'orchestrator.completeRootedBootstrapFromUserSigning.v1',
-      }),
-    );
   });
 
   it('uses a distinct rooted-bootstrap idempotency key when signing input changes on the same thread', async () => {
@@ -1315,6 +1339,99 @@ describe('createPortfolioManagerDomain', () => {
 
     expect(rootedBootstrapKeys).toHaveLength(2);
     expect(rootedBootstrapKeys[0]).not.toBe(rootedBootstrapKeys[1]);
+  });
+
+  it('dispatches adhoc execution through a hidden PM-owned worker command', async () => {
+    const adhocExecutionDispatcher = vi.fn(async () => ({
+      status: {
+        executionStatus: 'completed',
+        statusMessage: 'Adhoc execution dispatched through the hidden execution worker.',
+      },
+      artifacts: [
+        {
+          data: {
+            type: 'pm-hidden-execution-dispatch',
+            workerAgentId: 'agent-ember-lending',
+            workerThreadId: 'hidden-thread-1',
+          },
+        },
+      ],
+    }));
+
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      adhocExecutionDispatcher,
+    } as unknown as Parameters<typeof createPortfolioManagerDomain>[0]);
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: {
+            root_delegation_id: 'root-user-protocol-001',
+          },
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          pendingApprovedSetup: null,
+        },
+        operation: {
+          source: 'tool',
+          name: 'dispatch_adhoc_execution',
+          input: {
+            instruction: 'Supply 5 USDC into Aave on Arbitrum.',
+            control_path: 'lending.supply',
+            asset: 'USDC',
+            protocol_system: 'aave',
+            network: 'arbitrum',
+            quantity: {
+              kind: 'exact',
+              value: '5',
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 8,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Adhoc execution dispatched through the hidden execution worker.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'pm-hidden-execution-dispatch',
+              workerAgentId: 'agent-ember-lending',
+              workerThreadId: 'hidden-thread-1',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(adhocExecutionDispatcher).toHaveBeenCalledWith({
+      pmThreadId: 'thread-1',
+      instruction: 'Supply 5 USDC into Aave on Arbitrum.',
+      request: {
+        control_path: 'lending.supply',
+        asset: 'USDC',
+        protocol_system: 'aave',
+        network: 'arbitrum',
+        quantity: {
+          kind: 'exact',
+          value: '5',
+        },
+      },
+      reservationConflictHandling: null,
+    });
   });
 
   it('fails fast before rooted bootstrap when the managed ember-lending identity echo is misaddressed', async () => {
@@ -1671,19 +1788,14 @@ describe('createPortfolioManagerDomain', () => {
     );
   });
 
-  it('fails closed after rooted bootstrap when the managed ember-lending execution context still has no subagent wallet', async () => {
-    const signedDelegation = {
-      delegate: TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS,
-      delegator: '0x00000000000000000000000000000000000000a1',
-      authority: ROOT_AUTHORITY,
-      caveats: [],
-      salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      signature: '0x1234',
-    };
+  it('does not fail activation when the hidden worker execution context still has no subagent wallet', async () => {
+    const signedDelegation = createSignedRootDelegation(TEST_CONTROLLER_SMART_ACCOUNT_ADDRESS);
     const protocolHost = {
       handleJsonRpc: vi.fn(async (request: unknown) => {
         const jsonRpcRequest =
-          typeof request === 'object' && request !== null ? (request as Record<string, unknown>) : null;
+          typeof request === 'object' && request !== null
+            ? (request as Record<string, unknown>)
+            : null;
         const params =
           typeof jsonRpcRequest?.['params'] === 'object' && jsonRpcRequest['params'] !== null
             ? (jsonRpcRequest['params'] as Record<string, unknown>)
@@ -1733,11 +1845,11 @@ describe('createPortfolioManagerDomain', () => {
             jsonrpc: '2.0',
             id: 'shared-ember-wallet-accounting-ember-lending-0x00000000000000000000000000000000000000a1',
             result: {
-              revision: 4,
+              revision: 5,
               onboarding_state: {
                 wallet_address: '0x00000000000000000000000000000000000000a1',
                 network: 'arbitrum',
-                phase: 'ingested',
+                phase: 'active',
                 proofs: {
                   rooted_wallet_context_registered: true,
                   root_delegation_registered: true,
@@ -1745,11 +1857,11 @@ describe('createPortfolioManagerDomain', () => {
                   wallet_baseline_observed: true,
                   accounting_units_seeded: true,
                   mandate_inputs_configured: true,
-                  reserve_policy_configured: false,
-                  capital_reserved_for_agent: false,
-                  policy_snapshot_recorded: false,
+                  reserve_policy_configured: true,
+                  capital_reserved_for_agent: true,
+                  policy_snapshot_recorded: true,
                   initial_subagent_delegation_issued: false,
-                  agent_active: false,
+                  agent_active: true,
                 },
                 rooted_wallet_context: {
                   rooted_wallet_context_id: 'rwc-user-protocol-001',
@@ -1782,12 +1894,12 @@ describe('createPortfolioManagerDomain', () => {
       }),
       readCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
-        revision: 4,
+        revision: 5,
         events: [],
       })),
       acknowledgeCommittedEventOutbox: vi.fn(async () => ({
         protocol_version: 'v1',
-        revision: 4,
+        revision: 5,
         consumer_id: 'portfolio-manager',
         acknowledged_through_sequence: 0,
       })),
@@ -1827,8 +1939,8 @@ describe('createPortfolioManagerDomain', () => {
       }),
     ).resolves.toMatchObject({
       state: {
-        phase: 'onboarding',
-        lastSharedEmberRevision: 4,
+        phase: 'active',
+        lastSharedEmberRevision: 5,
         lastRootDelegation: {
           root_delegation_id: 'root-user-protocol-001',
           user_wallet: '0x00000000000000000000000000000000000000a1',
@@ -1836,22 +1948,13 @@ describe('createPortfolioManagerDomain', () => {
         },
         lastRootedWalletContextId: 'rwc-user-protocol-001',
         activeWalletAddress: '0x00000000000000000000000000000000000000a1',
-        pendingOnboardingWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: null,
       },
       outputs: {
         status: {
-          executionStatus: 'failed',
-          statusMessage:
-            'Portfolio manager onboarding is blocked because ember-lending did not expose a non-null subagent wallet in Shared Ember execution context after rooted bootstrap.',
+          executionStatus: 'completed',
+          statusMessage: 'Portfolio manager onboarding complete. Agent is active.',
         },
-        artifacts: [
-          {
-            data: {
-              type: 'shared-ember-rooted-bootstrap',
-              rootedWalletContextId: 'rwc-user-protocol-001',
-            },
-          },
-        ],
       },
     });
   });

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/index.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/index.ts
@@ -54,3 +54,8 @@ export {
   type OnboardingStepState,
   type OnboardingStepStatus,
 } from './onboardingContract.js';
+export {
+  ensureAgentServiceIdentity,
+  type AgentServiceIdentity,
+  type AgentServiceIdentityRole,
+} from './serviceIdentityPreflight.js';

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/serviceIdentityPreflight.ts
@@ -1,0 +1,221 @@
+type AgentServiceIdentityProtocolHost = {
+  handleJsonRpc: (input: unknown) => Promise<unknown>;
+};
+
+export type AgentServiceIdentityRole = 'orchestrator' | 'subagent';
+
+export type AgentServiceIdentity<Role extends AgentServiceIdentityRole = AgentServiceIdentityRole> = {
+  identity_ref: string;
+  agent_id: string;
+  role: Role;
+  wallet_address: `0x${string}`;
+  wallet_source: string;
+  capability_metadata: Record<string, unknown>;
+  registration_version: number;
+  registered_at: string;
+};
+
+type EnsureAgentServiceIdentityInput<Role extends AgentServiceIdentityRole> = {
+  protocolHost: AgentServiceIdentityProtocolHost;
+  agentId: string;
+  role: Role;
+  walletSource: string;
+  capabilityMetadata: Record<string, unknown>;
+  readWalletAddress: () => Promise<`0x${string}`>;
+  now?: () => Date;
+  unconfirmedIdentityErrorMessage: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readHexAddress(value: unknown): `0x${string}` | null {
+  const normalized = readString(value);
+  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+}
+
+function readInt(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readAgentServiceIdentity<Role extends AgentServiceIdentityRole>(input: {
+  value: unknown;
+  agentId: string;
+  role: Role;
+}): AgentServiceIdentity<Role> | null {
+  if (!isRecord(input.value)) {
+    return null;
+  }
+
+  const identityRef = readString(input.value['identity_ref']);
+  const agentId = readString(input.value['agent_id']);
+  const walletAddress = readHexAddress(input.value['wallet_address']);
+  const walletSource = readString(input.value['wallet_source']);
+  const registrationVersion = readInt(input.value['registration_version']);
+  const registeredAt = readString(input.value['registered_at']);
+  const capabilityMetadata = isRecord(input.value['capability_metadata'])
+    ? input.value['capability_metadata']
+    : null;
+
+  if (
+    identityRef === null ||
+    agentId === null ||
+    walletAddress === null ||
+    walletSource === null ||
+    registrationVersion === null ||
+    registeredAt === null ||
+    capabilityMetadata === null
+  ) {
+    return null;
+  }
+
+  if (agentId !== input.agentId) {
+    return null;
+  }
+
+  if (readString(input.value['role']) !== input.role) {
+    return null;
+  }
+
+  return {
+    identity_ref: identityRef,
+    agent_id: input.agentId,
+    role: input.role,
+    wallet_address: walletAddress,
+    wallet_source: walletSource,
+    capability_metadata: capabilityMetadata,
+    registration_version: registrationVersion,
+    registered_at: registeredAt,
+  };
+}
+
+async function readCurrentIdentity<Role extends AgentServiceIdentityRole>(input: {
+  protocolHost: AgentServiceIdentityProtocolHost;
+  agentId: string;
+  role: Role;
+}): Promise<{
+  revision: number;
+  identity: AgentServiceIdentity<Role> | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-read',
+    method: 'orchestrator.readAgentServiceIdentity.v1',
+    params: {
+      agent_id: input.agentId,
+      role: input.role,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']) ?? 0,
+    identity: readAgentServiceIdentity({
+      value: result?.['agent_service_identity'] ?? null,
+      agentId: input.agentId,
+      role: input.role,
+    }),
+  };
+}
+
+async function writeIdentity<Role extends AgentServiceIdentityRole>(input: {
+  protocolHost: AgentServiceIdentityProtocolHost;
+  expectedRevision: number;
+  identity: AgentServiceIdentity<Role>;
+}): Promise<{
+  revision: number | null;
+  identity: AgentServiceIdentity<Role> | null;
+}> {
+  const response = await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: 'rpc-agent-service-identity-write',
+    method: 'orchestrator.writeAgentServiceIdentity.v1',
+    params: {
+      idempotency_key: `idem-agent-service-identity-${input.identity.identity_ref}`,
+      expected_revision: input.expectedRevision,
+      agent_service_identity: input.identity,
+    },
+  });
+  const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
+
+  return {
+    revision: readInt(result?.['revision']),
+    identity: readAgentServiceIdentity({
+      value: result?.['agent_service_identity'] ?? null,
+      agentId: input.identity.agent_id,
+      role: input.identity.role,
+    }),
+  };
+}
+
+function requireConfirmedIdentity<Role extends AgentServiceIdentityRole>(input: {
+  expectedIdentity: Pick<AgentServiceIdentity<Role>, 'agent_id' | 'role' | 'wallet_address'>;
+  identity: AgentServiceIdentity<Role> | null;
+  unconfirmedIdentityErrorMessage: string;
+}): AgentServiceIdentity<Role> {
+  if (
+    input.identity?.agent_id !== input.expectedIdentity.agent_id ||
+    input.identity?.role !== input.expectedIdentity.role ||
+    input.identity?.wallet_address !== input.expectedIdentity.wallet_address
+  ) {
+    throw new Error(input.unconfirmedIdentityErrorMessage);
+  }
+
+  return input.identity;
+}
+
+export async function ensureAgentServiceIdentity<Role extends AgentServiceIdentityRole>(
+  input: EnsureAgentServiceIdentityInput<Role>,
+): Promise<{
+  revision: number | null;
+  wroteIdentity: boolean;
+  identity: AgentServiceIdentity<Role>;
+}> {
+  const walletAddress = await input.readWalletAddress();
+  const current = await readCurrentIdentity({
+    protocolHost: input.protocolHost,
+    agentId: input.agentId,
+    role: input.role,
+  });
+
+  if (current.identity?.wallet_address === walletAddress) {
+    return {
+      revision: current.revision,
+      wroteIdentity: false,
+      identity: current.identity,
+    };
+  }
+
+  const registrationVersion = (current.identity?.registration_version ?? 0) + 1;
+  const identity: AgentServiceIdentity<Role> = {
+    identity_ref: `agent-service-identity-${input.agentId}-${input.role}-${registrationVersion}`,
+    agent_id: input.agentId,
+    role: input.role,
+    wallet_address: walletAddress,
+    wallet_source: input.walletSource,
+    capability_metadata: input.capabilityMetadata,
+    registration_version: registrationVersion,
+    registered_at: (input.now ?? (() => new Date()))().toISOString(),
+  };
+  const written = await writeIdentity({
+    protocolHost: input.protocolHost,
+    expectedRevision: current.revision,
+    identity,
+  });
+  const confirmedIdentity = requireConfirmedIdentity({
+    expectedIdentity: identity,
+    identity: written.identity,
+    unconfirmedIdentityErrorMessage: input.unconfirmedIdentityErrorMessage,
+  });
+
+  return {
+    revision: written.revision,
+    wroteIdentity: true,
+    identity: confirmedIdentity,
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-workflow-core/src/serviceIdentityPreflight.unit.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureAgentServiceIdentity } from './index.js';
+
+describe('ensureAgentServiceIdentity', () => {
+  it('reuses the durable service identity when the expected wallet already matches', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 11,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-pm-hidden-executor-subagent-2',
+              agent_id: 'pm-hidden-executor',
+              role: 'subagent',
+              wallet_address: '0x00000000000000000000000000000000000000e1',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                visibility: 'internal',
+                owner_agent_id: 'agent-portfolio-manager',
+                worker_kind: 'execution',
+              },
+              registration_version: 2,
+              registered_at: '2026-04-01T09:30:00.000Z',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureAgentServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+        },
+        agentId: 'pm-hidden-executor',
+        role: 'subagent',
+        walletSource: 'ember_local_write',
+        capabilityMetadata: {
+          visibility: 'internal',
+          owner_agent_id: 'agent-portfolio-manager',
+          worker_kind: 'execution',
+        },
+        readWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000e1' as const,
+        ),
+        unconfirmedIdentityErrorMessage:
+          'Hidden executor identity preflight failed because Shared Ember did not confirm the expected internal execution-worker identity.',
+      }),
+    ).resolves.toMatchObject({
+      revision: 11,
+      wroteIdentity: false,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000e1',
+        registration_version: 2,
+      },
+    });
+
+    expect(handleJsonRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers a new durable identity when Shared Ember has no current record', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 3,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.['idempotency_key']).toBe(
+          'idem-agent-service-identity-agent-service-identity-pm-hidden-executor-subagent-1',
+        );
+        expect(jsonRpcRequest.params?.['expected_revision']).toBe(3);
+        expect(jsonRpcRequest.params?.['agent_service_identity']).toMatchObject({
+          identity_ref: 'agent-service-identity-pm-hidden-executor-subagent-1',
+          agent_id: 'pm-hidden-executor',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000e1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            visibility: 'internal',
+            owner_agent_id: 'agent-portfolio-manager',
+            worker_kind: 'execution',
+          },
+          registration_version: 1,
+          registered_at: '2026-04-02T12:00:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 4,
+            committed_event_ids: ['evt-agent-service-identity-1'],
+            agent_service_identity: jsonRpcRequest.params?.['agent_service_identity'],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureAgentServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+        },
+        agentId: 'pm-hidden-executor',
+        role: 'subagent',
+        walletSource: 'ember_local_write',
+        capabilityMetadata: {
+          visibility: 'internal',
+          owner_agent_id: 'agent-portfolio-manager',
+          worker_kind: 'execution',
+        },
+        readWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000e1' as const,
+        ),
+        now: () => new Date('2026-04-02T12:00:00.000Z'),
+        unconfirmedIdentityErrorMessage:
+          'Hidden executor identity preflight failed because Shared Ember did not confirm the expected internal execution-worker identity.',
+      }),
+    ).resolves.toMatchObject({
+      revision: 4,
+      wroteIdentity: true,
+      identity: {
+        wallet_address: '0x00000000000000000000000000000000000000e1',
+        registration_version: 1,
+      },
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
@@ -8,7 +8,6 @@ import { z } from 'zod';
 
 import { createAgentRuntimeHttpAgent } from '../copilotkit/piRuntimeHttpAgent';
 import {
-  EMBER_LENDING_AGENT_NAME,
   PI_EXAMPLE_AGENT_NAME,
   PORTFOLIO_MANAGER_AGENT_NAME,
   resolveAgentRuntimeUrl,
@@ -17,11 +16,7 @@ import {
 export const runtime = 'nodejs';
 
 const agentCommandPayloadBaseSchema = z.object({
-  agentId: z.enum([
-    PI_EXAMPLE_AGENT_NAME,
-    PORTFOLIO_MANAGER_AGENT_NAME,
-    EMBER_LENDING_AGENT_NAME,
-  ]),
+  agentId: z.enum([PI_EXAMPLE_AGENT_NAME, PORTFOLIO_MANAGER_AGENT_NAME]),
   threadId: z.string().min(1),
 });
 

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
@@ -48,6 +48,24 @@ describe('POST /api/agent-command', () => {
     });
   });
 
+  it('rejects direct command payloads targeting the hidden ember-lending worker', async () => {
+    const response = await POST(
+      buildRequest({
+        agentId: 'agent-ember-lending',
+        threadId: 'thread-1',
+        command: {
+          name: 'request_execution',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Invalid agent command payload.',
+    });
+  });
+
   it('returns the latest thread domain projection after a successful one-off command run', async () => {
     runMock.mockReturnValue(
       from([
@@ -438,10 +456,10 @@ describe('POST /api/agent-command', () => {
     const result = await Promise.race([
       POST(
         buildRequest({
-          agentId: 'agent-ember-lending',
+          agentId: 'agent-portfolio-manager',
           threadId: 'thread-1',
           command: {
-            name: 'hydrate_runtime_projection',
+            name: 'refresh_portfolio_state',
           },
         }),
       ).then(async (response) => ({

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/copilotRuntimeRegistry.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/copilotRuntimeRegistry.ts
@@ -34,7 +34,6 @@ export function resolveAgentRuntimeUrl(env: RuntimeEnv, agentId: string): string
 export function buildCopilotRuntimeAgents(env: RuntimeEnv) {
   const piAgentRuntimeUrl = resolveAgentRuntimeUrl(env, PI_EXAMPLE_AGENT_NAME);
   const portfolioManagerRuntimeUrl = resolveAgentRuntimeUrl(env, PORTFOLIO_MANAGER_AGENT_NAME);
-  const emberLendingRuntimeUrl = resolveAgentRuntimeUrl(env, EMBER_LENDING_AGENT_NAME);
   const agents = {
     [CLMM_AGENT_NAME]: new LangGraphInterruptSnapshotAgent({
       deploymentUrl: env.LANGGRAPH_DEPLOYMENT_URL || 'http://localhost:8124',
@@ -63,10 +62,6 @@ export function buildCopilotRuntimeAgents(env: RuntimeEnv) {
     [PORTFOLIO_MANAGER_AGENT_NAME]: createAgentRuntimeHttpAgent({
       agentId: PORTFOLIO_MANAGER_AGENT_NAME,
       runtimeUrl: portfolioManagerRuntimeUrl,
-    }),
-    [EMBER_LENDING_AGENT_NAME]: createAgentRuntimeHttpAgent({
-      agentId: EMBER_LENDING_AGENT_NAME,
-      runtimeUrl: emberLendingRuntimeUrl,
     }),
   };
 

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts
@@ -55,7 +55,6 @@ describe('buildCopilotRuntimeAgents', () => {
       'starterAgent',
       'agent-pi-example',
       'agent-portfolio-manager',
-      'agent-ember-lending',
     ]);
 
     expect(langGraphInterruptSnapshotAgentConfigs).toEqual([
@@ -90,10 +89,6 @@ describe('buildCopilotRuntimeAgents', () => {
         agentId: 'agent-portfolio-manager',
         runtimeUrl: 'http://portfolio-manager:3420/ag-ui',
       },
-      {
-        agentId: 'agent-ember-lending',
-        runtimeUrl: 'http://ember-lending:3430/ag-ui',
-      },
     ]);
     expect(agents['agent-pi-example']).toMatchObject({
       config: {
@@ -107,12 +102,7 @@ describe('buildCopilotRuntimeAgents', () => {
         runtimeUrl: 'http://portfolio-manager:3420/ag-ui',
       },
     });
-    expect(agents['agent-ember-lending']).toMatchObject({
-      config: {
-        agentId: 'agent-ember-lending',
-        runtimeUrl: 'http://ember-lending:3430/ag-ui',
-      },
-    });
+    expect(agents['agent-ember-lending']).toBeUndefined();
   });
 
   it('defaults the Pi example runtime URL for local development', async () => {
@@ -134,12 +124,6 @@ describe('buildCopilotRuntimeAgents', () => {
         runtimeUrl: 'http://127.0.0.1:3420/ag-ui',
       },
     });
-    expect(agents['agent-ember-lending']).toMatchObject({
-      config: {
-        agentId: 'agent-ember-lending',
-        runtimeUrl: 'http://127.0.0.1:3430/ag-ui',
-      },
-    });
     expect(agentRuntimeHttpAgentConfigs).toContainEqual({
       agentId: 'agent-pi-example',
       runtimeUrl: 'http://127.0.0.1:3410/ag-ui',
@@ -148,9 +132,24 @@ describe('buildCopilotRuntimeAgents', () => {
       agentId: 'agent-portfolio-manager',
       runtimeUrl: 'http://127.0.0.1:3420/ag-ui',
     });
-    expect(agentRuntimeHttpAgentConfigs).toContainEqual({
+    expect(agentRuntimeHttpAgentConfigs).not.toContainEqual({
       agentId: 'agent-ember-lending',
       runtimeUrl: 'http://127.0.0.1:3430/ag-ui',
+    });
+  });
+
+  it('does not expose the hidden ember-lending execution worker through CopilotKit runtime registration', async () => {
+    const { buildCopilotRuntimeAgents } = await import('./copilotRuntimeRegistry');
+
+    const agents = buildCopilotRuntimeAgents({
+      LANGSMITH_API_KEY: 'test-langsmith-key',
+      EMBER_LENDING_AGENT_DEPLOYMENT_URL: 'http://ember-lending:3430/ag-ui',
+    });
+
+    expect(Object.keys(agents)).not.toContain('agent-ember-lending');
+    expect(agentRuntimeHttpAgentConfigs).not.toContainEqual({
+      agentId: 'agent-ember-lending',
+      runtimeUrl: 'http://ember-lending:3430/ag-ui',
     });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/page.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/page.int.test.ts
@@ -167,14 +167,13 @@ describe('HireAgentsRoute integration', () => {
     expect(capturedProps).not.toBeNull();
     const props = capturedProps as HireAgentsRoutePropsCapture;
 
-    expect(props.agents).toHaveLength(5);
-    expect(props.featuredAgents).toHaveLength(5);
+    expect(props.agents).toHaveLength(4);
+    expect(props.featuredAgents).toHaveLength(4);
 
     const clmm = props.agents.find((agent) => agent.id === 'agent-clmm');
     const pendle = props.agents.find((agent) => agent.id === 'agent-pendle');
     const piExample = props.agents.find((agent) => agent.id === 'agent-pi-example');
     const portfolioManager = props.agents.find((agent) => agent.id === 'agent-portfolio-manager');
-    const emberLending = props.agents.find((agent) => agent.id === 'agent-ember-lending');
 
     expect(clmm?.chains).toEqual(['Arbitrum']);
     expect(clmm?.tokens).toEqual(['USDC', 'WETH', 'WBTC']);
@@ -205,30 +204,16 @@ describe('HireAgentsRoute integration', () => {
     expect(portfolioManager?.pointsTrend).toBe('up');
     expect(portfolioManager?.trendMultiplier).toBe('5x');
 
-    expect(emberLending?.chains).toEqual(['Arbitrum']);
-    expect(emberLending?.name).toBe('Ember Lending');
-    expect(emberLending?.protocols).toEqual(['Aave']);
-    expect(emberLending?.tokens).toEqual(['USDC']);
-    expect(emberLending?.imageUrl).toBe('/ember-lending-avatar.svg');
-    expect(emberLending?.avatarBg).toBe('#9896FF');
-    expect(emberLending?.surfaceTag).toBe('Swarm');
-    expect(emberLending?.status).toBe('hired');
-    expect(emberLending?.isActive).toBe(true);
-    expect(emberLending?.pointsTrend).toBe('up');
-    expect(emberLending?.trendMultiplier).toBe('2x');
     expect(clmm?.surfaceTag).toBe('Workflow');
 
-    expect(props.featuredAgents.map((agent) => agent.id).slice(0, 3)).toEqual([
+    expect(props.featuredAgents.map((agent) => agent.id).slice(0, 2)).toEqual([
       'agent-portfolio-manager',
-      'agent-ember-lending',
       'agent-clmm',
     ]);
     expect(props.featuredAgents.find((agent) => agent.id === 'agent-portfolio-manager')?.status).toBe(
       'hired',
     );
-    expect(props.featuredAgents.find((agent) => agent.id === 'agent-ember-lending')?.status).toBe(
-      'hired',
-    );
+    expect(props.featuredAgents.find((agent) => agent.id === 'agent-ember-lending')).toBeUndefined();
   });
 
   it('routes hire/view handlers to the correct detail URL', () => {
@@ -251,5 +236,13 @@ describe('HireAgentsRoute integration', () => {
 
     expect(portfolioManager).toBeDefined();
     expect(pendle?.description).toContain('highest-yielding Pendle YT markets');
+  });
+
+  it('omits the hidden ember-lending execution worker from the visible hire-agents route payload', () => {
+    renderToStaticMarkup(React.createElement(HireAgentsRoute));
+
+    const props = capturedProps as HireAgentsRoutePropsCapture;
+    expect(props.agents.find((agent) => agent.id === 'agent-ember-lending')).toBeUndefined();
+    expect(props.featuredAgents.find((agent) => agent.id === 'agent-ember-lending')).toBeUndefined();
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedAgents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedAgents.unit.test.ts
@@ -344,7 +344,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
 
     expect(html).toContain('Managed lending lane');
     expect(html).toContain('Ember Lending');
-    expect(html).toContain('/hire-agents/agent-ember-lending');
+    expect(html).not.toContain('/hire-agents/agent-ember-lending');
     expect(html).toContain('aria-expanded="false"');
     expect(html).toContain('Send message');
     expect(html).not.toContain('Settings and policies');
@@ -433,6 +433,39 @@ describe('AgentDetailPage managed-agent affordances', () => {
 
     expect(html).not.toContain('Managed lending lane');
     expect(html).not.toContain('Save managed mandate');
+    expect(html).not.toContain('/hire-agents/agent-ember-lending');
+  });
+
+  it('does not surface a direct detail route for the hidden ember-lending execution worker from the PM page', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(AgentDetailPage, {
+        agentId: 'agent-portfolio-manager',
+        agentName: 'Ember Portfolio Agent',
+        agentDescription: 'desc',
+        creatorName: 'Ember AI Team',
+        creatorVerified: true,
+        profile: {
+          chains: ['Arbitrum'],
+          protocols: ['Pi Runtime', 'Shared Ember Domain Service'],
+          tokens: ['USDC'],
+        },
+        metrics: {},
+        isHired: true,
+        isHiring: false,
+        hasLoadedView: true,
+        onHire: () => {},
+        onFire: () => {},
+        onSync: () => {},
+        onBack: () => {},
+        allowedPools: [],
+        lifecycleState: {
+          phase: 'active',
+        } as never,
+        domainProjection: createManagedMandateEditorProjection(),
+      }),
+    );
+
+    expect(html).toContain('Managed lending lane');
     expect(html).not.toContain('/hire-agents/agent-ember-lending');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -50,7 +50,7 @@ import type {
   ThreadLifecycle,
   ManagedMandateInput,
 } from '../types/agent';
-import { getAgentConfig } from '../config/agents';
+import { getAgentConfig, isRegisteredAgentId } from '../config/agents';
 import { usePrivyWalletClient } from '../hooks/usePrivyWalletClient';
 import { PROTOCOL_TOKEN_FALLBACK } from '../constants/protocolTokenFallback';
 import { useOnchainActionsIconMaps } from '../hooks/useOnchainActionsIconMaps';
@@ -592,7 +592,7 @@ function readManagedMandateEditorView(
 
 type PortfolioManagerManagedAgentView = {
   title: string;
-  detailHref: string;
+  detailHref: string | null;
   laneLabel: string | null;
   managedMandate: Record<string, unknown> | null;
   reservationSummary: string | null;
@@ -608,7 +608,9 @@ function buildPortfolioManagerManagedAgentView(
 
   return {
     title: managedMandateEditorView.title,
-    detailHref: `/hire-agents/${managedMandateEditorView.targetAgentRouteId}`,
+    detailHref: isRegisteredAgentId(managedMandateEditorView.targetAgentRouteId)
+      ? `/hire-agents/${managedMandateEditorView.targetAgentRouteId}`
+      : null,
     laneLabel: managedMandateEditorView.laneLabel,
     managedMandate: managedMandateEditorView.managedMandate,
     reservationSummary: managedMandateEditorView.reservationSummary,
@@ -1510,12 +1512,14 @@ export function AgentDetailPage({
                   </div>
                 </div>
               </button>
-              <a
-                href={visiblePortfolioManagerManagedAgentView.detailHref}
-                className="shrink-0 text-xs font-medium text-[#fd6731] hover:text-[#ff8a5c] transition-colors"
-              >
-                View lending agent
-              </a>
+              {visiblePortfolioManagerManagedAgentView.detailHref ? (
+                <a
+                  href={visiblePortfolioManagerManagedAgentView.detailHref}
+                  className="shrink-0 text-xs font-medium text-[#fd6731] hover:text-[#ff8a5c] transition-colors"
+                >
+                  View lending agent
+                </a>
+              ) : null}
             </div>
             {isManagedLaneExpanded ? (
               <div id={managedLaneContentId}>

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.ts
@@ -137,6 +137,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     isFeatured: true,
     featuredRank: 1,
   },
+};
+
+const INTERNAL_AGENT_CONFIGS: Record<string, AgentConfig> = {
   'agent-ember-lending': {
     id: 'agent-ember-lending',
     name: 'Ember Lending',
@@ -154,14 +157,16 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     chains: ['Arbitrum'],
     protocols: ['Aave'],
     tokens: ['USDC'],
-    isFeatured: true,
-    featuredRank: 2,
   },
 };
 
 export function getAgentConfig(agentId: string): AgentConfig {
   if (AGENT_REGISTRY[agentId]) {
     return AGENT_REGISTRY[agentId];
+  }
+
+  if (INTERNAL_AGENT_CONFIGS[agentId]) {
+    return INTERNAL_AGENT_CONFIGS[agentId];
   }
 
   return {

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
@@ -46,12 +46,11 @@ describe('agents config', () => {
     expect(isRegisteredAgentId('agent-clmm')).toBe(true);
     expect(isRegisteredAgentId('agent-pi-example')).toBe(true);
     expect(isRegisteredAgentId('agent-portfolio-manager')).toBe(true);
-    expect(isRegisteredAgentId('agent-ember-lending')).toBe(true);
+    expect(isRegisteredAgentId('agent-ember-lending')).toBe(false);
 
     const featured = getFeaturedAgents();
     expect(featured.map((agent) => agent.id)).toEqual([
       'agent-portfolio-manager',
-      'agent-ember-lending',
       'agent-clmm',
       'agent-pendle',
       'agent-gmx-allora',
@@ -79,6 +78,12 @@ describe('agents config', () => {
     expect(allAgentIds).toContain('agent-pi-example');
     expect(visibleAgentIds).not.toContain('agent-pi-example');
     expect(visibleAgentIds).toContain('agent-portfolio-manager');
-    expect(visibleAgentIds).toContain('agent-ember-lending');
+    expect(visibleAgentIds).not.toContain('agent-ember-lending');
+  });
+
+  it('keeps the hidden managed execution worker out of user-facing visible lists', () => {
+    const visibleAgentIds = getVisibleAgents().map((agent) => agent.id);
+
+    expect(visibleAgentIds).not.toContain('agent-ember-lending');
   });
 });

--- a/typescript/clients/web-ag-ui/compose.managed.yaml
+++ b/typescript/clients/web-ag-ui/compose.managed.yaml
@@ -57,6 +57,7 @@ services:
       NODE_ENV: production
       DATABASE_URL: postgresql://postgres:postgres@pi-runtime-postgres:5432/pi_runtime
       SHARED_EMBER_BASE_URL: http://shared-ember:4010
+      EMBER_LENDING_AGENT_DEPLOYMENT_URL: http://agent-ember-lending:3430/ag-ui
     depends_on:
       pi-runtime-postgres:
         condition: service_healthy

--- a/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
+++ b/typescript/clients/web-ag-ui/docs/c4-pi-runtime-architecture-and-boundaries.md
@@ -84,7 +84,7 @@ Key point:
 
 - Web, Telegram, and A2A are sibling client surfaces around the same Pi gateway runtime.
 - The gateway runtime itself is an initiative-specific layer built around `@mariozechner/pi-agent-core` + `@mariozechner/pi-ai`, not a claim that all of the durable records in this document already exist as `pi-mono` primitives today.
-- The current concrete managed downstream pair is `agent-portfolio-manager` plus `agent-ember-lending`; both are separate Pi-backed runtimes that consume Shared Ember over thin app-local adapters instead of talking to each other directly.
+- The current concrete managed downstream pair is `agent-portfolio-manager` plus hidden execution worker `agent-ember-lending`; only Portfolio Manager is user-facing, and PM dispatches the hidden worker over an internal AG-UI runtime lane while both runtimes still consume Shared Ember over thin app-local adapters.
 
 ## 4. Container view
 
@@ -160,22 +160,24 @@ Container responsibilities:
 - Current managed-runtime example:
   - `agent-portfolio-manager` owns onboarding approval, rooted-signing collection, and managed-agent control-plane projection, but Shared Ember owns the durable reservation and owned-unit truth created during onboarding completion.
   - `agent-portfolio-manager` startup must resolve the configured direct OWS controller wallet, confirm or rewrite the durable `portfolio-manager` / `orchestrator` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address.
-  - `agent-portfolio-manager` does not mark managed onboarding complete until a follow-up `subagent.readExecutionContext.v1` read for `ember-lending` exposes a non-null `subagent_wallet_address`.
+  - `agent-portfolio-manager` performs hidden-worker identity plus `subagent.readExecutionContext.v1` repair on a best-effort basis and does not block managed onboarding completion solely because the hidden worker identity or `subagent_wallet_address` is still missing on first use.
   - `agent-portfolio-manager` wallet-accounting reads must target the activated managed mandate lane, not the portfolio-manager lane, so reservation and policy-snapshot context comes from the same agent scope that Shared Ember activated during bootstrap.
   - The current portfolio-manager implementation writes `activation.mandateRef` on new bootstrap completions but still tolerates legacy stored bootstrap payloads that only captured `activation.agentId` until older thread state is replaced.
   - `agent-ember-lending` owns the bounded subagent read/plan/execute/escalate
-    runtime against Shared Ember and consumes agent-scoped lane data plus
-    rooted-wallet-wide wallet contents from Shared Ember execution context.
+    runtime against Shared Ember as a PM-owned hidden execution worker and
+    consumes agent-scoped lane data plus rooted-wallet-wide wallet contents
+    from Shared Ember execution context.
   - `agent-ember-lending` startup must resolve the configured direct OWS signer wallet, confirm or rewrite the durable `ember-lending` / `subagent` identity with an identity-scoped idempotency key, and fail closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address.
   - After healthy identity preflight plus onboarding, the first healthy `subagent.readExecutionContext.v1` read is expected to expose a non-null `subagent_wallet_address`.
-  - `agent-ember-lending` keeps `request_transaction_execution` as one
-    model-visible tool while internally composing runtime-owned redelegation
+  - `agent-portfolio-manager` keeps `dispatch_adhoc_execution` as the
+    model-visible adhoc execution command while hidden `agent-ember-lending`
+    internally composes runtime-owned redelegation
     typed-data signing, service-owned anchored Onchain Actions ordered
     transaction-request persistence and step resolution in runtime-owned domain
     state, chain-aware unsigned-transaction preparation with the managed wallet
     plus RPC state, runtime-owned execution signing, and Shared Ember
     submission/finalization.
-  - `agent-ember-lending` also fails `create_transaction_plan` closed unless it
+  - `agent-ember-lending` also fails internal candidate-plan creation closed unless it
     can persist the planner-returned payload behind that service-owned anchoring
     boundary; missing planner metadata, missing managed wallet context, or
     missing resolver wiring must stop plan creation before local state records a

--- a/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
+++ b/typescript/clients/web-ag-ui/docs/c4-target-architecture-web-ag-ui-agents.md
@@ -42,9 +42,9 @@ flowchart LR
   U[End User] --> W[web-ag-ui Web App]
   W --> R[CopilotKit Runtime Endpoint /api/copilotkit]
   R --> PM[Agent Runtime: agent-portfolio-manager]
-  R --> EL[Agent Runtime: agent-ember-lending]
   R --> O[Other Agent Runtimes]
 
+  PM --> EL[Hidden Execution Worker: agent-ember-lending]
   PM --> SE[Shared Ember Domain Service]
   EL --> SE
   O --> X[External Protocols/APIs]
@@ -54,7 +54,7 @@ Boundary intent:
 
 - User-facing web talks only to CopilotKit runtime over AG-UI-compatible routes.
 - Runtime talks to agent runtimes; web never talks directly to LangGraph thread APIs.
-- The first concrete managed-runtime pair is `agent-portfolio-manager` plus `agent-ember-lending`; they stay as separate runtimes and meet only through the Shared Ember boundary rather than direct runtime-to-runtime calls.
+- The first concrete managed-runtime pair is `agent-portfolio-manager` plus hidden execution worker `agent-ember-lending`; only Portfolio Manager is user-facing in web/CopilotKit, and PM dispatches the hidden worker over an internal AG-UI lane.
 
 ## 4. C4 Level 2: Container View
 
@@ -73,7 +73,7 @@ flowchart TB
 
   subgraph AgentRuntimes[Agent Runtimes]
     PM[agent-portfolio-manager]
-    EL[agent-ember-lending]
+    EL[hidden agent-ember-lending]
     OTHER[other agent runtimes]
   end
 
@@ -84,8 +84,8 @@ flowchart TB
   StreamMgr --> CK
   BFF --> CK
   CK --> PM
-  CK --> EL
   CK --> OTHER
+  PM --> EL
   PM --> SE
   EL --> SE
 ```
@@ -97,7 +97,7 @@ Container responsibilities:
 - Projection Store: derives sidebar/detail state from AG-UI events.
 - CopilotKit endpoint: protocol boundary and routing to agents.
 - Agent runtimes: workflow execution and state emission.
-- Managed downstream note: `agent-portfolio-manager` owns managed onboarding/control-plane flows, while `agent-ember-lending` stays on the bounded subagent read/plan/execute/escalate surface against Shared Ember.
+- Managed downstream note: `agent-portfolio-manager` owns the user-visible managed onboarding/control-plane flows, while hidden `agent-ember-lending` stays on the bounded subagent read/plan/execute/escalate surface against Shared Ember.
   - Shared Ember, not the portfolio-manager runtime, owns the durable wallet observation, managed-lane owned units, reservations, and policy snapshots produced during onboarding completion.
   - Portfolio-manager wallet/accounting context must read `orchestrator.readOnboardingState.v1` through the activated managed mandate lane so the operator sees the same `lending.supply` reservation and policy state that Ember Lending consumes.
   - During migration, portfolio-manager keeps a read-side fallback for older stored bootstrap payloads that only recorded `activation.agentId`; current writes still use `activation.mandateRef`.
@@ -194,19 +194,20 @@ Current concrete managed-path specialization:
   - owns onboarding approval, rooted-signing collection, and managed-agent activation/deactivation intent submission
   - resolves the configured direct OWS controller wallet during startup and confirms or rewrites the durable `portfolio-manager` / `orchestrator` identity before boot
   - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address
-  - only marks onboarding complete after rooted bootstrap once a follow-up `subagent.readExecutionContext.v1` read for `ember-lending` exposes a non-null `subagent_wallet_address`
+  - performs hidden-worker identity and execution-context repair on a best-effort basis and does not block onboarding completion solely because the hidden worker identity record or `subagent_wallet_address` is still missing on first use
+  - exposes the model-visible `dispatch_adhoc_execution` command and uses it to delegate adhoc lending work to the hidden execution worker
   - submits the minimal rooted-bootstrap activation contract that tells Shared Ember which managed mandate should materialize the initial lane
   - consumes Shared Ember through a thin app-local adapter without owning Ember business logic
 
 - `agent-ember-lending`
-  - owns the first bounded managed-subagent runtime
+  - owns the first bounded managed-subagent runtime as a PM-owned hidden execution worker
   - resolves the configured direct OWS signer wallet during startup and confirms or rewrites the durable `ember-lending` / `subagent` identity before boot
   - treats each distinct startup identity rewrite as a new command with its own identity-scoped idempotency key and fails closed unless Shared Ember echoes the confirmed identity with the expected `agent_id`, `role`, and wallet address
-  - consumes runtime-internal Shared Ember projection and execution-context reads plus the model-visible `create_transaction_plan`, `request_transaction_execution`, and `create_escalation_request` contract
+  - consumes runtime-internal Shared Ember projection and execution-context reads behind PM-owned dispatch rather than as a model-visible web/CopilotKit contract
   - keeps planning on the bounded Shared Ember planner contract, sending only a bounded planning handoff while receiving planner-generated payload output back in the candidate plan
-  - keeps Shared Ember idempotency internal to the runtime-owned adapter; model-visible planning and execution tools do not accept or require caller-managed idempotency keys
+  - keeps Shared Ember idempotency internal to the runtime-owned adapter; PM delegates into the worker without exposing caller-managed idempotency keys at the public control plane
   - treats candidate-plan creation as complete only after the lending service has privately anchored that planner-returned payload; missing planner metadata, missing managed wallet context, or missing anchored-resolver wiring must fail closed instead of leaving an apparently executable local plan
-  - keeps `request_transaction_execution` as one model-visible tool while
+  - keeps internal `create_transaction` plus `request_execution` worker commands while
     internally composing Shared Ember execution preparation, service-owned
     anchored Onchain Actions ordered transaction-request persistence and step
     resolution in runtime-owned domain state, local OWS signing custody, shared


### PR DESCRIPTION
## Summary
- add a PM-owned `dispatch_adhoc_execution` control-plane command that delegates adhoc lending work to a hidden `agent-ember-lending` execution worker
- make PM onboarding best-effort and non-blocking when the hidden worker still needs identity or wallet repair, while keeping fail-closed validation for confirmed hidden-worker identity echoes
- remove `agent-ember-lending` from the public web/CopilotKit/direct-command surfaces, extract the shared service-identity preflight helper, and update the durable architecture docs

## Test plan
- `pnpm run test:unit -- src/serviceIdentityPreflight.unit.test.ts` in `typescript/clients/web-ag-ui/apps/agent-workflow-core`
- `pnpm run test:unit -- src/portfolioManagerFoundation.unit.test.ts src/sharedEmberAdapter.unit.test.ts src/serviceIdentityPreflight.unit.test.ts src/agUiServer.unit.test.ts src/startup.unit.test.ts` in `typescript/clients/web-ag-ui/apps/agent-portfolio-manager`
- `bash -lc 'ENV_FILE=.env.test; [ -f "$ENV_FILE" ] || ENV_FILE=.env.test.example; exec node --env-file="$ENV_FILE" ./node_modules/vitest/vitest.mjs run --config vitest.config.unit.ts src/config/agents.unit.test.ts src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts src/app/api/agent-command/route.unit.test.ts src/components/AgentDetailPage.managedAgents.unit.test.ts'` in `typescript/clients/web-ag-ui/apps/web`
- `pnpm test:int -- src/app/hire-agents/page.int.test.ts` in `typescript/clients/web-ag-ui/apps/web`

## Notes
- The broader `apps/web` unit suite still has an unrelated pre-existing timeout in `src/components/AgentDetailPage.piExampleA2ui.unit.test.ts`, so the web validation here stayed targeted to the touched surfaces.

Closes #582
