### PR TITLE
fix: keep borrow-only Aave reserves in lending positions

### DIFF
--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.ts
@@ -280,7 +280,9 @@ export class AAVEAdapter {
       variableBorrowsUSD,
       totalBorrows,
       totalBorrowsUSD,
-    } of userReservesData.filter((ur) => ur.underlyingBalanceUSD !== '0')) {
+    } of userReservesData.filter(
+      (ur) => ur.underlyingBalanceUSD !== '0' || ur.totalBorrowsUSD !== '0',
+    )) {
       userReservesFormatted.push({
         tokenUid: {
           address: reserve.underlyingAsset,

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.unit.test.ts
@@ -64,3 +64,97 @@ describe('AAVEAdapter.createWithdrawTransaction', () => {
     expect(response.transactions[0]?.chainId).toBe('42161');
   });
 });
+
+describe('AAVEAdapter.getUserSummary', () => {
+  it('keeps borrow-only reserves while still excluding zero-value reserve noise', async () => {
+    const adapter = new AAVEAdapter({
+      chainId: 42161,
+      rpcUrl: 'http://127.0.0.1:8545',
+      wrappedNativeToken: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+    });
+
+    Reflect.set(
+      adapter,
+      '_getUserSummary',
+      vi.fn().mockResolvedValue({
+        reserves: {
+          totalLiquidityUSD: '58.36060178724453554490014',
+          totalCollateralUSD: '56.29733587641693554490014',
+          totalBorrowsUSD: '2.0632659108276',
+          netWorthUSD: '54.23406996558933554490014',
+          availableBorrowsUSD: '4.11411854325336000000000869546235081841162831848',
+          currentLoanToValue: '0.10972782917545976573',
+          currentLiquidationThreshold: '0.83122177366596321874',
+          healthFactor: '22.68033952109134593808',
+          userReservesData: [
+            {
+              reserve: {
+                underlyingAsset: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+              },
+              underlyingBalance: '0.020772004322653379',
+              underlyingBalanceUSD: '48.06082327097565554490014',
+              variableBorrows: '0',
+              variableBorrowsUSD: '0',
+              totalBorrows: '0',
+              totalBorrowsUSD: '0',
+            },
+            {
+              reserve: {
+                underlyingAsset: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+              },
+              underlyingBalance: '0',
+              underlyingBalanceUSD: '0',
+              variableBorrows: '0.00003175',
+              variableBorrowsUSD: '2.0632659108276',
+              totalBorrows: '0.00003175',
+              totalBorrowsUSD: '2.0632659108276',
+            },
+            {
+              reserve: {
+                underlyingAsset: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+              },
+              underlyingBalance: '0',
+              underlyingBalanceUSD: '0',
+              variableBorrows: '0',
+              variableBorrowsUSD: '0',
+              totalBorrows: '0',
+              totalBorrowsUSD: '0',
+            },
+          ],
+        },
+      }),
+    );
+
+    const response = await adapter.getUserSummary({
+      walletAddress: '0xaD53eC51a70e9a17df6752fdA80cd465457c258d',
+    });
+
+    expect(response.userReserves).toEqual([
+      {
+        tokenUid: {
+          address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          chainId: '42161',
+        },
+        underlyingBalance: '0.020772004322653379',
+        underlyingBalanceUsd: '48.06082327097565554490014',
+        variableBorrows: '0',
+        variableBorrowsUsd: '0',
+        totalBorrows: '0',
+        totalBorrowsUsd: '0',
+      },
+      {
+        tokenUid: {
+          address: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+          chainId: '42161',
+        },
+        underlyingBalance: '0',
+        underlyingBalanceUsd: '0',
+        variableBorrows: '0.00003175',
+        variableBorrowsUsd: '2.0632659108276',
+        totalBorrows: '0.00003175',
+        totalBorrowsUsd: '2.0632659108276',
+      },
+    ]);
+    expect(response.totalBorrowsUsd).toBe('2.0632659108276');
+  });
+});


### PR DESCRIPTION
## Summary
- keep borrow-only Aave reserves in `getUserSummary()` when borrow exposure is positive even if supplied balance is zero
- preserve exclusion of meaningless zero/zero reserve rows
- add a regression covering supplied, borrow-only, and zero-noise reserve rows

## Validation
- `pnpm -C typescript --filter @emberai/onchain-actions-registry test:ci -- src/aave-lending-plugin/adapter.unit.test.ts`
- `pnpm -C typescript --filter @emberai/onchain-actions-registry lint:fix`
- `pnpm -C typescript --filter @emberai/onchain-actions-registry build`

Closes #621
Related to EmberAGI/onchain-actions#303
Related to EmberAGI/onchain-actions#305
