### PR TITLE
fix(aave-lending-plugin): surface reserve quotes for lending positions

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -136,6 +136,7 @@ type SharedEmberExecutionContext = {
     container_ref?: string;
     status?: string;
     market_state?: Record<string, unknown> | null;
+    action_capacities?: Record<string, unknown>[];
     members?: Record<string, unknown>[];
   }>;
 } | null;
@@ -449,6 +450,14 @@ function readFirstRecordFromArray(value: unknown): Record<string, unknown> | nul
   return null;
 }
 
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is Record<string, unknown> => isRecord(entry));
+}
+
 function summarizeReservation(portfolioState: unknown): string | null {
   if (!isRecord(portfolioState)) {
     return null;
@@ -555,6 +564,55 @@ function scoreActivePositionScopeVisibility(scope: Record<string, unknown>): num
         score += 1;
       }
       if (readString(freshness['source_kind'])) {
+        score += 1;
+      }
+    }
+  }
+
+  const actionCapacities = readRecordArray(scope['action_capacities']);
+  score += actionCapacities.length * 2;
+  for (const actionCapacity of actionCapacities) {
+    if (readString(actionCapacity['control_path'])) {
+      score += 1;
+    }
+    if (readString(actionCapacity['capacity_kind'])) {
+      score += 1;
+    }
+    if (readString(actionCapacity['max_capacity'])) {
+      score += 2;
+    }
+    const limitingConstraints = readStringArray(actionCapacity['limiting_constraints']);
+    if (limitingConstraints) {
+      score += limitingConstraints.length;
+    }
+
+    const observedState = readRecordKey(actionCapacity, 'observed_state');
+    if (observedState) {
+      if (readString(observedState['total_supplied_usd'])) {
+        score += 1;
+      }
+      if (readString(observedState['total_borrowed_usd'])) {
+        score += 1;
+      }
+      if (readString(observedState['available_borrows_usd'])) {
+        score += 1;
+      }
+      if (readString(observedState['liquidation_threshold_borrow_capacity_usd'])) {
+        score += 1;
+      }
+      if (readFiniteNumber(observedState['current_ltv_bps']) !== null) {
+        score += 1;
+      }
+      if (readFiniteNumber(observedState['liquidation_threshold_bps']) !== null) {
+        score += 1;
+      }
+      if (readString(observedState['health_factor'])) {
+        score += 1;
+      }
+      if (readString(observedState['normalized_health_factor'])) {
+        score += 1;
+      }
+      if (readString(observedState['health_factor_status'])) {
         score += 1;
       }
     }
@@ -1354,6 +1412,99 @@ function appendActivePositionScopesXml(input: {
       }
 
       input.lines.push('      </market_state>');
+    }
+
+    const actionCapacities = readRecordArray(scope['action_capacities']);
+    if (actionCapacities.length > 0) {
+      input.lines.push('      <action_capacities>');
+      for (const actionCapacity of actionCapacities) {
+        const controlPath = readString(actionCapacity['control_path']);
+        const capacityKind = readString(actionCapacity['capacity_kind']);
+        const attributes = [
+          controlPath ? `control_path="${escapeXml(controlPath)}"` : null,
+          capacityKind ? `capacity_kind="${escapeXml(capacityKind)}"` : null,
+        ]
+          .filter((value): value is string => value !== null)
+          .join(' ');
+        input.lines.push(`        <action_capacity${attributes ? ` ${attributes}` : ''}>`);
+
+        const maxCapacity = readString(actionCapacity['max_capacity']);
+        if (maxCapacity) {
+          input.lines.push(`          <max_capacity>${escapeXml(maxCapacity)}</max_capacity>`);
+        }
+
+        const limitingConstraints = readStringArray(actionCapacity['limiting_constraints']);
+        if (limitingConstraints) {
+          input.lines.push('          <limiting_constraints>');
+          for (const constraint of limitingConstraints) {
+            input.lines.push(`            <constraint>${escapeXml(constraint)}</constraint>`);
+          }
+          input.lines.push('          </limiting_constraints>');
+        }
+
+        const observedState = readRecordKey(actionCapacity, 'observed_state');
+        if (observedState) {
+          input.lines.push('          <observed_state>');
+          const totalSuppliedUsd = readString(observedState['total_supplied_usd']);
+          if (totalSuppliedUsd) {
+            input.lines.push(
+              `            <total_supplied_usd>${escapeXml(totalSuppliedUsd)}</total_supplied_usd>`,
+            );
+          }
+          const totalBorrowedUsd = readString(observedState['total_borrowed_usd']);
+          if (totalBorrowedUsd) {
+            input.lines.push(
+              `            <total_borrowed_usd>${escapeXml(totalBorrowedUsd)}</total_borrowed_usd>`,
+            );
+          }
+          const availableBorrowsUsd = readString(observedState['available_borrows_usd']);
+          if (availableBorrowsUsd) {
+            input.lines.push(
+              `            <available_borrows_usd>${escapeXml(availableBorrowsUsd)}</available_borrows_usd>`,
+            );
+          }
+          const liquidationThresholdBorrowCapacityUsd = readString(
+            observedState['liquidation_threshold_borrow_capacity_usd'],
+          );
+          if (liquidationThresholdBorrowCapacityUsd) {
+            input.lines.push(
+              `            <liquidation_threshold_borrow_capacity_usd>${escapeXml(liquidationThresholdBorrowCapacityUsd)}</liquidation_threshold_borrow_capacity_usd>`,
+            );
+          }
+          const currentLtvBps = readFiniteNumber(observedState['current_ltv_bps']);
+          if (currentLtvBps !== null) {
+            input.lines.push(`            <current_ltv_bps>${currentLtvBps}</current_ltv_bps>`);
+          }
+          const liquidationThresholdBps = readFiniteNumber(
+            observedState['liquidation_threshold_bps'],
+          );
+          if (liquidationThresholdBps !== null) {
+            input.lines.push(
+              `            <liquidation_threshold_bps>${liquidationThresholdBps}</liquidation_threshold_bps>`,
+            );
+          }
+          const healthFactor = readString(observedState['health_factor']);
+          if (healthFactor) {
+            input.lines.push(`            <health_factor>${escapeXml(healthFactor)}</health_factor>`);
+          }
+          const normalizedHealthFactor = readString(observedState['normalized_health_factor']);
+          if (normalizedHealthFactor) {
+            input.lines.push(
+              `            <normalized_health_factor>${escapeXml(normalizedHealthFactor)}</normalized_health_factor>`,
+            );
+          }
+          const healthFactorStatus = readString(observedState['health_factor_status']);
+          if (healthFactorStatus) {
+            input.lines.push(
+              `            <health_factor_status>${escapeXml(healthFactorStatus)}</health_factor_status>`,
+            );
+          }
+          input.lines.push('          </observed_state>');
+        }
+
+        input.lines.push('        </action_capacity>');
+      }
+      input.lines.push('      </action_capacities>');
     }
 
     const members = Array.isArray(scope['members'])

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -130,67 +130,7 @@ function createManagedLifecycleState() {
         },
       ],
       active_position_scopes: [
-        {
-          scope_id:
-            'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
-          kind: 'lending',
-          scope_type_id: 'lending.aave.position',
-          root_user_wallet: '0x00000000000000000000000000000000000000a1',
-          network: 'arbitrum',
-          protocol_system: 'aave',
-          container_ref: 'aave:0x00000000000000000000000000000000000000a1',
-          status: 'active',
-          market_state: {
-            available_borrows_usd: '63.00',
-            borrowable_headroom_usd: '63.00',
-            current_ltv_bps: 3000,
-            liquidation_threshold_bps: 8400,
-            health_factor: '1.42',
-            freshness: {
-              derived_at: '2026-04-01T06:00:00.000Z',
-              oldest_observed_at: '2026-04-01T05:59:00.000Z',
-              latest_observed_at: '2026-04-01T06:00:00.000Z',
-              source_kind: 'valuation_ref',
-            },
-          },
-          members: [
-            {
-              member_id:
-                'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
-              role: 'collateral',
-              asset: 'aArbUSDC',
-              quantity: '90',
-              value_usd: '90.00',
-              economic_exposures: [
-                {
-                  asset: 'USDC',
-                  quantity: '90',
-                },
-              ],
-              state: {
-                withdrawable_quantity: '63',
-                supply_apr: '0.03',
-              },
-            },
-            {
-              member_id:
-                'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
-              role: 'debt',
-              asset: 'variableDebtArbUSDC',
-              quantity: '27',
-              value_usd: '27.00',
-              economic_exposures: [
-                {
-                  asset: 'USDC',
-                  quantity: '27',
-                },
-              ],
-              state: {
-                borrow_apr: '0.05',
-              },
-            },
-          ],
-        },
+        createActivePositionScope(),
       ],
       owned_units: [
         {
@@ -242,6 +182,89 @@ function createManagedMandateContext() {
   };
 }
 
+function createActivePositionScope() {
+  return {
+    scope_id:
+      'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
+    kind: 'lending',
+    scope_type_id: 'lending.aave.position',
+    root_user_wallet: '0x00000000000000000000000000000000000000a1',
+    network: 'arbitrum',
+    protocol_system: 'aave',
+    container_ref: 'aave:0x00000000000000000000000000000000000000a1',
+    status: 'active',
+    market_state: {
+      available_borrows_usd: '63.00',
+      borrowable_headroom_usd: '63.00',
+      current_ltv_bps: 3000,
+      liquidation_threshold_bps: 8400,
+      health_factor: '1.42',
+      freshness: {
+        derived_at: '2026-04-01T06:00:00.000Z',
+        oldest_observed_at: '2026-04-01T05:59:00.000Z',
+        latest_observed_at: '2026-04-01T06:00:00.000Z',
+        source_kind: 'valuation_ref',
+      },
+    },
+    action_capacities: [
+      {
+        control_path: 'lending.borrow',
+        capacity_kind: 'usd',
+        max_capacity: '48.00',
+        limiting_constraints: ['mandate_max_ltv'],
+        observed_state: {
+          total_supplied_usd: '90.00',
+          total_borrowed_usd: '27.00',
+          available_borrows_usd: '63.00',
+          liquidation_threshold_borrow_capacity_usd: '67.00',
+          current_ltv_bps: 3000,
+          liquidation_threshold_bps: 8400,
+          health_factor: '1.42',
+          normalized_health_factor: '1.42',
+          health_factor_status: 'measured',
+        },
+      },
+    ],
+    members: [
+      {
+        member_id:
+          'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
+        role: 'collateral',
+        asset: 'aArbUSDC',
+        quantity: '90',
+        value_usd: '90.00',
+        economic_exposures: [
+          {
+            asset: 'USDC',
+            quantity: '90',
+          },
+        ],
+        state: {
+          withdrawable_quantity: '63',
+          supply_apr: '0.03',
+        },
+      },
+      {
+        member_id:
+          'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
+        role: 'debt',
+        asset: 'variableDebtArbUSDC',
+        quantity: '27',
+        value_usd: '27.00',
+        economic_exposures: [
+          {
+            asset: 'USDC',
+            quantity: '27',
+          },
+        ],
+        state: {
+          borrow_apr: '0.05',
+        },
+      },
+    ],
+  };
+}
+
 function createPortfolioStateResponse() {
   return {
     jsonrpc: '2.0',
@@ -277,67 +300,7 @@ function createPortfolioStateResponse() {
           },
         ],
         active_position_scopes: [
-          {
-            scope_id:
-              'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
-            kind: 'lending',
-            scope_type_id: 'lending.aave.position',
-            root_user_wallet: '0x00000000000000000000000000000000000000a1',
-            network: 'arbitrum',
-            protocol_system: 'aave',
-            container_ref: 'aave:0x00000000000000000000000000000000000000a1',
-            status: 'active',
-            market_state: {
-              available_borrows_usd: '63.00',
-              borrowable_headroom_usd: '63.00',
-              current_ltv_bps: 3000,
-              liquidation_threshold_bps: 8400,
-              health_factor: '1.42',
-              freshness: {
-                derived_at: '2026-04-01T06:00:00.000Z',
-                oldest_observed_at: '2026-04-01T05:59:00.000Z',
-                latest_observed_at: '2026-04-01T06:00:00.000Z',
-                source_kind: 'valuation_ref',
-              },
-            },
-            members: [
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
-                role: 'collateral',
-                asset: 'aArbUSDC',
-                quantity: '90',
-                value_usd: '90.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '90',
-                  },
-                ],
-                state: {
-                  withdrawable_quantity: '63',
-                  supply_apr: '0.03',
-                },
-              },
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
-                role: 'debt',
-                asset: 'variableDebtArbUSDC',
-                quantity: '27',
-                value_usd: '27.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '27',
-                  },
-                ],
-                state: {
-                  borrow_apr: '0.05',
-                },
-              },
-            ],
-          },
+          createActivePositionScope(),
         ],
         owned_units: [
           {
@@ -456,67 +419,7 @@ function createExecutionContextResponse() {
         subagent_wallet_address: '0x00000000000000000000000000000000000000b1',
         root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
         active_position_scopes: [
-          {
-            scope_id:
-              'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
-            kind: 'lending',
-            scope_type_id: 'lending.aave.position',
-            root_user_wallet: '0x00000000000000000000000000000000000000a1',
-            network: 'arbitrum',
-            protocol_system: 'aave',
-            container_ref: 'aave:0x00000000000000000000000000000000000000a1',
-            status: 'active',
-            market_state: {
-              available_borrows_usd: '63.00',
-              borrowable_headroom_usd: '63.00',
-              current_ltv_bps: 3000,
-              liquidation_threshold_bps: 8400,
-              health_factor: '1.42',
-              freshness: {
-                derived_at: '2026-04-01T06:00:00.000Z',
-                oldest_observed_at: '2026-04-01T05:59:00.000Z',
-                latest_observed_at: '2026-04-01T06:00:00.000Z',
-                source_kind: 'valuation_ref',
-              },
-            },
-            members: [
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
-                role: 'collateral',
-                asset: 'aArbUSDC',
-                quantity: '90',
-                value_usd: '90.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '90',
-                  },
-                ],
-                state: {
-                  withdrawable_quantity: '63',
-                  supply_apr: '0.03',
-                },
-              },
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
-                role: 'debt',
-                asset: 'variableDebtArbUSDC',
-                quantity: '27',
-                value_usd: '27.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '27',
-                  },
-                ],
-                state: {
-                  borrow_apr: '0.05',
-                },
-              },
-            ],
-          },
+          createActivePositionScope(),
         ],
         wallet_contents: [
           {
@@ -1158,6 +1061,9 @@ describe('createEmberLendingDomain', () => {
         '      <protocol_system>aave</protocol_system>',
         '      <market_state>',
         '        <health_factor>1.42</health_factor>',
+        '      <action_capacities>',
+        '        <action_capacity control_path="lending.borrow" capacity_kind="usd">',
+        '          <max_capacity>48.00</max_capacity>',
         '      <members>',
         '        <member member_id="position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC" role="collateral" asset="aArbUSDC">',
         '          <value_usd>90.00</value_usd>',
@@ -1317,6 +1223,9 @@ describe('createEmberLendingDomain', () => {
         '  <active_position_scopes>',
         '      <protocol_system>aave</protocol_system>',
         '        <borrowable_headroom_usd>63.00</borrowable_headroom_usd>',
+        '      <action_capacities>',
+        '        <action_capacity control_path="lending.borrow" capacity_kind="usd">',
+        '          <max_capacity>48.00</max_capacity>',
         '    <wallet_balance asset="USDC" network="arbitrum">',
         '      <value_usd>100.00</value_usd>',
       ]),
@@ -1366,6 +1275,9 @@ describe('createEmberLendingDomain', () => {
         '      <protocol_system>aave</protocol_system>',
         '      <market_state>',
         '        <health_factor>1.42</health_factor>',
+        '      <action_capacities>',
+        '        <action_capacity control_path="lending.borrow" capacity_kind="usd">',
+        '          <max_capacity>48.00</max_capacity>',
       ]),
     );
     expect(context?.join('\n')).toContain('<active_reservations>');

--- a/typescript/onchain-actions-plugins/registry/README.md
+++ b/typescript/onchain-actions-plugins/registry/README.md
@@ -236,7 +236,7 @@ The schema system provides comprehensive type safety with Zod validation:
 
 **Action-Specific Schemas**:
 
-- **Lending** (`schemas/lending.ts`): Supply, borrow, repay, withdraw operations with comprehensive position tracking
+- **Lending** (`schemas/lending.ts`): Supply, borrow, repay, withdraw operations with comprehensive position tracking, optional `tokenAddress` targeting, and reserve quote fields for exact max-borrow resolution
 - **Liquidity** (`schemas/liquidity.ts`): Advanced liquidity provision with discriminated unions for full/limited range positions
 - **Swap** (`schemas/swap.ts`): Token exchange with slippage tolerance and price tracking
 - **Perpetuals** (`schemas/perpetuals.ts`): Integration with GMX SDK for complex derivatives trading

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/README.md
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/README.md
@@ -121,8 +121,7 @@ exact max-borrow resolution:
   - `availableLiquidityUsd`
 - When `tokenAddress` is provided, the response also returns
   `requestedReserve` for that reserve even if the wallet has no current
-  exposure in it, and that reserve is also included in `userReserves` when it
-  was not already surfaced there.
+  exposure in it.
 - Aggregate lending fields such as `availableBorrowsUsd` remain unchanged.
 
 ### 3. Action Definitions

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/README.md
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/README.md
@@ -104,6 +104,27 @@ export class AAVEAdapter {
 }
 ```
 
+#### Positions Query Surface
+
+`getUserSummary()` / `queries.getPositions()` now honors the optional
+`tokenAddress` request field and surfaces live reserve quote data needed for
+exact max-borrow resolution:
+
+- `userReserves` keeps active supplied reserves and borrow-only reserves while
+  still omitting zero-exposure noise.
+- Each surfaced reserve carries:
+  - balances and borrow totals
+  - `priceInUsd`
+  - `priceInMarketReferenceCurrency`
+  - `formattedPriceInMarketReferenceCurrency`
+  - `availableLiquidity`
+  - `availableLiquidityUsd`
+- When `tokenAddress` is provided, the response also returns
+  `requestedReserve` for that reserve even if the wallet has no current
+  exposure in it, and that reserve is also included in `userReserves` when it
+  was not already surfaced there.
+- Aggregate lending fields such as `availableBorrowsUsd` remain unchanged.
+
 ### 3. Action Definitions
 
 The plugin implements 5 distinct lending actions:

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.ts
@@ -356,15 +356,6 @@ export class AAVEAdapter {
         })()
       : undefined;
 
-    if (
-      requestedReserve &&
-      !userReservesFormatted.some(
-        ({ tokenUid }) => tokenUid.address.toLowerCase() === requestedReserve.tokenUid.address,
-      )
-    ) {
-      userReservesFormatted.push(requestedReserve);
-    }
-
     return {
       userReserves: userReservesFormatted,
       requestedReserve,

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.ts
@@ -5,6 +5,7 @@ import {
   type ReservesDataHumanized,
   type ReserveDataHumanized,
 } from '@aave/contract-helpers';
+import type { ComputedUserReserve, FormatReserveUSDResponse } from '@aave/math-utils';
 import { ethers, type PopulatedTransaction, utils } from 'ethers';
 
 import {
@@ -28,6 +29,67 @@ import { getUiPoolDataProviderImpl, type IUiPoolDataProvider } from './dataProvi
 import { type AAVEMarket, getMarket } from './market.js';
 import { populateTransaction } from './populateTransaction.js';
 import { UserSummary } from './userSummary.js';
+
+type UserReserveWithQuote = ComputedUserReserve<FormatReserveUSDResponse>;
+type ReserveQuoteFields = Pick<
+  FormatReserveUSDResponse,
+  | 'underlyingAsset'
+  | 'priceInUSD'
+  | 'priceInMarketReferenceCurrency'
+  | 'formattedPriceInMarketReferenceCurrency'
+  | 'availableLiquidity'
+  | 'availableLiquidityUSD'
+> &
+  Partial<Pick<FormatReserveUSDResponse, 'symbol' | 'name' | 'decimals'>>;
+
+function hasVisibleReservePosition({
+  underlyingBalance,
+  totalBorrows,
+}: Pick<UserReserveWithQuote, 'underlyingBalance' | 'totalBorrows'>): boolean {
+  return underlyingBalance !== '0' || totalBorrows !== '0';
+}
+
+function toLendingReserveDetail(
+  chainId: string,
+  {
+    reserve,
+    underlyingBalance = '0',
+    underlyingBalanceUSD = '0',
+    variableBorrows = '0',
+    variableBorrowsUSD = '0',
+    totalBorrows = '0',
+    totalBorrowsUSD = '0',
+  }: {
+    reserve: ReserveQuoteFields;
+    underlyingBalance?: string;
+    underlyingBalanceUSD?: string;
+    variableBorrows?: string;
+    variableBorrowsUSD?: string;
+    totalBorrows?: string;
+    totalBorrowsUSD?: string;
+  },
+) {
+  return {
+    tokenUid: {
+      address: reserve.underlyingAsset,
+      chainId,
+    },
+    ...(reserve.symbol !== undefined ? { symbol: reserve.symbol } : {}),
+    ...(reserve.name !== undefined ? { name: reserve.name } : {}),
+    ...(reserve.decimals !== undefined ? { decimals: reserve.decimals } : {}),
+    underlyingBalance,
+    underlyingBalanceUsd: underlyingBalanceUSD,
+    variableBorrows,
+    variableBorrowsUsd: variableBorrowsUSD,
+    totalBorrows,
+    totalBorrowsUsd: totalBorrowsUSD,
+    priceInUsd: reserve.priceInUSD,
+    priceInMarketReferenceCurrency: reserve.priceInMarketReferenceCurrency,
+    formattedPriceInMarketReferenceCurrency: reserve.formattedPriceInMarketReferenceCurrency,
+    availableLiquidity: reserve.availableLiquidity,
+    availableLiquidityUsd: reserve.availableLiquidityUSD,
+  };
+}
 
 export type EModeCategory = 'default' | 'stablecoins';
 
@@ -271,32 +333,41 @@ export class AAVEAdapter {
       userReservesData,
     } = userSummaryResponse.reserves;
 
-    const userReservesFormatted = [];
-    for (const {
-      reserve,
-      underlyingBalance,
-      underlyingBalanceUSD,
-      variableBorrows,
-      variableBorrowsUSD,
-      totalBorrows,
-      totalBorrowsUSD,
-    } of userReservesData.filter((ur) => ur.underlyingBalanceUSD !== '0')) {
-      userReservesFormatted.push({
-        tokenUid: {
-          address: reserve.underlyingAsset,
-          chainId: this.chain.id.toString(),
-        },
-        underlyingBalance,
-        underlyingBalanceUsd: underlyingBalanceUSD,
-        variableBorrows,
-        variableBorrowsUsd: variableBorrowsUSD,
-        totalBorrows,
-        totalBorrowsUsd: totalBorrowsUSD,
-      });
+    const chainId = this.chain.id.toString();
+    const userReservesFormatted = userReservesData
+      .filter(hasVisibleReservePosition)
+      .map((reserve) => toLendingReserveDetail(chainId, reserve));
+
+    const requestedReserveAddress = params.tokenAddress
+      ? params.tokenAddress.toLowerCase()
+      : undefined;
+    const requestedReserve = requestedReserveAddress
+      ? userReservesFormatted.find(
+          ({ tokenUid }) => tokenUid.address.toLowerCase() === requestedReserveAddress,
+        ) ??
+        (() => {
+          const reserve = userSummaryResponse.getReserveByUnderlyingAsset(requestedReserveAddress);
+
+          if (!reserve) {
+            return undefined;
+          }
+
+          return toLendingReserveDetail(chainId, { reserve });
+        })()
+      : undefined;
+
+    if (
+      requestedReserve &&
+      !userReservesFormatted.some(
+        ({ tokenUid }) => tokenUid.address.toLowerCase() === requestedReserve.tokenUid.address,
+      )
+    ) {
+      userReservesFormatted.push(requestedReserve);
     }
 
     return {
       userReserves: userReservesFormatted,
+      requestedReserve,
       totalLiquidityUsd: totalLiquidityUSD,
       totalCollateralUsd: totalCollateralUSD,
       totalBorrowsUsd: totalBorrowsUSD,

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.unit.test.ts
@@ -64,3 +64,229 @@ describe('AAVEAdapter.createWithdrawTransaction', () => {
     expect(response.transactions[0]?.chainId).toBe('42161');
   });
 });
+
+describe('AAVEAdapter.getUserSummary', () => {
+  const walletAddress = '0xaD53eC51a70e9a17df6752fdA80cd465457c258d';
+
+  function createAdapter() {
+    return new AAVEAdapter({
+      chainId: 42161,
+      rpcUrl: 'http://127.0.0.1:8545',
+      wrappedNativeToken: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+    });
+  }
+
+  function mockUserSummary(adapter: AAVEAdapter) {
+    Reflect.set(
+      adapter,
+      '_getUserSummary',
+      vi.fn().mockResolvedValue({
+        reserves: {
+          totalLiquidityUSD: '58.36060178724453554490014',
+          totalCollateralUSD: '56.29733587641693554490014',
+          totalBorrowsUSD: '2.0632659108276',
+          netWorthUSD: '54.23406996558933554490014',
+          availableBorrowsUSD: '4.11411854325336000000000869546235081841162831848',
+          currentLoanToValue: '0.10972782917545976573',
+          currentLiquidationThreshold: '0.83122177366596321874',
+          healthFactor: '22.68033952109134593808',
+          userReservesData: [
+            {
+              reserve: {
+                underlyingAsset: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+                symbol: 'WETH',
+                name: 'Wrapped Ether',
+                decimals: 18,
+                priceInUSD: '2313.259876',
+                priceInMarketReferenceCurrency: '231325987600',
+                formattedPriceInMarketReferenceCurrency: '2313.259876',
+                availableLiquidity: '100',
+                availableLiquidityUSD: '231325.9876',
+              },
+              underlyingBalance: '0.020772004322653379',
+              underlyingBalanceUSD: '48.06082327097565554490014',
+              variableBorrows: '0',
+              variableBorrowsUSD: '0',
+              totalBorrows: '0',
+              totalBorrowsUSD: '0',
+            },
+            {
+              reserve: {
+                underlyingAsset: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+                symbol: 'WBTC',
+                name: 'Wrapped BTC',
+                decimals: 8,
+                priceInUSD: '64985.320025',
+                priceInMarketReferenceCurrency: '6498532002500',
+                formattedPriceInMarketReferenceCurrency: '64985.320025',
+                availableLiquidity: '0.35',
+                availableLiquidityUSD: '22744.86200875',
+              },
+              underlyingBalance: '0',
+              underlyingBalanceUSD: '0',
+              variableBorrows: '0.00003175',
+              variableBorrowsUSD: '2.0632659108276',
+              totalBorrows: '0.00003175',
+              totalBorrowsUSD: '2.0632659108276',
+            },
+            {
+              reserve: {
+                underlyingAsset: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+                symbol: 'USDC',
+                name: 'USD Coin',
+                decimals: 6,
+                priceInUSD: '1',
+                priceInMarketReferenceCurrency: '100000000',
+                formattedPriceInMarketReferenceCurrency: '1',
+                availableLiquidity: '1000000',
+                availableLiquidityUSD: '1000000',
+              },
+              underlyingBalance: '0',
+              underlyingBalanceUSD: '0',
+              variableBorrows: '0',
+              variableBorrowsUSD: '0',
+              totalBorrows: '0',
+              totalBorrowsUSD: '0',
+            },
+          ],
+        },
+        getReserveByUnderlyingAsset: vi.fn((tokenAddress: string) => {
+          if (tokenAddress.toLowerCase() === '0xaf88d065e77c8cc2239327c5edb3a432268e5831') {
+            return {
+              underlyingAsset: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+              symbol: 'USDC',
+              name: 'USD Coin',
+              decimals: 6,
+              priceInUSD: '1',
+              priceInMarketReferenceCurrency: '100000000',
+              formattedPriceInMarketReferenceCurrency: '1',
+              availableLiquidity: '1000000',
+              availableLiquidityUSD: '1000000',
+            };
+          }
+          return undefined;
+        }),
+      }),
+    );
+  }
+
+  it('surfaces borrow-only reserves with reserve pricing and quote data', async () => {
+    const adapter = createAdapter();
+    mockUserSummary(adapter);
+
+    const response = await adapter.getUserSummary({ walletAddress });
+
+    expect(response.userReserves).toEqual([
+      {
+        tokenUid: {
+          address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+          chainId: '42161',
+        },
+        symbol: 'WETH',
+        name: 'Wrapped Ether',
+        decimals: 18,
+        underlyingBalance: '0.020772004322653379',
+        underlyingBalanceUsd: '48.06082327097565554490014',
+        variableBorrows: '0',
+        variableBorrowsUsd: '0',
+        totalBorrows: '0',
+        totalBorrowsUsd: '0',
+        priceInUsd: '2313.259876',
+        priceInMarketReferenceCurrency: '231325987600',
+        formattedPriceInMarketReferenceCurrency: '2313.259876',
+        availableLiquidity: '100',
+        availableLiquidityUsd: '231325.9876',
+      },
+      {
+        tokenUid: {
+          address: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+          chainId: '42161',
+        },
+        symbol: 'WBTC',
+        name: 'Wrapped BTC',
+        decimals: 8,
+        underlyingBalance: '0',
+        underlyingBalanceUsd: '0',
+        variableBorrows: '0.00003175',
+        variableBorrowsUsd: '2.0632659108276',
+        totalBorrows: '0.00003175',
+        totalBorrowsUsd: '2.0632659108276',
+        priceInUsd: '64985.320025',
+        priceInMarketReferenceCurrency: '6498532002500',
+        formattedPriceInMarketReferenceCurrency: '64985.320025',
+        availableLiquidity: '0.35',
+        availableLiquidityUsd: '22744.86200875',
+      },
+    ]);
+  });
+
+  it('returns the requested reserve even when the user has no current exposure in it', async () => {
+    const adapter = createAdapter();
+    mockUserSummary(adapter);
+
+    const response = await adapter.getUserSummary({
+      walletAddress,
+      tokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    });
+
+    expect(response.requestedReserve).toEqual({
+      tokenUid: {
+        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        chainId: '42161',
+      },
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      underlyingBalance: '0',
+      underlyingBalanceUsd: '0',
+      variableBorrows: '0',
+      variableBorrowsUsd: '0',
+      totalBorrows: '0',
+      totalBorrowsUsd: '0',
+      priceInUsd: '1',
+      priceInMarketReferenceCurrency: '100000000',
+      formattedPriceInMarketReferenceCurrency: '1',
+      availableLiquidity: '1000000',
+      availableLiquidityUsd: '1000000',
+    });
+    expect(response.userReserves).toContainEqual({
+      tokenUid: {
+        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        chainId: '42161',
+      },
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      underlyingBalance: '0',
+      underlyingBalanceUsd: '0',
+      variableBorrows: '0',
+      variableBorrowsUsd: '0',
+      totalBorrows: '0',
+      totalBorrowsUsd: '0',
+      priceInUsd: '1',
+      priceInMarketReferenceCurrency: '100000000',
+      formattedPriceInMarketReferenceCurrency: '1',
+      availableLiquidity: '1000000',
+      availableLiquidityUsd: '1000000',
+    });
+  });
+
+  it('preserves aggregate lending fields when tokenAddress is used', async () => {
+    const adapter = createAdapter();
+    mockUserSummary(adapter);
+
+    const response = await adapter.getUserSummary({
+      walletAddress,
+      tokenAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    });
+
+    expect(response.totalLiquidityUsd).toBe('58.36060178724453554490014');
+    expect(response.totalCollateralUsd).toBe('56.29733587641693554490014');
+    expect(response.totalBorrowsUsd).toBe('2.0632659108276');
+    expect(response.netWorthUsd).toBe('54.23406996558933554490014');
+    expect(response.availableBorrowsUsd).toBe('4.11411854325336000000000869546235081841162831848');
+    expect(response.currentLoanToValue).toBe('0.10972782917545976573');
+    expect(response.currentLiquidationThreshold).toBe('0.83122177366596321874');
+    expect(response.healthFactor).toBe('22.68033952109134593808');
+  });
+});

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/adapter.unit.test.ts
@@ -220,7 +220,7 @@ describe('AAVEAdapter.getUserSummary', () => {
     ]);
   });
 
-  it('returns the requested reserve even when the user has no current exposure in it', async () => {
+  it('returns the requested reserve without injecting quote-only reserves into userReserves', async () => {
     const adapter = createAdapter();
     mockUserSummary(adapter);
 
@@ -249,26 +249,65 @@ describe('AAVEAdapter.getUserSummary', () => {
       availableLiquidity: '1000000',
       availableLiquidityUsd: '1000000',
     });
-    expect(response.userReserves).toContainEqual({
-      tokenUid: {
-        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
-        chainId: '42161',
-      },
-      symbol: 'USDC',
-      name: 'USD Coin',
-      decimals: 6,
-      underlyingBalance: '0',
-      underlyingBalanceUsd: '0',
-      variableBorrows: '0',
-      variableBorrowsUsd: '0',
-      totalBorrows: '0',
-      totalBorrowsUsd: '0',
-      priceInUsd: '1',
-      priceInMarketReferenceCurrency: '100000000',
-      formattedPriceInMarketReferenceCurrency: '1',
-      availableLiquidity: '1000000',
-      availableLiquidityUsd: '1000000',
+    expect(response.userReserves).toHaveLength(2);
+    expect(
+      response.userReserves.some(
+        ({ tokenUid }) =>
+          tokenUid.address.toLowerCase() === '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not duplicate an already surfaced reserve when tokenAddress casing differs', async () => {
+    const adapter = createAdapter();
+    Reflect.set(
+      adapter,
+      '_getUserSummary',
+      vi.fn().mockResolvedValue({
+        reserves: {
+          totalLiquidityUSD: '1',
+          totalCollateralUSD: '1',
+          totalBorrowsUSD: '0',
+          netWorthUSD: '1',
+          availableBorrowsUSD: '0',
+          currentLoanToValue: '0',
+          currentLiquidationThreshold: '0',
+          healthFactor: '1',
+          userReservesData: [
+            {
+              reserve: {
+                underlyingAsset: '0xAbCd000000000000000000000000000000000000',
+                symbol: 'TEST',
+                name: 'Test Token',
+                decimals: 18,
+                priceInUSD: '1',
+                priceInMarketReferenceCurrency: '100000000',
+                formattedPriceInMarketReferenceCurrency: '1',
+                availableLiquidity: '10',
+                availableLiquidityUSD: '10',
+              },
+              underlyingBalance: '1',
+              underlyingBalanceUSD: '1',
+              variableBorrows: '0',
+              variableBorrowsUSD: '0',
+              totalBorrows: '0',
+              totalBorrowsUSD: '0',
+            },
+          ],
+        },
+        getReserveByUnderlyingAsset: vi.fn().mockReturnValue(undefined),
+      }),
+    );
+
+    const response = await adapter.getUserSummary({
+      walletAddress,
+      tokenAddress: '0xabcd000000000000000000000000000000000000',
     });
+
+    expect(response.requestedReserve?.tokenUid.address).toBe(
+      '0xAbCd000000000000000000000000000000000000',
+    );
+    expect(response.userReserves).toHaveLength(1);
   });
 
   it('preserves aggregate lending fields when tokenAddress is used', async () => {

--- a/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/userSummary.ts
+++ b/typescript/onchain-actions-plugins/registry/src/aave-lending-plugin/userSummary.ts
@@ -14,6 +14,7 @@ function formatNumeric(value: string): string {
 
 export class UserSummary {
   public reserves: FormatUserSummaryResponse<FormatReserveUSDResponse>;
+  private readonly formattedReserves: FormatReserveUSDResponse[];
 
   /**
    * @param userReservesResponse - The response from getUserReservesHumanized.
@@ -28,7 +29,7 @@ export class UserSummary {
   ) {
     const currentTimestamp = Date.now() / 1000;
 
-    const formattedReserves = formatReserves({
+    this.formattedReserves = formatReserves({
       reserves: reservesResponse.reservesData,
       currentTimestamp,
       marketReferenceCurrencyDecimals:
@@ -44,9 +45,17 @@ export class UserSummary {
       marketReferenceCurrencyDecimals:
         reservesResponse.baseCurrencyData.marketReferenceCurrencyDecimals,
       userReserves: userReservesResponse.userReserves,
-      formattedReserves,
+      formattedReserves: this.formattedReserves,
       userEmodeCategoryId: userReservesResponse.userEmodeCategoryId,
     });
+  }
+
+  public getReserveByUnderlyingAsset(tokenAddress: string): FormatReserveUSDResponse | undefined {
+    const normalizedTokenAddress = tokenAddress.toLowerCase();
+
+    return this.formattedReserves.find(
+      (reserve) => reserve.underlyingAsset.toLowerCase() === normalizedTokenAddress,
+    );
   }
 
   public toHumanReadable(): string {

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/lending.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/lending.ts
@@ -72,17 +72,26 @@ export type GetWalletLendingPositionsRequest = z.infer<
 
 export const LendTokenDetailSchema = z.object({
   tokenUid: TokenIdentifierSchema,
+  symbol: z.string().optional(),
+  name: z.string().optional(),
+  decimals: z.number().int().optional(),
   underlyingBalance: z.string(),
   underlyingBalanceUsd: z.string(),
   variableBorrows: z.string(),
   variableBorrowsUsd: z.string(),
   totalBorrows: z.string(),
   totalBorrowsUsd: z.string(),
+  priceInUsd: z.string(),
+  priceInMarketReferenceCurrency: z.string(),
+  formattedPriceInMarketReferenceCurrency: z.string(),
+  availableLiquidity: z.string(),
+  availableLiquidityUsd: z.string(),
 });
 export type LendTokenDetail = z.infer<typeof LendTokenDetailSchema>;
 
 export const GetWalletLendingPositionsResponseSchema = z.object({
   userReserves: z.array(LendTokenDetailSchema),
+  requestedReserve: LendTokenDetailSchema.optional(),
   totalLiquidityUsd: z.string(),
   totalCollateralUsd: z.string(),
   totalBorrowsUsd: z.string(),

--- a/typescript/onchain-actions-plugins/registry/src/core/schemas/lending.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/core/schemas/lending.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GetWalletLendingPositionsResponseSchema,
+  LendTokenDetailSchema,
+} from './lending.js';
+
+describe('LendTokenDetailSchema', () => {
+  it('retains reserve metadata and quote fields used for exact max-borrow resolution', () => {
+    const parsed = LendTokenDetailSchema.parse({
+      tokenUid: {
+        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        chainId: '42161',
+      },
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      underlyingBalance: '0',
+      underlyingBalanceUsd: '0',
+      variableBorrows: '0',
+      variableBorrowsUsd: '0',
+      totalBorrows: '0',
+      totalBorrowsUsd: '0',
+      priceInUsd: '1',
+      priceInMarketReferenceCurrency: '100000000',
+      formattedPriceInMarketReferenceCurrency: '1',
+      availableLiquidity: '1000000',
+      availableLiquidityUsd: '1000000',
+    });
+
+    expect(parsed.symbol).toBe('USDC');
+    expect(parsed.priceInUsd).toBe('1');
+    expect(parsed.priceInMarketReferenceCurrency).toBe('100000000');
+    expect(parsed.formattedPriceInMarketReferenceCurrency).toBe('1');
+    expect(parsed.availableLiquidity).toBe('1000000');
+    expect(parsed.availableLiquidityUsd).toBe('1000000');
+  });
+});
+
+describe('GetWalletLendingPositionsResponseSchema', () => {
+  it('retains an optional requestedReserve alongside aggregate lending fields', () => {
+    const parsed = GetWalletLendingPositionsResponseSchema.parse({
+      userReserves: [],
+      requestedReserve: {
+        tokenUid: {
+          address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          chainId: '42161',
+        },
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+        underlyingBalance: '0',
+        underlyingBalanceUsd: '0',
+        variableBorrows: '0',
+        variableBorrowsUsd: '0',
+        totalBorrows: '0',
+        totalBorrowsUsd: '0',
+        priceInUsd: '1',
+        priceInMarketReferenceCurrency: '100000000',
+        formattedPriceInMarketReferenceCurrency: '1',
+        availableLiquidity: '1000000',
+        availableLiquidityUsd: '1000000',
+      },
+      totalLiquidityUsd: '10',
+      totalCollateralUsd: '9',
+      totalBorrowsUsd: '1',
+      netWorthUsd: '8',
+      availableBorrowsUsd: '5',
+      currentLoanToValue: '0.1',
+      currentLiquidationThreshold: '0.8',
+      healthFactor: '5',
+    });
+
+    expect(parsed.requestedReserve?.priceInUsd).toBe('1');
+    expect(parsed.availableBorrowsUsd).toBe('5');
+  });
+});


### PR DESCRIPTION
## Summary
- surface reserve quote data for Aave lending positions and keep `requestedReserve` additive
- add regression coverage for the Aave lending adapter reserve-shape fixes
- render Shared Ember `action_capacities` in `agent-ember-lending` so downstream context shows mandate-shaped borrow truth

## Testing
- `pnpm --filter @emberai/onchain-actions-registry test:ci -- src/aave-lending-plugin/adapter.unit.test.ts src/core/schemas/lending.unit.test.ts`
- `pnpm test:unit -- src/sharedEmberAdapter.unit.test.ts`
- `pnpm build`

## Related
- Closes #623
- Related EmberAGI/ember-orchestration-v1-spec#279
- Related EmberAGI/ember-orchestration-v1-spec#280

## Scope Note
- the `#623` registry/API contract work on this branch is in `aa17dd16` and `13334649`
- `eee2759b` is a downstream adapter adoption follow-up on the same branch, not the core `#623` fix