### PR TITLE
fix(agent-ember-lending): surface scoped action capacities

### DIFF
--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -782,6 +782,51 @@ describe('agent-ember-lending AG-UI integration', () => {
                   control_path: 'lending.supply',
                 },
               ],
+              active_position_scopes: [
+                {
+                  scope_id:
+                    'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
+                  kind: 'lending',
+                  scope_type_id: 'lending.aave.position',
+                  root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                  network: 'arbitrum',
+                  protocol_system: 'aave',
+                  container_ref: 'aave:0x00000000000000000000000000000000000000a1',
+                  status: 'active',
+                  market_state: {
+                    available_borrows_usd: '63.00',
+                    borrowable_headroom_usd: '63.00',
+                    current_ltv_bps: 3000,
+                    liquidation_threshold_bps: 8400,
+                    health_factor: '1.42',
+                    freshness: {
+                      derived_at: '2026-04-01T06:00:00.000Z',
+                      oldest_observed_at: '2026-04-01T05:59:00.000Z',
+                      latest_observed_at: '2026-04-01T06:00:00.000Z',
+                      source_kind: 'valuation_ref',
+                    },
+                  },
+                  action_capacities: [
+                    {
+                      control_path: 'lending.borrow',
+                      capacity_kind: 'usd',
+                      max_capacity: '48.00',
+                      limiting_constraints: ['mandate_min_health_factor'],
+                      observed_state: {
+                        total_supplied_usd: '90.00',
+                        total_borrowed_usd: '27.00',
+                        available_borrows_usd: '63.00',
+                        liquidation_threshold_borrow_capacity_usd: '67.00',
+                        current_ltv_bps: 3000,
+                        liquidation_threshold_bps: 8400,
+                        health_factor: '1.42',
+                        normalized_health_factor: '1.42',
+                        health_factor_status: 'measured',
+                      },
+                    },
+                  ],
+                },
+              ],
               owned_units: [
                 {
                   unit_id: 'unit-ember-lending-001',
@@ -982,6 +1027,29 @@ describe('agent-ember-lending AG-UI integration', () => {
         },
       }),
     );
+
+    expect(
+      readPersistedLifecycleState(persistedPostgres.persistedThreads.values(), 'thread-connect-1'),
+    ).toMatchObject({
+      lastPortfolioState: {
+        active_position_scopes: [
+          expect.objectContaining({
+            scope_id:
+              'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
+            market_state: expect.objectContaining({
+              borrowable_headroom_usd: '63.00',
+            }),
+            action_capacities: [
+              expect.objectContaining({
+                control_path: 'lending.borrow',
+                max_capacity: '48.00',
+                limiting_constraints: ['mandate_min_health_factor'],
+              }),
+            ],
+          }),
+        ],
+      },
+    });
   });
 
   it('does not fabricate handoff identity over AG-UI when the live portfolio payload omits it', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -136,6 +136,7 @@ type SharedEmberExecutionContext = {
     container_ref?: string;
     status?: string;
     market_state?: Record<string, unknown> | null;
+    action_capacities?: Record<string, unknown>[];
     members?: Record<string, unknown>[];
   }>;
 } | null;
@@ -449,6 +450,14 @@ function readFirstRecordFromArray(value: unknown): Record<string, unknown> | nul
   return null;
 }
 
+function readRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is Record<string, unknown> => isRecord(entry));
+}
+
 function summarizeReservation(portfolioState: unknown): string | null {
   if (!isRecord(portfolioState)) {
     return null;
@@ -555,6 +564,55 @@ function scoreActivePositionScopeVisibility(scope: Record<string, unknown>): num
         score += 1;
       }
       if (readString(freshness['source_kind'])) {
+        score += 1;
+      }
+    }
+  }
+
+  const actionCapacities = readRecordArray(scope['action_capacities']);
+  score += actionCapacities.length * 2;
+  for (const actionCapacity of actionCapacities) {
+    if (readString(actionCapacity['control_path'])) {
+      score += 1;
+    }
+    if (readString(actionCapacity['capacity_kind'])) {
+      score += 1;
+    }
+    if (readString(actionCapacity['max_capacity'])) {
+      score += 2;
+    }
+    const limitingConstraints = readStringArray(actionCapacity['limiting_constraints']);
+    if (limitingConstraints) {
+      score += limitingConstraints.length;
+    }
+
+    const observedState = readRecordKey(actionCapacity, 'observed_state');
+    if (observedState) {
+      if (readString(observedState['total_supplied_usd'])) {
+        score += 1;
+      }
+      if (readString(observedState['total_borrowed_usd'])) {
+        score += 1;
+      }
+      if (readString(observedState['available_borrows_usd'])) {
+        score += 1;
+      }
+      if (readString(observedState['liquidation_threshold_borrow_capacity_usd'])) {
+        score += 1;
+      }
+      if (readFiniteNumber(observedState['current_ltv_bps']) !== null) {
+        score += 1;
+      }
+      if (readFiniteNumber(observedState['liquidation_threshold_bps']) !== null) {
+        score += 1;
+      }
+      if (readString(observedState['health_factor'])) {
+        score += 1;
+      }
+      if (readString(observedState['normalized_health_factor'])) {
+        score += 1;
+      }
+      if (readString(observedState['health_factor_status'])) {
         score += 1;
       }
     }
@@ -1354,6 +1412,99 @@ function appendActivePositionScopesXml(input: {
       }
 
       input.lines.push('      </market_state>');
+    }
+
+    const actionCapacities = readRecordArray(scope['action_capacities']);
+    if (actionCapacities.length > 0) {
+      input.lines.push('      <action_capacities>');
+      for (const actionCapacity of actionCapacities) {
+        const controlPath = readString(actionCapacity['control_path']);
+        const capacityKind = readString(actionCapacity['capacity_kind']);
+        const attributes = [
+          controlPath ? `control_path="${escapeXml(controlPath)}"` : null,
+          capacityKind ? `capacity_kind="${escapeXml(capacityKind)}"` : null,
+        ]
+          .filter((value): value is string => value !== null)
+          .join(' ');
+        input.lines.push(`        <action_capacity${attributes ? ` ${attributes}` : ''}>`);
+
+        const maxCapacity = readString(actionCapacity['max_capacity']);
+        if (maxCapacity) {
+          input.lines.push(`          <max_capacity>${escapeXml(maxCapacity)}</max_capacity>`);
+        }
+
+        const limitingConstraints = readStringArray(actionCapacity['limiting_constraints']);
+        if (limitingConstraints) {
+          input.lines.push('          <limiting_constraints>');
+          for (const constraint of limitingConstraints) {
+            input.lines.push(`            <constraint>${escapeXml(constraint)}</constraint>`);
+          }
+          input.lines.push('          </limiting_constraints>');
+        }
+
+        const observedState = readRecordKey(actionCapacity, 'observed_state');
+        if (observedState) {
+          input.lines.push('          <observed_state>');
+          const totalSuppliedUsd = readString(observedState['total_supplied_usd']);
+          if (totalSuppliedUsd) {
+            input.lines.push(
+              `            <total_supplied_usd>${escapeXml(totalSuppliedUsd)}</total_supplied_usd>`,
+            );
+          }
+          const totalBorrowedUsd = readString(observedState['total_borrowed_usd']);
+          if (totalBorrowedUsd) {
+            input.lines.push(
+              `            <total_borrowed_usd>${escapeXml(totalBorrowedUsd)}</total_borrowed_usd>`,
+            );
+          }
+          const availableBorrowsUsd = readString(observedState['available_borrows_usd']);
+          if (availableBorrowsUsd) {
+            input.lines.push(
+              `            <available_borrows_usd>${escapeXml(availableBorrowsUsd)}</available_borrows_usd>`,
+            );
+          }
+          const liquidationThresholdBorrowCapacityUsd = readString(
+            observedState['liquidation_threshold_borrow_capacity_usd'],
+          );
+          if (liquidationThresholdBorrowCapacityUsd) {
+            input.lines.push(
+              `            <liquidation_threshold_borrow_capacity_usd>${escapeXml(liquidationThresholdBorrowCapacityUsd)}</liquidation_threshold_borrow_capacity_usd>`,
+            );
+          }
+          const currentLtvBps = readFiniteNumber(observedState['current_ltv_bps']);
+          if (currentLtvBps !== null) {
+            input.lines.push(`            <current_ltv_bps>${currentLtvBps}</current_ltv_bps>`);
+          }
+          const liquidationThresholdBps = readFiniteNumber(
+            observedState['liquidation_threshold_bps'],
+          );
+          if (liquidationThresholdBps !== null) {
+            input.lines.push(
+              `            <liquidation_threshold_bps>${liquidationThresholdBps}</liquidation_threshold_bps>`,
+            );
+          }
+          const healthFactor = readString(observedState['health_factor']);
+          if (healthFactor) {
+            input.lines.push(`            <health_factor>${escapeXml(healthFactor)}</health_factor>`);
+          }
+          const normalizedHealthFactor = readString(observedState['normalized_health_factor']);
+          if (normalizedHealthFactor) {
+            input.lines.push(
+              `            <normalized_health_factor>${escapeXml(normalizedHealthFactor)}</normalized_health_factor>`,
+            );
+          }
+          const healthFactorStatus = readString(observedState['health_factor_status']);
+          if (healthFactorStatus) {
+            input.lines.push(
+              `            <health_factor_status>${escapeXml(healthFactorStatus)}</health_factor_status>`,
+            );
+          }
+          input.lines.push('          </observed_state>');
+        }
+
+        input.lines.push('        </action_capacity>');
+      }
+      input.lines.push('      </action_capacities>');
     }
 
     const members = Array.isArray(scope['members'])

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -3324,10 +3324,13 @@ function buildCreateTransactionIdempotencyKey(input: {
 function buildRequestExecutionIdempotencyKey(input: {
   threadId: string;
   transactionPlanId: string;
+  retryNonce?: string;
 }): string {
-  return `idem-request-execution-${input.threadId}-${buildStableCommandSuffix({
+  const base = `idem-request-execution-${input.threadId}-${buildStableCommandSuffix({
     transactionPlanId: input.transactionPlanId,
   })}`;
+
+  return input.retryNonce ? `${base}:retry:${input.retryNonce}` : base;
 }
 
 function buildCreateTransactionRequest(input: {
@@ -3433,6 +3436,31 @@ function readTransactionPlanId(
   }
 
   return null;
+}
+
+function shouldStartFreshExecutionRequestAttempt(
+  state: EmberLendingLifecycleState,
+  transactionPlanId: string,
+): boolean {
+  if (state.pendingExecutionSubmission?.transactionPlanId === transactionPlanId) {
+    return false;
+  }
+
+  const lastExecutionResult = isRecord(state.lastExecutionResult) ? state.lastExecutionResult : null;
+  if (!lastExecutionResult) {
+    return false;
+  }
+
+  if (readString(lastExecutionResult['transaction_plan_id']) !== transactionPlanId) {
+    return false;
+  }
+
+  if (readString(lastExecutionResult['phase']) !== 'completed') {
+    return false;
+  }
+
+  const execution = readRecordKey(lastExecutionResult, 'execution');
+  return readString(execution?.['status']) === 'failed_before_submission';
 }
 
 function buildExecutionPreparationContinuationIdempotencyKey(input: {
@@ -4237,6 +4265,15 @@ export function createEmberLendingDomain(
           const idempotencyKey = buildRequestExecutionIdempotencyKey({
             threadId,
             transactionPlanId,
+            ...(shouldStartFreshExecutionRequestAttempt(currentState, transactionPlanId)
+              ? {
+                  retryNonce: crypto
+                    .createHash('sha256')
+                    .update(crypto.randomUUID())
+                    .digest('hex')
+                    .slice(0, 12),
+                }
+              : {}),
           });
           const runExecutionAttempt = (state: EmberLendingLifecycleState) =>
             state.pendingExecutionSubmission?.transactionPlanId === transactionPlanId &&

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -352,6 +352,15 @@ function isSharedEmberRevisionConflict(error: unknown): boolean {
   );
 }
 
+function isSharedEmberActiveDelegationMismatch(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(
+      'Shared Ember Domain Service JSON-RPC error: internal_error: signed transaction must match the active delegation id',
+    )
+  );
+}
+
 function readSharedEmberRevisionConflictMessage(error: Error): string {
   const match = error.message.match(/expected_revision=(\d+)\s+actual_revision=(\d+)/);
   if (!match) {
@@ -365,6 +374,10 @@ function readSharedEmberRevisionConflictMessage(error: Error): string {
 function normalizeSharedEmberExecutionErrorMessage(error: Error): string {
   if (isSharedEmberRevisionConflict(error)) {
     return readSharedEmberRevisionConflictMessage(error);
+  }
+
+  if (isSharedEmberActiveDelegationMismatch(error)) {
+    return 'Lending execution signing became stale because Shared Ember refreshed the active delegation. Retry execution to prepare a fresh signing package.';
   }
 
   if (
@@ -4225,57 +4238,80 @@ export function createEmberLendingDomain(
             threadId,
             transactionPlanId,
           });
+          const runExecutionAttempt = (state: EmberLendingLifecycleState) =>
+            state.pendingExecutionSubmission?.transactionPlanId === transactionPlanId &&
+            state.pendingExecutionSubmission?.idempotencyKey === idempotencyKey
+              ? resumePendingExecutionSubmission({
+                  protocolHost: options.protocolHost,
+                  threadId,
+                  agentId,
+                  pendingSubmission: state.pendingExecutionSubmission,
+                })
+              : runPreparedExecutionFlow({
+                  protocolHost: options.protocolHost,
+                  runtimeSigning: options.runtimeSigning,
+                  anchoredPayloadResolver: options.anchoredPayloadResolver,
+                  runtimeSignerRef: options.runtimeSignerRef,
+                  requestRedelegationRefresh: options.requestRedelegationRefresh,
+                  threadId,
+                  agentId,
+                  currentState: state,
+                  transactionPlanId,
+                  idempotencyKey,
+                });
           let preparedExecutionResult: Awaited<ReturnType<typeof runPreparedExecutionFlow>>;
+          let executionAttemptState = currentState;
           try {
-            preparedExecutionResult =
-              currentState.pendingExecutionSubmission?.transactionPlanId === transactionPlanId &&
-              currentState.pendingExecutionSubmission?.idempotencyKey === idempotencyKey
-                ? await resumePendingExecutionSubmission({
-                    protocolHost: options.protocolHost,
-                    threadId,
-                    agentId,
-                    pendingSubmission: currentState.pendingExecutionSubmission,
-                  })
-                : await runPreparedExecutionFlow({
-                    protocolHost: options.protocolHost,
-                    runtimeSigning: options.runtimeSigning,
-                    anchoredPayloadResolver: options.anchoredPayloadResolver,
-                    runtimeSignerRef: options.runtimeSignerRef,
-                    requestRedelegationRefresh: options.requestRedelegationRefresh,
-                    threadId,
-                    agentId,
-                    currentState,
-                    transactionPlanId,
-                    idempotencyKey,
-                  });
+            preparedExecutionResult = await runExecutionAttempt(executionAttemptState);
           } catch (error) {
-            if (!(error instanceof Error)) {
-              throw error;
+            if (
+              isSharedEmberActiveDelegationMismatch(error) &&
+              executionAttemptState.pendingExecutionSubmission
+            ) {
+              executionAttemptState = {
+                ...executionAttemptState,
+                pendingExecutionSubmission: null,
+                lastSharedEmberRevision: mergeKnownRevision(
+                  executionAttemptState.lastSharedEmberRevision,
+                  error instanceof PendingExecutionSubmissionError ? error.revision : null,
+                ),
+              };
+              try {
+                preparedExecutionResult = await runExecutionAttempt(executionAttemptState);
+              } catch (retryError) {
+                error = retryError;
+              }
             }
 
-            return {
-              state: {
-                ...currentState,
-                phase: 'active',
-                lastSharedEmberRevision:
-                  error instanceof LocalExecutionFailureError ||
-                  error instanceof PendingExecutionSubmissionError
-                    ? error.revision ?? currentState.lastSharedEmberRevision
-                    : currentState.lastSharedEmberRevision,
-                lastExecutionResult: currentState.lastExecutionResult,
-                lastExecutionTxHash: null,
-                pendingExecutionSubmission:
-                  error instanceof PendingExecutionSubmissionError
-                    ? error.pendingSubmission
-                    : null,
-              },
-              outputs: {
-                status: {
-                  executionStatus: 'failed',
-                  statusMessage: normalizeSharedEmberExecutionErrorMessage(error),
+            if (preparedExecutionResult === undefined) {
+              if (!(error instanceof Error)) {
+                throw error;
+              }
+
+              return {
+                state: {
+                  ...executionAttemptState,
+                  phase: 'active',
+                  lastSharedEmberRevision:
+                    error instanceof LocalExecutionFailureError ||
+                    error instanceof PendingExecutionSubmissionError
+                      ? error.revision ?? executionAttemptState.lastSharedEmberRevision
+                      : executionAttemptState.lastSharedEmberRevision,
+                  lastExecutionResult: currentState.lastExecutionResult,
+                  lastExecutionTxHash: null,
+                  pendingExecutionSubmission:
+                    error instanceof PendingExecutionSubmissionError
+                      ? error.pendingSubmission
+                      : null,
                 },
-              },
-            };
+                outputs: {
+                  status: {
+                    executionStatus: 'failed',
+                    statusMessage: normalizeSharedEmberExecutionErrorMessage(error),
+                  },
+                },
+              };
+            }
           }
 
           const executionResult = preparedExecutionResult.executionResult ?? null;

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -4247,6 +4247,7 @@ export function createEmberLendingDomain(
               },
             };
           }
+          const protocolHost = options.protocolHost;
 
           const transactionPlanId = readTransactionPlanId(operation.input, currentState);
           if (!transactionPlanId) {
@@ -4279,13 +4280,13 @@ export function createEmberLendingDomain(
             state.pendingExecutionSubmission?.transactionPlanId === transactionPlanId &&
             state.pendingExecutionSubmission?.idempotencyKey === idempotencyKey
               ? resumePendingExecutionSubmission({
-                  protocolHost: options.protocolHost,
+                  protocolHost,
                   threadId,
                   agentId,
                   pendingSubmission: state.pendingExecutionSubmission,
                 })
               : runPreparedExecutionFlow({
-                  protocolHost: options.protocolHost,
+                  protocolHost,
                   runtimeSigning: options.runtimeSigning,
                   anchoredPayloadResolver: options.anchoredPayloadResolver,
                   runtimeSignerRef: options.runtimeSignerRef,
@@ -4296,7 +4297,8 @@ export function createEmberLendingDomain(
                   transactionPlanId,
                   idempotencyKey,
                 });
-          let preparedExecutionResult: Awaited<ReturnType<typeof runPreparedExecutionFlow>>;
+          let preparedExecutionResult: Awaited<ReturnType<typeof runPreparedExecutionFlow>> | null =
+            null;
           let executionAttemptState = currentState;
           try {
             preparedExecutionResult = await runExecutionAttempt(executionAttemptState);
@@ -4320,7 +4322,7 @@ export function createEmberLendingDomain(
               }
             }
 
-            if (preparedExecutionResult === undefined) {
+            if (preparedExecutionResult === null) {
               if (!(error instanceof Error)) {
                 throw error;
               }

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.ts
@@ -352,6 +352,32 @@ function isSharedEmberRevisionConflict(error: unknown): boolean {
   );
 }
 
+function readSharedEmberRevisionConflictMessage(error: Error): string {
+  const match = error.message.match(/expected_revision=(\d+)\s+actual_revision=(\d+)/);
+  if (!match) {
+    return 'Lending transaction plan is stale because Shared Ember state changed. Create a fresh plan and execute that new plan.';
+  }
+
+  const [, expectedRevision, actualRevision] = match;
+  return `Lending transaction plan is stale because Shared Ember state advanced from revision ${expectedRevision} to ${actualRevision}. Create a fresh plan and execute that new plan.`;
+}
+
+function normalizeSharedEmberExecutionErrorMessage(error: Error): string {
+  if (isSharedEmberRevisionConflict(error)) {
+    return readSharedEmberRevisionConflictMessage(error);
+  }
+
+  if (
+    error.message.includes(
+      'Shared Ember Domain Service JSON-RPC error: protocol_invalid_params: transaction_plan_id must reference an existing transaction plan',
+    )
+  ) {
+    return 'Lending transaction plan is no longer available in Shared Ember. Create a fresh plan and try again.';
+  }
+
+  return error.message;
+}
+
 async function readSharedEmberExecutionContext(input: {
   protocolHost: EmberLendingSharedEmberProtocolHost;
   threadId: string;
@@ -2084,6 +2110,7 @@ function readCommittedExecutionProgressEvent(input: {
   ) {
     const status = readString(matchingEvent.payload?.['status']);
     const executionId = readString(matchingEvent.payload?.['execution_id']);
+    const message = readString(matchingEvent.payload?.['message']);
     const transactionHash = readHexAddress(matchingEvent.payload?.['transaction_hash']);
 
     if (!status) {
@@ -2099,6 +2126,7 @@ function readCommittedExecutionProgressEvent(input: {
         execution: {
           status,
           ...(executionId ? { execution_id: executionId } : {}),
+          ...(message ? { message } : {}),
           ...(transactionHash ? { transaction_hash: transactionHash } : {}),
         },
       },
@@ -2158,9 +2186,9 @@ function readExecutionStatusMessage(executionResult: unknown): {
   if (phase === 'completed' && status === 'failed_before_submission') {
     return {
       executionStatus: 'failed',
-      statusMessage: withExecutionDetail(
-        'Lending transaction failed before submission through Shared Ember.',
-      ),
+      statusMessage: executionMessage
+        ? withExecutionDetail('Lending transaction failed before submission through Shared Ember.')
+        : 'Lending transaction failed before submission through Shared Ember. Create a fresh plan and try again if the problem persists.',
     };
   }
 
@@ -4244,7 +4272,7 @@ export function createEmberLendingDomain(
               outputs: {
                 status: {
                   executionStatus: 'failed',
-                  statusMessage: error.message,
+                  statusMessage: normalizeSharedEmberExecutionErrorMessage(error),
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -6706,6 +6706,62 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
+  it('surfaces a stale-plan message when Shared Ember keeps rejecting request_execution with expected_revision conflicts', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            'Shared Ember Domain Service JSON-RPC error: protocol_conflict expected_revision=7 actual_revision=8',
+          ),
+        )
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-read-current-revision',
+          result: {
+            protocol_version: 'v1',
+            revision: 8,
+          },
+        })
+        .mockRejectedValueOnce(
+          new Error(
+            'Shared Ember Domain Service JSON-RPC error: protocol_conflict expected_revision=8 actual_revision=9',
+          ),
+        ),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'borrow WBTC on Aave',
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_execution',
+      },
+    });
+
+    expect(result).toMatchObject({
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending transaction plan is stale because Shared Ember state advanced from revision 8 to 9. Create a fresh plan and execute that new plan.',
+        },
+      },
+    });
+  });
+
   it('keys signed-transaction submit idempotency by the exact signed artifact', async () => {
     const protocolHost = {
       handleJsonRpc: vi
@@ -7053,6 +7109,124 @@ describe('createEmberLendingDomain', () => {
         status: {
           executionStatus: 'completed',
           statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+      },
+    });
+  });
+
+  it('preserves a failed-before-submission message recovered from the committed-event outbox', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            committed_event_ids: ['evt-prepare-execution-1'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:4010'))
+        .mockRejectedValueOnce(new Error('projection refresh unavailable')),
+      readCommittedEventOutbox: vi
+        .fn()
+        .mockResolvedValueOnce({
+          protocol_version: 'v1',
+          revision: 10,
+          events: [
+            {
+              event_id: 'evt-request-execution-3',
+              sequence: 3,
+              aggregate: 'request',
+              aggregate_id: 'req-ember-lending-execution-001',
+              event_type: 'requestExecution.completed.v1',
+              committed_at: '2026-04-01T06:18:00Z',
+              payload: {
+                request_id: 'req-ember-lending-execution-001',
+                transaction_plan_id: 'txplan-ember-lending-001',
+                execution_id: 'exec-ember-lending-001',
+                status: 'failed_before_submission',
+                message:
+                  'send_insufficient_funds: rpc_32000: insufficient funds for gas * price + value',
+                transaction_hash: null,
+              },
+            },
+          ],
+        }),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 10,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000b1',
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      runtimeSigning,
+      runtimeSignerRef: 'service-wallet',
+      agentId: 'ember-lending',
+    });
+    const initialState = {
+      ...createManagedLifecycleState(),
+      lastCandidatePlan: {
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+      lastCandidatePlanSummary: 'borrow WBTC on Aave',
+    };
+
+    const firstAttempt = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: initialState,
+      operation: {
+        source: 'tool',
+        name: 'request_execution',
+      },
+    });
+
+    const resumedAttempt = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: firstAttempt?.state,
+      operation: {
+        source: 'tool',
+        name: 'request_execution',
+      },
+    });
+
+    expect(runtimeSigning.signPayload).toHaveBeenCalledTimes(1);
+    expect(resumedAttempt).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 10,
+        lastExecutionResult: {
+          phase: 'completed',
+          request_id: 'req-ember-lending-execution-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          execution: {
+            execution_id: 'exec-ember-lending-001',
+            status: 'failed_before_submission',
+            message:
+              'send_insufficient_funds: rpc_32000: insufficient funds for gas * price + value',
+          },
+        },
+        lastExecutionTxHash: null,
+        pendingExecutionSubmission: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Lending transaction failed before submission through Shared Ember: send_insufficient_funds: rpc_32000: insufficient funds for gas * price + value.',
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -630,6 +630,7 @@ function createReadyForExecutionSigningPreparationResult(input?: {
   executionPreparationId?: string;
   canonicalUnsignedPayloadRef?: string;
   plannedTransactionPayloadRef?: string;
+  activeDelegationId?: string;
 }) {
   const executionPreparationId =
     input?.executionPreparationId ?? 'execprep-ember-lending-001';
@@ -637,6 +638,7 @@ function createReadyForExecutionSigningPreparationResult(input?: {
     input?.canonicalUnsignedPayloadRef ?? 'unsigned-txpayload-ember-lending-001';
   const plannedTransactionPayloadRef =
     input?.plannedTransactionPayloadRef ?? 'txpayload-ember-lending-001';
+  const activeDelegationId = input?.activeDelegationId ?? 'del-ember-lending-001';
   return {
     phase: 'ready_for_execution_signing',
     transaction_plan_id: 'txplan-ember-lending-001',
@@ -653,7 +655,7 @@ function createReadyForExecutionSigningPreparationResult(input?: {
       reservation_id: 'reservation-ember-lending-001',
       required_control_path: 'lending.supply',
       canonical_unsigned_payload_ref: canonicalUnsignedPayloadRef,
-      active_delegation_id: 'del-ember-lending-001',
+      active_delegation_id: activeDelegationId,
       root_delegation_id: 'root-user-ember-lending-001',
       prepared_at: '2026-04-01T06:15:00.000Z',
       metadata: {
@@ -664,7 +666,7 @@ function createReadyForExecutionSigningPreparationResult(input?: {
       execution_preparation_id: executionPreparationId,
       transaction_plan_id: 'txplan-ember-lending-001',
       request_id: 'req-ember-lending-execution-001',
-      active_delegation_id: 'del-ember-lending-001',
+      active_delegation_id: activeDelegationId,
       delegation_artifact_ref: 'metamask-delegation:delegation-ember-lending-001',
       root_delegation_artifact_ref: 'metamask-delegation:root-ember-lending-001',
       canonical_unsigned_payload_ref: canonicalUnsignedPayloadRef,
@@ -7227,6 +7229,165 @@ describe('createEmberLendingDomain', () => {
           executionStatus: 'failed',
           statusMessage:
             'Lending transaction failed before submission through Shared Ember: send_insufficient_funds: rpc_32000: insufficient funds for gas * price + value.',
+        },
+      },
+    });
+  });
+
+  it('re-prepares execution when a cached submission uses a stale active delegation id', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            'Shared Ember Domain Service JSON-RPC error: internal_error: signed transaction must match the active delegation id (expected del-ember-lending-002, got del-ember-lending-001)',
+          ),
+        )
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-prepare-execution-2'],
+            execution_result: createReadyForExecutionSigningPreparationResult({
+              executionPreparationId: 'execprep-ember-lending-002',
+              canonicalUnsignedPayloadRef: 'unsigned-txpayload-ember-lending-002',
+              plannedTransactionPayloadRef: 'txpayload-ember-lending-002',
+              activeDelegationId: 'del-ember-lending-002',
+            }),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 11,
+            committed_event_ids: ['evt-request-execution-3'],
+            execution_result: createTerminalExecutionResult({
+              status: 'confirmed',
+              transactionHash:
+                '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            }),
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 9,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000b1',
+        signedPayload: {
+          signature: ALT_TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      runtimeSigning,
+      runtimeSignerRef: 'service-wallet',
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'borrow WBTC on Aave',
+        pendingExecutionSubmission: {
+          transactionPlanId: 'txplan-ember-lending-001',
+          requestId: 'req-ember-lending-execution-001',
+          idempotencyKey: DEFAULT_EXECUTION_IDEMPOTENCY_KEY,
+          signedTransaction: {
+            execution_preparation_id: 'execprep-ember-lending-001',
+            transaction_plan_id: 'txplan-ember-lending-001',
+            request_id: 'req-ember-lending-execution-001',
+            active_delegation_id: 'del-ember-lending-001',
+            canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-001',
+            signer_address: '0x00000000000000000000000000000000000000b1',
+            raw_transaction: '0xdeadbeef',
+          },
+          revision: 9,
+        },
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_execution',
+      },
+    });
+
+    expect(runtimeSigning.signPayload).toHaveBeenCalledTimes(1);
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: expect.objectContaining({
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: expect.objectContaining({
+          active_delegation_id: 'del-ember-lending-001',
+        }),
+      }),
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-execution',
+      method: 'subagent.requestExecution.v1',
+      params: {
+        idempotency_key: DEFAULT_EXECUTION_IDEMPOTENCY_KEY,
+        expected_revision: 9,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-signed-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: expect.objectContaining({
+        transaction_plan_id: 'txplan-ember-lending-001',
+        signed_transaction: expect.objectContaining({
+          execution_preparation_id: 'execprep-ember-lending-002',
+          active_delegation_id: 'del-ember-lending-002',
+          canonical_unsigned_payload_ref: 'unsigned-txpayload-ember-lending-002',
+        }),
+      }),
+    });
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 11,
+        lastExecutionResult: {
+          phase: 'completed',
+          request_id: 'req-ember-lending-execution-001',
+          transaction_plan_id: 'txplan-ember-lending-001',
+          execution: {
+            execution_id: 'exec-ember-lending-001',
+            status: 'confirmed',
+            transaction_hash:
+              '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
+        },
+        lastExecutionTxHash:
+          '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        pendingExecutionSubmission: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -130,67 +130,7 @@ function createManagedLifecycleState() {
         },
       ],
       active_position_scopes: [
-        {
-          scope_id:
-            'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
-          kind: 'lending',
-          scope_type_id: 'lending.aave.position',
-          root_user_wallet: '0x00000000000000000000000000000000000000a1',
-          network: 'arbitrum',
-          protocol_system: 'aave',
-          container_ref: 'aave:0x00000000000000000000000000000000000000a1',
-          status: 'active',
-          market_state: {
-            available_borrows_usd: '63.00',
-            borrowable_headroom_usd: '63.00',
-            current_ltv_bps: 3000,
-            liquidation_threshold_bps: 8400,
-            health_factor: '1.42',
-            freshness: {
-              derived_at: '2026-04-01T06:00:00.000Z',
-              oldest_observed_at: '2026-04-01T05:59:00.000Z',
-              latest_observed_at: '2026-04-01T06:00:00.000Z',
-              source_kind: 'valuation_ref',
-            },
-          },
-          members: [
-            {
-              member_id:
-                'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
-              role: 'collateral',
-              asset: 'aArbUSDC',
-              quantity: '90',
-              value_usd: '90.00',
-              economic_exposures: [
-                {
-                  asset: 'USDC',
-                  quantity: '90',
-                },
-              ],
-              state: {
-                withdrawable_quantity: '63',
-                supply_apr: '0.03',
-              },
-            },
-            {
-              member_id:
-                'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
-              role: 'debt',
-              asset: 'variableDebtArbUSDC',
-              quantity: '27',
-              value_usd: '27.00',
-              economic_exposures: [
-                {
-                  asset: 'USDC',
-                  quantity: '27',
-                },
-              ],
-              state: {
-                borrow_apr: '0.05',
-              },
-            },
-          ],
-        },
+        createActivePositionScope(),
       ],
       owned_units: [
         {
@@ -242,6 +182,89 @@ function createManagedMandateContext() {
   };
 }
 
+function createActivePositionScope() {
+  return {
+    scope_id:
+      'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
+    kind: 'lending',
+    scope_type_id: 'lending.aave.position',
+    root_user_wallet: '0x00000000000000000000000000000000000000a1',
+    network: 'arbitrum',
+    protocol_system: 'aave',
+    container_ref: 'aave:0x00000000000000000000000000000000000000a1',
+    status: 'active',
+    market_state: {
+      available_borrows_usd: '63.00',
+      borrowable_headroom_usd: '63.00',
+      current_ltv_bps: 3000,
+      liquidation_threshold_bps: 8400,
+      health_factor: '1.42',
+      freshness: {
+        derived_at: '2026-04-01T06:00:00.000Z',
+        oldest_observed_at: '2026-04-01T05:59:00.000Z',
+        latest_observed_at: '2026-04-01T06:00:00.000Z',
+        source_kind: 'valuation_ref',
+      },
+    },
+    action_capacities: [
+      {
+        control_path: 'lending.borrow',
+        capacity_kind: 'usd',
+        max_capacity: '48.00',
+        limiting_constraints: ['mandate_max_ltv'],
+        observed_state: {
+          total_supplied_usd: '90.00',
+          total_borrowed_usd: '27.00',
+          available_borrows_usd: '63.00',
+          liquidation_threshold_borrow_capacity_usd: '67.00',
+          current_ltv_bps: 3000,
+          liquidation_threshold_bps: 8400,
+          health_factor: '1.42',
+          normalized_health_factor: '1.42',
+          health_factor_status: 'measured',
+        },
+      },
+    ],
+    members: [
+      {
+        member_id:
+          'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
+        role: 'collateral',
+        asset: 'aArbUSDC',
+        quantity: '90',
+        value_usd: '90.00',
+        economic_exposures: [
+          {
+            asset: 'USDC',
+            quantity: '90',
+          },
+        ],
+        state: {
+          withdrawable_quantity: '63',
+          supply_apr: '0.03',
+        },
+      },
+      {
+        member_id:
+          'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
+        role: 'debt',
+        asset: 'variableDebtArbUSDC',
+        quantity: '27',
+        value_usd: '27.00',
+        economic_exposures: [
+          {
+            asset: 'USDC',
+            quantity: '27',
+          },
+        ],
+        state: {
+          borrow_apr: '0.05',
+        },
+      },
+    ],
+  };
+}
+
 function createPortfolioStateResponse() {
   return {
     jsonrpc: '2.0',
@@ -277,67 +300,7 @@ function createPortfolioStateResponse() {
           },
         ],
         active_position_scopes: [
-          {
-            scope_id:
-              'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
-            kind: 'lending',
-            scope_type_id: 'lending.aave.position',
-            root_user_wallet: '0x00000000000000000000000000000000000000a1',
-            network: 'arbitrum',
-            protocol_system: 'aave',
-            container_ref: 'aave:0x00000000000000000000000000000000000000a1',
-            status: 'active',
-            market_state: {
-              available_borrows_usd: '63.00',
-              borrowable_headroom_usd: '63.00',
-              current_ltv_bps: 3000,
-              liquidation_threshold_bps: 8400,
-              health_factor: '1.42',
-              freshness: {
-                derived_at: '2026-04-01T06:00:00.000Z',
-                oldest_observed_at: '2026-04-01T05:59:00.000Z',
-                latest_observed_at: '2026-04-01T06:00:00.000Z',
-                source_kind: 'valuation_ref',
-              },
-            },
-            members: [
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
-                role: 'collateral',
-                asset: 'aArbUSDC',
-                quantity: '90',
-                value_usd: '90.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '90',
-                  },
-                ],
-                state: {
-                  withdrawable_quantity: '63',
-                  supply_apr: '0.03',
-                },
-              },
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
-                role: 'debt',
-                asset: 'variableDebtArbUSDC',
-                quantity: '27',
-                value_usd: '27.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '27',
-                  },
-                ],
-                state: {
-                  borrow_apr: '0.05',
-                },
-              },
-            ],
-          },
+          createActivePositionScope(),
         ],
         owned_units: [
           {
@@ -456,67 +419,7 @@ function createExecutionContextResponse() {
         subagent_wallet_address: '0x00000000000000000000000000000000000000b1',
         root_user_wallet_address: '0x00000000000000000000000000000000000000a1',
         active_position_scopes: [
-          {
-            scope_id:
-              'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1',
-            kind: 'lending',
-            scope_type_id: 'lending.aave.position',
-            root_user_wallet: '0x00000000000000000000000000000000000000a1',
-            network: 'arbitrum',
-            protocol_system: 'aave',
-            container_ref: 'aave:0x00000000000000000000000000000000000000a1',
-            status: 'active',
-            market_state: {
-              available_borrows_usd: '63.00',
-              borrowable_headroom_usd: '63.00',
-              current_ltv_bps: 3000,
-              liquidation_threshold_bps: 8400,
-              health_factor: '1.42',
-              freshness: {
-                derived_at: '2026-04-01T06:00:00.000Z',
-                oldest_observed_at: '2026-04-01T05:59:00.000Z',
-                latest_observed_at: '2026-04-01T06:00:00.000Z',
-                source_kind: 'valuation_ref',
-              },
-            },
-            members: [
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC',
-                role: 'collateral',
-                asset: 'aArbUSDC',
-                quantity: '90',
-                value_usd: '90.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '90',
-                  },
-                ],
-                state: {
-                  withdrawable_quantity: '63',
-                  supply_apr: '0.03',
-                },
-              },
-              {
-                member_id:
-                  'position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:debt:USDC',
-                role: 'debt',
-                asset: 'variableDebtArbUSDC',
-                quantity: '27',
-                value_usd: '27.00',
-                economic_exposures: [
-                  {
-                    asset: 'USDC',
-                    quantity: '27',
-                  },
-                ],
-                state: {
-                  borrow_apr: '0.05',
-                },
-              },
-            ],
-          },
+          createActivePositionScope(),
         ],
         wallet_contents: [
           {
@@ -1158,6 +1061,9 @@ describe('createEmberLendingDomain', () => {
         '      <protocol_system>aave</protocol_system>',
         '      <market_state>',
         '        <health_factor>1.42</health_factor>',
+        '      <action_capacities>',
+        '        <action_capacity control_path="lending.borrow" capacity_kind="usd">',
+        '          <max_capacity>48.00</max_capacity>',
         '      <members>',
         '        <member member_id="position-scope-aave-arbitrum-0x00000000000000000000000000000000000000a1:collateral:USDC" role="collateral" asset="aArbUSDC">',
         '          <value_usd>90.00</value_usd>',
@@ -1317,6 +1223,9 @@ describe('createEmberLendingDomain', () => {
         '  <active_position_scopes>',
         '      <protocol_system>aave</protocol_system>',
         '        <borrowable_headroom_usd>63.00</borrowable_headroom_usd>',
+        '      <action_capacities>',
+        '        <action_capacity control_path="lending.borrow" capacity_kind="usd">',
+        '          <max_capacity>48.00</max_capacity>',
         '    <wallet_balance asset="USDC" network="arbitrum">',
         '      <value_usd>100.00</value_usd>',
       ]),
@@ -1366,6 +1275,9 @@ describe('createEmberLendingDomain', () => {
         '      <protocol_system>aave</protocol_system>',
         '      <market_state>',
         '        <health_factor>1.42</health_factor>',
+        '      <action_capacities>',
+        '        <action_capacity control_path="lending.borrow" capacity_kind="usd">',
+        '          <max_capacity>48.00</max_capacity>',
       ]),
     );
     expect(context?.join('\n')).toContain('<active_reservations>');

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/sharedEmberAdapter.unit.test.ts
@@ -7234,6 +7234,110 @@ describe('createEmberLendingDomain', () => {
     });
   });
 
+  it('uses a fresh request-execution idempotency key after a failed-before-submission result for the same plan', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-prepare-execution-2'],
+            execution_result: createReadyForExecutionSigningPreparationResult(),
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-signed-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 11,
+            committed_event_ids: ['evt-submit-execution-2'],
+            execution_result: createTerminalExecutionResult({
+              status: 'confirmed',
+              transactionHash:
+                '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            }),
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 11,
+        consumer_id: 'ember-lending',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000b1',
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const domain = createEmberLendingDomain({
+      protocolHost,
+      runtimeSigning,
+      runtimeSignerRef: 'service-wallet',
+      agentId: 'ember-lending',
+    });
+
+    const result = await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        ...createManagedLifecycleState(),
+        lastCandidatePlan: {
+          transaction_plan_id: 'txplan-ember-lending-001',
+        },
+        lastCandidatePlanSummary: 'borrow WBTC on Aave',
+        lastExecutionResult: createTerminalExecutionResult({
+          status: 'failed_before_submission',
+          message:
+            'send_insufficient_funds: rpc_32000: insufficient funds for gas * price + value',
+        }),
+      },
+      operation: {
+        source: 'tool',
+        name: 'request_execution',
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-execution',
+      method: 'subagent.requestExecution.v1',
+      params: {
+        idempotency_key: expect.stringMatching(
+          /^idem-request-execution-thread-1-07b74ae67cd9:retry:[0-9a-f]{12}$/,
+        ),
+        expected_revision: 7,
+        transaction_plan_id: 'txplan-ember-lending-001',
+      },
+    });
+    expect(result).toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 11,
+        lastExecutionTxHash:
+          '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Lending transaction execution confirmed through Shared Ember.',
+        },
+      },
+    });
+  });
+
   it('re-prepares execution when a cached submission uses a stale active delegation id', async () => {
     const protocolHost = {
       handleJsonRpc: vi

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useCallback, useEffect, useRef, type ComponentProps } from 'react';
 import { useSearchParams } from 'next/navigation';
 import type { Message } from '@ag-ui/core';
+import { useLogin } from '@privy-io/react-auth';
 import { AgentDetailPage } from '@/components/AgentDetailPage';
 import { getAgentConfig, isRegisteredAgentId } from '@/config/agents';
 import { useAgent } from '@/contexts/AgentContext';
@@ -10,6 +11,7 @@ import { usePrivyWalletClient } from '@/hooks/usePrivyWalletClient';
 import { invokeAgentCommandRoute } from '@/utils/agentCommandRoute';
 import { getAgentThreadId } from '@/utils/agentThread';
 import { navigateToHref } from '@/utils/hardNavigation';
+import { isPrivyConfigured } from '@/utils/privyConfig';
 
 type UiPreviewState = 'prehire' | 'onboarding' | 'active';
 type UiPreviewFixture = 'managed';
@@ -117,6 +119,7 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const { id } = use(params);
   const searchParams = useSearchParams();
   const agent = useAgent();
+  const { login } = useLogin();
   const { privyWallet } = usePrivyWalletClient();
   const activeAgentId = agent.config.id;
   const routeAgentId = id;
@@ -153,12 +156,26 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const handleBack = () => {
     navigateToHref('/hire-agents');
   };
+  const handleWalletGate = useCallback(() => {
+    if (isPrivyConfigured()) {
+      login();
+      return;
+    }
+
+    navigateToHref('/wallet');
+  }, [login]);
   const handleManagedOwnerNavigation = (ownerAgentId: string) => {
+    if (!getAgentThreadId(ownerAgentId, privyWallet?.address)) {
+      handleWalletGate();
+      return;
+    }
     navigateToHref(`/hire-agents/${ownerAgentId}`);
   };
   const handleHire = onboardingOwnerAgentId
     ? () => handleManagedOwnerNavigation(onboardingOwnerAgentId)
-    : agent.runHire;
+    : agent.threadId
+      ? agent.runHire
+      : handleWalletGate;
   const handleFire = onboardingOwnerAgentId
     ? () => handleManagedOwnerNavigation(onboardingOwnerAgentId)
     : agent.runFire;

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   replace: vi.fn(),
   navigateToHref: vi.fn(),
+  login: vi.fn(),
   invokeAgentCommandRoute: vi.fn(),
   getAgentThreadId: vi.fn(),
   applyDomainProjection: vi.fn(),
@@ -42,6 +43,16 @@ vi.mock('@/hooks/usePrivyWalletClient', () => ({
       address: '0x1111111111111111111111111111111111111111',
     },
   }),
+}));
+
+vi.mock('@privy-io/react-auth', () => ({
+  useLogin: () => ({
+    login: mocks.login,
+  }),
+}));
+
+vi.mock('@/utils/privyConfig', () => ({
+  isPrivyConfigured: () => true,
 }));
 
 vi.mock('@/utils/agentCommandRoute', () => ({
@@ -154,6 +165,7 @@ describe('AgentDetailRoute managed mandate wiring', () => {
     mocks.push.mockReset();
     mocks.replace.mockReset();
     mocks.navigateToHref.mockReset();
+    mocks.login.mockReset();
     mocks.invokeAgentCommandRoute.mockReset();
     mocks.getAgentThreadId.mockReset();
     mocks.applyDomainProjection.mockReset();
@@ -231,6 +243,29 @@ describe('AgentDetailRoute managed mandate wiring', () => {
         mandateRef: 'mandate-ember-lending-001',
       },
     });
+  });
+
+  it('opens Privy login instead of no-op hire when only a derived thread id exists', async () => {
+    mocks.agentValue = createAgentValue({
+      config: {
+        id: 'inactive-agent',
+      },
+      threadId: undefined,
+      hasLoadedView: false,
+      hasAuthoritativeState: false,
+      isConnected: false,
+      isHired: false,
+      isActive: false,
+    });
+    mocks.getAgentThreadId.mockReturnValue('derived-thread-id');
+
+    await renderRoute('agent-portfolio-manager');
+
+    const props = readCapturedProps();
+    expect(typeof props.onHire).toBe('function');
+    (props.onHire as () => void)();
+
+    expect(mocks.login).toHaveBeenCalledTimes(1);
   });
 
   it('hydrates the PM page from refresh even when the hired PM thread is still marked onboarding', async () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.int.test.tsx
@@ -3487,6 +3487,93 @@ describe('useAgentConnection integration', () => {
     expect(latestValue?.uiError).toBeNull();
   });
 
+  it('resumes a thread-backed interrupt on the connected thread when the derived thread id has drifted', async () => {
+    let latestValue: ReturnType<typeof useAgentConnection> | null = null;
+    const payload = {
+      outcome: 'signed' as const,
+      signedDelegations: [
+        {
+          delegate: '0x0000000000000000000000000000000000000003' as const,
+          delegator: '0x0000000000000000000000000000000000000002' as const,
+          authority: '0x' as const,
+          caveats: [],
+          salt: '0x01' as const,
+          signature: '0x1234' as const,
+        },
+      ],
+    };
+
+    mocks.threadId = 'thread-live';
+    mocks.interruptState.activeInterrupt = {
+      type: 'portfolio-manager-delegation-signing-request',
+      message: 'Review and sign the delegation needed to activate your portfolio manager.',
+      chainId: 42161,
+      delegationManager: '0x0000000000000000000000000000000000000001',
+      delegatorAddress: '0x0000000000000000000000000000000000000002',
+      delegateeAddress: '0x0000000000000000000000000000000000000003',
+      delegationsToSign: [
+        {
+          delegate: '0x0000000000000000000000000000000000000003',
+          delegator: '0x0000000000000000000000000000000000000002',
+          authority: '0x',
+          caveats: [],
+          salt: '0x01',
+        },
+      ],
+      descriptions: ['delegate portfolio-manager actions'],
+      warnings: [],
+    };
+    mocks.interruptState.canResolve = true;
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(mocks.agent.threadId).toBe('thread-live');
+
+    mocks.runtimeStatus = mocks.runtimeStatuses.Disconnected;
+    mocks.threadId = 'thread-drifted';
+
+    await act(async () => {
+      root.render(
+        <CapturingHarness
+          agentId="agent-portfolio-manager"
+          onSnapshot={(value) => {
+            latestValue = value;
+          }}
+        />,
+      );
+    });
+    await flushEffects();
+
+    latestValue?.resolveInterrupt(payload);
+    await flushEffects();
+
+    expect(mocks.disconnectFetch).toHaveBeenCalledWith(
+      '/api/agent-command',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          agentId: 'agent-portfolio-manager',
+          threadId: 'thread-live',
+          resume: payload,
+        }),
+      }),
+    );
+    expect(latestValue?.uiError).toBeNull();
+  });
+
   it('falls back to CopilotKit interrupt resolution when no thread id is available', async () => {
     let latestValue: ReturnType<typeof useAgentConnection> | null = null;
     const payload = {

--- a/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/hooks/useAgentConnection.ts
@@ -1855,7 +1855,8 @@ export function useAgentConnection(agentId: string): UseAgentConnectionResult {
             interruptType: interruptType ?? null,
             runInFlight: runInFlightRef.current,
           });
-          const currentThreadId = threadIdRef.current;
+          const currentThreadId =
+            currentAgent?.threadId ?? lastConnectedThreadRef.current ?? threadIdRef.current;
           if (currentThreadId) {
             await invokeAgentCommandRoute({
               agentId,


### PR DESCRIPTION
## Summary
- complete the remaining Shared Ember lending-read adoption by surfacing `active_position_scopes[*].action_capacities` in `agent-ember-lending`
- preserve the existing `next` baseline `market_state` and freshness handling alongside the new scoped capacity surface
- add default AG-UI connect-hydration coverage so scoped capacities survive persisted thread state

## Validation
- `cd typescript/clients/web-ag-ui/apps/agent-ember-lending && pnpm test:unit -- src/sharedEmberAdapter.unit.test.ts`
- `cd typescript/clients/web-ag-ui/apps/agent-ember-lending && pnpm test:int -- src/agUiServer.int.test.ts`
- `cd typescript/clients/web-ag-ui/apps/agent-ember-lending && pnpm build`

## Related
- Closes #596
- Split out of the mixed-scope #634 branch so app adoption can review independently from registry changes