### PR TITLE
chore: merge next into main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,6 @@ on:
     branches:
       - main
       - next
-    paths:
-      - "typescript/lib/agent-node/**"
-      - "typescript/onchain-actions-plugins/registry/**"
-      - "typescript/scripts/**"
-      - "typescript/release/**"
-      - "typescript/.multi-releaserc.cjs"
-      - ".github/workflows/release.yml"
 
 permissions:
   contents: write
@@ -51,12 +44,6 @@ jobs:
         with:
           node-version: 24.10.0
           registry-url: https://registry.npmjs.org
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Determine release targets
         id: targets
         env:

--- a/typescript/onchain-actions-plugins/registry/src/registry.ts
+++ b/typescript/onchain-actions-plugins/registry/src/registry.ts
@@ -48,6 +48,14 @@ export class PublicEmberPluginRegistry {
   }
 
   /**
+   * Returns the lifecycle capability registered for a provider id, if present.
+   * @param providerId Provider/plugin id to look up.
+   */
+  public getLifecycleCapability(providerId: string): LifecycleCapability | undefined {
+    return this.lifecycleCapabilities.get(providerId);
+  }
+
+  /**
    * Iterator for the registered Ember plugins.
    */
   public async *getPlugins(): AsyncIterable<EmberPlugin<PluginType>> {

--- a/typescript/onchain-actions-plugins/registry/src/registry.unit.test.ts
+++ b/typescript/onchain-actions-plugins/registry/src/registry.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LifecycleCapability } from './core/index.js';
+import { PublicEmberPluginRegistry } from './registry.js';
+
+function createLifecycleCapability(providerId: string): LifecycleCapability {
+  return {
+    providerId,
+    refreshScope: 'full-provider',
+    volatileActionTypes: [],
+    computeTopologySignature() {
+      return Promise.resolve(`${providerId}-signature`);
+    },
+    getSegmentTopologies() {
+      return Promise.resolve([]);
+    },
+  };
+}
+
+describe('PublicEmberPluginRegistry lifecycle capability lookups', () => {
+  it('returns the lifecycle capability for a registered provider id', () => {
+    const registry = new PublicEmberPluginRegistry();
+    const capability = createLifecycleCapability('aave');
+
+    registry.registerLifecycleCapability(capability);
+
+    expect(registry.getLifecycleCapability('aave')).toBe(capability);
+  });
+
+  it('returns undefined when a provider id has no registered lifecycle capability', () => {
+    const registry = new PublicEmberPluginRegistry();
+
+    expect(registry.getLifecycleCapability('missing-provider')).toBeUndefined();
+  });
+});

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -24,7 +24,7 @@
     "lint:root": "pnpm exec eslint src tests --ext .ts",
     "test": "pnpm run test:ci",
     "test:ci": "pnpm run test:ci:root && pnpm --filter '!monorepo-root' --workspace-concurrency=1 --sort run test:ci && pnpm run test:anvil",
-    "test:ci:root": "pnpm test:vitest src/ci/affected-packages.unit.test.ts tests/ci/detect-affected-packages.int.test.ts tests/ci/run-affected-command.int.test.ts",
+    "test:ci:root": "pnpm test:vitest src/ci/affected-packages.unit.test.ts tests/ci/detect-affected-packages.int.test.ts tests/ci/run-affected-command.int.test.ts tests/ci/release-workflow-config.int.test.ts tests/ci/detect-release-targets.int.test.ts",
     "test:anvil": "echo \"Skipping Anvil-dependent test suites in CI\"",
     "test:vitest": "vitest run",
     "lint:require-submodule": "./scripts/require-submodule.sh",

--- a/typescript/src/ci/affected-packages.ts
+++ b/typescript/src/ci/affected-packages.ts
@@ -45,8 +45,12 @@ interface PackageManifest {
   name?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  engines?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  packageManager?: string;
+  pnpm?: unknown;
+  scripts?: Record<string, string>;
 }
 
 interface WorkspaceFile {
@@ -54,11 +58,21 @@ interface WorkspaceFile {
 }
 
 const execFileAsync = promisify(execFile);
+const ROOT_PACKAGE_JSON_FULL_SCOPE_INVALIDATOR = "__ci__/root-package-json-full-scope";
+const ROOT_PACKAGE_JSON_RISKY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "engines",
+  "optionalDependencies",
+  "packageManager",
+  "peerDependencies",
+  "pnpm",
+] as const;
 
 export const DEFAULT_GLOBAL_INVALIDATORS = [
   ".github/workflows/ci.yml",
   "eslint.config.js",
-  "package.json",
+  ROOT_PACKAGE_JSON_FULL_SCOPE_INVALIDATOR,
   "pnpm-workspace.yaml",
   "tsconfig.base.json",
   "tsconfig.json",
@@ -142,16 +156,87 @@ function collectManifestDependencyNames(manifest: PackageManifest): string[] {
   return dependencyGroups.flatMap((group) => Object.keys(group ?? {}));
 }
 
+async function resolveRepositoryPaths(workspaceRoot: string) {
+  const { stdout: repoRootStdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+    cwd: workspaceRoot,
+  });
+  const repoRoot = await realpath(repoRootStdout.trim());
+  const normalizedWorkspaceRoot = await realpath(workspaceRoot);
+
+  return {
+    repoRoot,
+    workspaceRoot: normalizedWorkspaceRoot,
+    workspaceRootRelativePath: normalizePath(path.relative(repoRoot, normalizedWorkspaceRoot)),
+  };
+}
+
+function resolveRepoRelativePath(workspaceRelativePath: string, workspaceRootRelativePath: string): string {
+  if (workspaceRootRelativePath.length === 0) {
+    return workspaceRelativePath;
+  }
+
+  return normalizePath(path.posix.join(workspaceRootRelativePath, workspaceRelativePath));
+}
+
+async function readGitFileAtRef(ref: string, repoRelativePath: string, cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["show", `${ref}:${repoRelativePath}`], {
+      cwd,
+    });
+
+    return stdout;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "stderr" in error &&
+      typeof error.stderr === "string" &&
+      error.stderr.includes("exists on disk, but not in")
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function manifestFieldChanged(
+  previousManifest: PackageManifest,
+  nextManifest: PackageManifest,
+  field: (typeof ROOT_PACKAGE_JSON_RISKY_FIELDS)[number],
+): boolean {
+  return JSON.stringify(previousManifest[field] ?? null) !== JSON.stringify(nextManifest[field] ?? null);
+}
+
+async function shouldForceFullScopeForRootPackageJsonChange(options: {
+  baseRef: string;
+  headRef: string;
+  workspaceRoot: string;
+  workspaceRootRelativePath: string;
+}): Promise<boolean> {
+  const repoRelativePackageJsonPath = resolveRepoRelativePath("package.json", options.workspaceRootRelativePath);
+  const previousPackageJson = await readGitFileAtRef(
+    options.baseRef,
+    repoRelativePackageJsonPath,
+    options.workspaceRoot,
+  );
+  const nextPackageJson = await readGitFileAtRef(
+    options.headRef,
+    repoRelativePackageJsonPath,
+    options.workspaceRoot,
+  );
+  const previousManifest = previousPackageJson ? (JSON.parse(previousPackageJson) as PackageManifest) : {};
+  const nextManifest = nextPackageJson ? (JSON.parse(nextPackageJson) as PackageManifest) : {};
+
+  return ROOT_PACKAGE_JSON_RISKY_FIELDS.some((field) =>
+    manifestFieldChanged(previousManifest, nextManifest, field),
+  );
+}
+
 export async function listChangedFilesFromGit(
   options: ChangedFilesFromGitOptions,
 ): Promise<string[]> {
   const headRef = options.headRef ?? "HEAD";
-  const { stdout: repoRootStdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
-    cwd: options.workspaceRoot,
-  });
-  const repoRoot = await realpath(repoRootStdout.trim());
-  const workspaceRoot = await realpath(options.workspaceRoot);
-  const workspaceRootRelativePath = normalizePath(path.relative(repoRoot, workspaceRoot));
+  const repositoryPaths = await resolveRepositoryPaths(options.workspaceRoot);
   const { stdout } = await execFileAsync(
     "git",
     ["diff", "--name-only", `${options.baseRef}...${headRef}`],
@@ -160,11 +245,25 @@ export async function listChangedFilesFromGit(
     },
   );
 
-  return stdout
+  const changedFiles = stdout
     .split(/\r?\n/u)
     .map(normalizePath)
-    .map((changedFile) => relativizeToWorkspaceRoot(changedFile, workspaceRootRelativePath))
+    .map((changedFile) => relativizeToWorkspaceRoot(changedFile, repositoryPaths.workspaceRootRelativePath))
     .filter((changedFile) => changedFile.length > 0);
+
+  if (
+    changedFiles.includes("package.json") &&
+    await shouldForceFullScopeForRootPackageJsonChange({
+      baseRef: options.baseRef,
+      headRef,
+      workspaceRoot: repositoryPaths.workspaceRoot,
+      workspaceRootRelativePath: repositoryPaths.workspaceRootRelativePath,
+    })
+  ) {
+    return [...changedFiles, ROOT_PACKAGE_JSON_FULL_SCOPE_INVALIDATOR];
+  }
+
+  return changedFiles;
 }
 
 export async function discoverWorkspacePackages(workspaceRoot: string): Promise<WorkspacePackage[]> {

--- a/typescript/tests/ci/detect-affected-packages.int.test.ts
+++ b/typescript/tests/ci/detect-affected-packages.int.test.ts
@@ -8,6 +8,27 @@ import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
+async function initGitRepository(repoRoot: string) {
+  await execFileAsync("git", ["init", "--initial-branch=main"], {
+    cwd: repoRoot,
+  });
+  await execFileAsync("git", ["config", "user.name", "Codex"], {
+    cwd: repoRoot,
+  });
+  await execFileAsync("git", ["config", "user.email", "codex@example.com"], {
+    cwd: repoRoot,
+  });
+}
+
+async function commitAll(repoRoot: string, message: string) {
+  await execFileAsync("git", ["add", "."], {
+    cwd: repoRoot,
+  });
+  await execFileAsync("git", ["commit", "-m", message], {
+    cwd: repoRoot,
+  });
+}
+
 describe("detect-affected-packages CLI", () => {
   it("prints affected package names and dirs as JSON", async () => {
     const workspaceRoot = await mkdtemp(path.join(tmpdir(), "affected-cli-"));
@@ -235,6 +256,160 @@ describe("detect-affected-packages CLI", () => {
       });
     } finally {
       await rm(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("treats low-risk root package.json script changes as partial root-only changes", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "affected-cli-root-scripts-"));
+
+    try {
+      await writeFile(
+        path.join(workspaceRoot, "package.json"),
+        JSON.stringify(
+          {
+            name: "monorepo-root",
+            version: "1.0.0",
+            scripts: {
+              lint: "pnpm lint",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        path.join(workspaceRoot, "pnpm-workspace.yaml"),
+        "packages:\n  - 'packages/*'\n",
+      );
+      await mkdir(path.join(workspaceRoot, "packages/core"), { recursive: true });
+      await writeFile(
+        path.join(workspaceRoot, "packages/core/package.json"),
+        JSON.stringify({
+          name: "core",
+          version: "1.0.0",
+        }),
+      );
+
+      await initGitRepository(workspaceRoot);
+      await commitAll(workspaceRoot, "initial");
+
+      await writeFile(
+        path.join(workspaceRoot, "package.json"),
+        JSON.stringify(
+          {
+            name: "monorepo-root",
+            version: "1.0.0",
+            scripts: {
+              lint: "pnpm lint",
+              "test:ci:root": "pnpm test:vitest tests/ci/new-root-test.int.test.ts",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await commitAll(workspaceRoot, "script-only root package change");
+
+      const { stdout } = await execFileAsync(
+        "pnpm",
+        [
+          "exec",
+          "tsx",
+          "src/ci/detect-affected-packages.ts",
+          "--workspace-root",
+          workspaceRoot,
+          "--base-ref",
+          "HEAD~1",
+          "--head-ref",
+          "HEAD",
+        ],
+        {
+          cwd: path.resolve(import.meta.dirname, "../.."),
+        },
+      );
+
+      expect(JSON.parse(stdout)).toEqual({
+        scope: "partial",
+        selectedPackageDirs: [""],
+        selectedPackageNames: ["monorepo-root"],
+      });
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("still treats risky root package.json dependency changes as full-workspace changes", async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), "affected-cli-root-deps-"));
+
+    try {
+      await writeFile(
+        path.join(workspaceRoot, "package.json"),
+        JSON.stringify(
+          {
+            name: "monorepo-root",
+            version: "1.0.0",
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        path.join(workspaceRoot, "pnpm-workspace.yaml"),
+        "packages:\n  - 'packages/*'\n",
+      );
+      await mkdir(path.join(workspaceRoot, "packages/core"), { recursive: true });
+      await writeFile(
+        path.join(workspaceRoot, "packages/core/package.json"),
+        JSON.stringify({
+          name: "core",
+          version: "1.0.0",
+        }),
+      );
+
+      await initGitRepository(workspaceRoot);
+      await commitAll(workspaceRoot, "initial");
+
+      await writeFile(
+        path.join(workspaceRoot, "package.json"),
+        JSON.stringify(
+          {
+            name: "monorepo-root",
+            version: "1.0.0",
+            devDependencies: {
+              vitest: "^3.2.4",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await commitAll(workspaceRoot, "root dependency change");
+
+      const { stdout } = await execFileAsync(
+        "pnpm",
+        [
+          "exec",
+          "tsx",
+          "src/ci/detect-affected-packages.ts",
+          "--workspace-root",
+          workspaceRoot,
+          "--base-ref",
+          "HEAD~1",
+          "--head-ref",
+          "HEAD",
+        ],
+        {
+          cwd: path.resolve(import.meta.dirname, "../.."),
+        },
+      );
+
+      expect(JSON.parse(stdout)).toEqual({
+        scope: "full",
+        selectedPackageDirs: ["", "packages/core"],
+        selectedPackageNames: ["core", "monorepo-root"],
+      });
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true });
     }
   });
 });

--- a/typescript/tests/ci/detect-release-targets.int.test.ts
+++ b/typescript/tests/ci/detect-release-targets.int.test.ts
@@ -1,0 +1,212 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const detectReleaseTargetsScript = path.resolve(
+  import.meta.dirname,
+  '../../scripts/detect-release-targets.mjs',
+);
+
+async function initGitRepository(repoRoot: string) {
+  await execFileAsync('git', ['init', '--initial-branch=main'], {
+    cwd: repoRoot,
+  });
+  await execFileAsync('git', ['config', 'user.name', 'Codex'], {
+    cwd: repoRoot,
+  });
+  await execFileAsync('git', ['config', 'user.email', 'codex@example.com'], {
+    cwd: repoRoot,
+  });
+}
+
+async function commitAll(repoRoot: string, message: string) {
+  await execFileAsync('git', ['add', '.'], {
+    cwd: repoRoot,
+  });
+  await execFileAsync('git', ['commit', '-m', message], {
+    cwd: repoRoot,
+  });
+}
+
+async function writeReleaseWorkspace(repoRoot: string) {
+  const workspaceRoot = path.join(repoRoot, 'typescript');
+
+  await mkdir(path.join(workspaceRoot, 'lib/agent-node/src'), { recursive: true });
+  await mkdir(path.join(workspaceRoot, 'onchain-actions-plugins/registry/src'), {
+    recursive: true,
+  });
+
+  await writeFile(
+    path.join(workspaceRoot, 'lib/agent-node/package.json'),
+    JSON.stringify({
+      name: '@emberai/agent-node',
+      version: '0.0.0',
+    }),
+  );
+  await writeFile(
+    path.join(workspaceRoot, 'onchain-actions-plugins/registry/package.json'),
+    JSON.stringify({
+      name: '@emberai/onchain-actions-registry',
+      version: '0.0.0',
+    }),
+  );
+  await writeFile(
+    path.join(workspaceRoot, 'lib/agent-node/src/index.ts'),
+    "export const agentNode = 'stable';\n",
+  );
+  await writeFile(
+    path.join(workspaceRoot, 'onchain-actions-plugins/registry/src/index.ts'),
+    "export const registryVersion = 'stable';\n",
+  );
+
+  return workspaceRoot;
+}
+
+async function runDetectReleaseTargets(workspaceRoot: string, extraEnv: NodeJS.ProcessEnv = {}) {
+  const { stdout } = await execFileAsync(
+    'node',
+    [detectReleaseTargetsScript, '--output', 'release-targets.json'],
+    {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        ...extraEnv,
+      },
+    },
+  );
+
+  return JSON.parse(stdout) as {
+    matrix: Array<{ id: string; packageName: string }>;
+    selected: string[];
+  };
+}
+
+describe('detect-release-targets', () => {
+  it('uses the latest stable tag on main even when a newer prerelease tag exists', async () => {
+    const repoRoot = await mkdtemp(path.join(tmpdir(), 'detect-release-targets-main-'));
+
+    try {
+      const workspaceRoot = await writeReleaseWorkspace(repoRoot);
+
+      await initGitRepository(repoRoot);
+      await commitAll(repoRoot, 'initial release state');
+
+      await execFileAsync('git', ['tag', '@emberai/agent-node@1.0.0'], {
+        cwd: repoRoot,
+      });
+      await execFileAsync('git', ['tag', '@emberai/onchain-actions-registry@1.2.3'], {
+        cwd: repoRoot,
+      });
+
+      await writeFile(
+        path.join(workspaceRoot, 'onchain-actions-plugins/registry/src/index.ts'),
+        "export const registryVersion = 'next';\n",
+      );
+      await commitAll(repoRoot, 'registry prerelease change');
+
+      await execFileAsync('git', ['tag', '@emberai/onchain-actions-registry@1.2.4-next.1'], {
+        cwd: repoRoot,
+      });
+
+      const result = await runDetectReleaseTargets(workspaceRoot, {
+        RELEASE_SIMULATE_BRANCH: 'main',
+      });
+
+      expect(result.selected).toEqual(['registry']);
+      expect(result.matrix).toHaveLength(1);
+      expect(result.matrix[0]).toMatchObject({
+        id: 'registry',
+        packageName: '@emberai/onchain-actions-registry',
+      });
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('returns no release targets when only the release workflow file changes', async () => {
+    const repoRoot = await mkdtemp(path.join(tmpdir(), 'detect-release-targets-noop-'));
+
+    try {
+      const workspaceRoot = await writeReleaseWorkspace(repoRoot);
+
+      await initGitRepository(repoRoot);
+      await commitAll(repoRoot, 'initial release state');
+
+      await execFileAsync('git', ['tag', '@emberai/agent-node@1.0.0'], {
+        cwd: repoRoot,
+      });
+      await execFileAsync('git', ['tag', '@emberai/onchain-actions-registry@1.2.3'], {
+        cwd: repoRoot,
+      });
+
+      await mkdir(path.join(repoRoot, '.github/workflows'), { recursive: true });
+      await writeFile(
+        path.join(repoRoot, '.github/workflows/release.yml'),
+        'name: Release Packages\n',
+      );
+      await commitAll(repoRoot, 'workflow-only change');
+
+      const result = await runDetectReleaseTargets(workspaceRoot, {
+        RELEASE_SIMULATE_BRANCH: 'main',
+      });
+
+      expect(result.selected).toEqual([]);
+      expect(result.matrix).toEqual([]);
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('uses the latest prerelease tag on next for prerelease publishing', async () => {
+    const repoRoot = await mkdtemp(path.join(tmpdir(), 'detect-release-targets-next-'));
+
+    try {
+      const workspaceRoot = await writeReleaseWorkspace(repoRoot);
+
+      await initGitRepository(repoRoot);
+      await commitAll(repoRoot, 'initial release state');
+
+      await execFileAsync('git', ['tag', '@emberai/agent-node@1.0.0'], {
+        cwd: repoRoot,
+      });
+      await execFileAsync('git', ['tag', '@emberai/onchain-actions-registry@1.2.3'], {
+        cwd: repoRoot,
+      });
+
+      await writeFile(
+        path.join(workspaceRoot, 'onchain-actions-plugins/registry/src/index.ts'),
+        "export const registryVersion = 'next-1';\n",
+      );
+      await commitAll(repoRoot, 'registry prerelease base');
+
+      await execFileAsync('git', ['tag', '@emberai/onchain-actions-registry@1.2.4-next.1'], {
+        cwd: repoRoot,
+      });
+
+      await writeFile(
+        path.join(workspaceRoot, 'onchain-actions-plugins/registry/src/index.ts'),
+        "export const registryVersion = 'next-2';\n",
+      );
+      await commitAll(repoRoot, 'registry prerelease follow-up');
+
+      const result = await runDetectReleaseTargets(workspaceRoot, {
+        RELEASE_SIMULATE_BRANCH: 'next',
+      });
+
+      expect(result.selected).toEqual(['registry']);
+      expect(result.matrix).toHaveLength(1);
+      expect(result.matrix[0]).toMatchObject({
+        id: 'registry',
+        packageName: '@emberai/onchain-actions-registry',
+      });
+    } finally {
+      await rm(repoRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/typescript/tests/ci/release-workflow-config.int.test.ts
+++ b/typescript/tests/ci/release-workflow-config.int.test.ts
@@ -1,0 +1,53 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+type WorkflowTrigger = {
+  branches?: string[];
+  paths?: string[];
+};
+
+type WorkflowStep = {
+  name?: string;
+};
+
+type WorkflowConfig = {
+  on?: {
+    pull_request?: WorkflowTrigger;
+    push?: WorkflowTrigger;
+    workflow_dispatch?: Record<string, unknown>;
+  };
+  jobs?: {
+    prepare?: {
+      steps?: WorkflowStep[];
+    };
+  };
+};
+
+async function readReleaseWorkflow(): Promise<WorkflowConfig> {
+  const workflowPath = path.resolve(import.meta.dirname, "../../../.github/workflows/release.yml");
+  const workflowContent = await readFile(workflowPath, "utf8");
+
+  return yaml.load(workflowContent) as WorkflowConfig;
+}
+
+describe("release workflow trusted-branch configuration", () => {
+  it("runs on trusted branch pushes without top-level push path gating", async () => {
+    const workflow = await readReleaseWorkflow();
+
+    expect(workflow.on?.workflow_dispatch).toBeDefined();
+    expect(workflow.on?.push?.branches).toEqual(["main", "next"]);
+    expect(workflow.on?.push?.paths).toBeUndefined();
+    expect(workflow.on?.pull_request?.paths).toContain("typescript/onchain-actions-plugins/registry/**");
+  });
+
+  it("keeps the prepare job lightweight by avoiding dependency installation", async () => {
+    const workflow = await readReleaseWorkflow();
+    const stepNames = workflow.jobs?.prepare?.steps?.map((step) => step.name) ?? [];
+
+    expect(stepNames).not.toContain("Setup pnpm");
+    expect(stepNames).not.toContain("Install dependencies");
+  });
+});


### PR DESCRIPTION
## Summary
- promote the current `next` branch state into `main`
- carry forward the merged release workflow fix from #643 and the other commits currently ahead on `next`

## Validation
- branch comparison confirms `next` is ahead of `main`
- no additional local code changes were made for this PR

## References
- Follows #643
