### PR TITLE
[Feature] Add hidden OCA executor swap dispatch

### DIFF
--- a/typescript/agent-runtime/lib/pi/package.json
+++ b/typescript/agent-runtime/lib/pi/package.json
@@ -45,5 +45,8 @@
     "@mariozechner/pi-ai": "0.64.0",
     "agent-runtime-postgres": "workspace:^",
     "fast-json-patch": "3.1.1"
+  },
+  "devDependencies": {
+    "rxjs": "7.8.1"
   }
 }

--- a/typescript/agent-runtime/lib/pi/src/agUiProjection.unit.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/agUiProjection.unit.test.ts
@@ -1,13 +1,50 @@
+import {
+  defaultApplyEvents,
+  type AbstractAgent,
+  type RunAgentInput,
+} from '@ag-ui/client';
 import { EventType } from '@ag-ui/core';
+import type { BaseEvent } from '@ag-ui/core';
 import type { AgentEvent } from '@mariozechner/pi-agent-core';
-import { describe, expect, it } from 'vitest';
+import { lastValueFrom, of, toArray } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildPiA2UiActivityEvent,
+  buildPiRuntimeGatewayStateRebaselineEvent,
   buildPiRuntimeGatewayStateDeltaEvent,
   buildPiThreadStateSnapshot,
   mapPiAgentEventsToAgUiEvents,
 } from './index.js';
+
+const applyEventsWithAgUiClient = async (
+  initialState: unknown,
+  events: BaseEvent[],
+): Promise<unknown[]> => {
+  const input = {
+    threadId: 'thread-1',
+    runId: 'run-1',
+    messages: [],
+    tools: [],
+    context: [],
+    state: initialState,
+  } satisfies RunAgentInput;
+  const agent = {
+    messages: [],
+    state: initialState,
+  } as unknown as AbstractAgent;
+
+  const mutations = await lastValueFrom(
+    defaultApplyEvents(input, of(...events), agent, []).pipe(toArray()),
+  );
+  return mutations as unknown[];
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const readPath = (value: unknown, path: string[]): unknown =>
+  path.reduce<unknown>((current, key) => (isRecord(current) ? current[key] : undefined), value);
 
 describe('pi AG-UI projection', () => {
   it('builds a thread snapshot that preserves canonical ids, task projection, artifacts, and activity-renderable A2UI payloads', () => {
@@ -154,6 +191,132 @@ describe('pi AG-UI projection', () => {
         },
       ]),
     });
+  });
+
+  it('builds a snapshot rebaseline for run-completion state when an intervening refresh can stale a delta', async () => {
+    const previousSession = {
+      thread: { id: 'thread-1' },
+      execution: {
+        id: 'exec-1',
+        status: 'completed' as const,
+        statusMessage: 'Portfolio state refreshed.',
+      },
+      artifacts: {
+        current: {
+          artifactId: 'refresh-1',
+          data: {
+            type: 'shared-ember-portfolio-state',
+            revision: 1,
+          },
+        },
+        activity: {
+          artifactId: 'refresh-1',
+          data: {
+            type: 'shared-ember-portfolio-state',
+            revision: 1,
+          },
+        },
+      },
+      threadPatch: {
+        lifecycle: {
+          phase: 'prehire',
+        },
+      },
+    };
+    const interveningClientSession = {
+      ...previousSession,
+      artifacts: {
+        current: {
+          artifactId: 'refresh-2',
+          data: {
+            type: 'shared-ember-portfolio-state',
+            revision: 2,
+          },
+        },
+        activity: {
+          artifactId: 'refresh-2',
+          data: {
+            type: 'shared-ember-portfolio-state',
+            revision: 2,
+          },
+        },
+      },
+    };
+    const runCompletionSession = {
+      thread: { id: 'thread-1' },
+      execution: {
+        id: 'exec-1',
+        status: 'interrupted' as const,
+        statusMessage: 'Connect the wallet you want the portfolio manager to onboard.',
+      },
+      artifacts: {
+        current: {
+          artifactId: 'interrupt-1',
+          data: {
+            type: 'interrupt-status',
+            interruptType: 'portfolio-manager-setup-request',
+            status: 'pending',
+            mirroredToActivity: false,
+            message: 'Connect the wallet you want the portfolio manager to onboard.',
+          },
+        },
+        activity: {
+          artifactId: 'interrupt-1',
+          data: {
+            type: 'interrupt-status',
+            interruptType: 'portfolio-manager-setup-request',
+            status: 'pending',
+            mirroredToActivity: false,
+            message: 'Connect the wallet you want the portfolio manager to onboard.',
+          },
+        },
+      },
+      threadPatch: {
+        lifecycle: {
+          phase: 'onboarding',
+        },
+      },
+    };
+
+    const staleClientState = buildPiThreadStateSnapshot(interveningClientSession);
+    const staleDelta = buildPiRuntimeGatewayStateDeltaEvent({
+      previousSession,
+      session: runCompletionSession,
+    });
+    if (!staleDelta) {
+      throw new Error('Expected previous run-completion delta to be non-empty');
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await expect(applyEventsWithAgUiClient(staleClientState, [staleDelta])).resolves.toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to apply state patch:'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    const rebaseline = buildPiRuntimeGatewayStateRebaselineEvent({
+      previousSession,
+      session: runCompletionSession,
+    });
+    if (!rebaseline) {
+      throw new Error('Expected changed run-completion state to produce a rebaseline');
+    }
+
+    expect(rebaseline.type).toBe(EventType.STATE_SNAPSHOT);
+    const appliedMutations = await applyEventsWithAgUiClient(staleClientState, [rebaseline]);
+    expect(appliedMutations).toHaveLength(1);
+    expect(readPath(appliedMutations[0], ['state', 'thread', 'lifecycle', 'phase'])).toBe(
+      'onboarding',
+    );
+    expect(
+      readPath(appliedMutations[0], ['state', 'thread', 'artifacts', 'current', 'artifactId']),
+    ).toBe('interrupt-1');
+    expect(readPath(appliedMutations[0], ['state', 'thread', 'task', 'taskStatus', 'state'])).toBe(
+      'input-required',
+    );
   });
 
   it('does not surface hidden interrupt checkpoint artifacts into thread activity fallbacks', () => {

--- a/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
+++ b/typescript/agent-runtime/lib/pi/src/gatewayService.int.test.ts
@@ -1466,20 +1466,21 @@ describe('pi gateway service integration', () => {
         status: 'failed',
       },
     });
+    expect(runEvents.filter((event) => event.type === EventType.STATE_DELTA)).toEqual([]);
     expect(runEvents).toContainEqual({
-      type: EventType.STATE_DELTA,
-      delta: expect.arrayContaining([
-        {
-          op: 'replace',
-          path: '/thread/task/taskStatus/state',
-          value: 'failed',
-        },
-        {
-          op: 'replace',
-          path: '/thread/task/taskStatus/message/content',
-          value: 'Key limit exceeded (monthly limit).',
-        },
-      ]),
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: expect.objectContaining({
+        thread: expect.objectContaining({
+          task: expect.objectContaining({
+            taskStatus: {
+              state: 'failed',
+              message: {
+                content: 'Key limit exceeded (monthly limit).',
+              },
+            },
+          }),
+        }),
+      }),
     });
     expect(runEvents).toContainEqual({
       type: EventType.MESSAGES_SNAPSHOT,

--- a/typescript/agent-runtime/lib/pi/src/index.ts
+++ b/typescript/agent-runtime/lib/pi/src/index.ts
@@ -1529,6 +1529,30 @@ export const buildPiRuntimeGatewayStateDeltaEvent = (params: {
   } satisfies StateDeltaEvent;
 };
 
+export const buildPiRuntimeGatewayStateRebaselineEvent = (params: {
+  previousSession: PiRuntimeGatewaySession;
+  session: PiRuntimeGatewaySession;
+}): StateSnapshotEvent | null => {
+  const previousSnapshot = buildPiThreadStateSnapshot(params.previousSession);
+  const nextSnapshot = buildPiThreadStateSnapshot(params.session);
+  if (!jsonPatchCompare) {
+    throw new TypeError('fast-json-patch compare export unavailable');
+  }
+  const delta = jsonPatchCompare(previousSnapshot, nextSnapshot, true);
+
+  if (delta.length === 0) {
+    return null;
+  }
+
+  // Run completion can fold in state changes that were already published on
+  // another stream. A snapshot re-establishes the AG-UI baseline for future
+  // deltas instead of assuming the client still matches previousSession.
+  return {
+    type: EventType.STATE_SNAPSHOT,
+    snapshot: nextSnapshot,
+  } satisfies StateSnapshotEvent;
+};
+
 export const buildPiA2UiActivityEvent = (params: {
   threadId: string;
   executionId: string;
@@ -2253,12 +2277,12 @@ export const createPiRuntimeGatewayRuntime = (params: {
             failureMessage,
           );
           logPiGatewayDebug('run session after transcript persist', session);
-          const stateDeltaEvent = buildPiRuntimeGatewayStateDeltaEvent({
+          const stateRebaselineEvent = buildPiRuntimeGatewayStateRebaselineEvent({
             previousSession: requestSession,
             session,
           });
-          if (stateDeltaEvent) {
-            controller.push(stateDeltaEvent);
+          if (stateRebaselineEvent) {
+            controller.push(stateRebaselineEvent);
           }
           const messagesSnapshotEvent = buildMessagesSnapshotEvent(session);
           if (messagesSnapshotEvent) {

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -898,6 +898,9 @@ describe('agent-runtime integration', () => {
     ).toBe(true);
     expect(observedDomainCommandToolDescription).toContain('Available commands: hire (Start onboarding.)');
     expect(observedDomainCommandToolDescription).toContain('complete_onboarding (Finish onboarding.)');
+    expect(observedDomainCommandToolDescription).toContain(
+      'Put any structured command payload in inputJson as a JSON object string',
+    );
     expect(observedDomainCommandNames).toEqual([
       'hire',
       'continue_onboarding',

--- a/typescript/agent-runtime/src/index.int.test.ts
+++ b/typescript/agent-runtime/src/index.int.test.ts
@@ -521,6 +521,13 @@ function isStateDeltaEvent(event: GatewayEvent): event is StateDeltaEvent {
   );
 }
 
+function findStateSnapshotEvent(
+  events: readonly GatewayEvent[],
+  predicate: (event: StateSnapshotEvent) => boolean,
+): StateSnapshotEvent | undefined {
+  return events.filter(isStateSnapshotEvent).find(predicate);
+}
+
 function isMessagesSnapshotEvent(event: GatewayEvent): event is MessagesSnapshotEvent {
   return typeof event === 'object' && event !== null && 'messages' in event;
 }
@@ -888,7 +895,7 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const hireDelta = hireEvents.find(isStateDeltaEvent);
+    const hireSnapshot = hireEvents.find(isStateSnapshotEvent);
     expect(latestUserText).toBe('Please hire the agent.');
     expect(
       hasSystemPromptFragments(observedSystemPrompts, [
@@ -919,34 +926,20 @@ describe('agent-runtime integration', () => {
         content: 'Ready for a live runtime conversation.',
       },
     });
-    expect(hireDelta).toBeDefined();
-    expect(hireDelta!.delta).toEqual(
-      expect.arrayContaining([
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/phase',
-          value: 'onboarding',
-        },
-        {
-          op: 'add',
-          path: '/thread/lifecycle/onboardingStep',
-          value: 'operator-profile',
-        },
-        {
-          op: 'replace',
-          path: '/thread/task/taskStatus/state',
-          value: 'input-required',
-        },
-        {
-          op: 'add',
-          path: '/projected/managedLifecycle',
-          value: {
-            phase: 'onboarding',
-            onboardingStep: 'operator-profile',
-          },
-        },
-      ]),
-    );
+    expect(hireSnapshot).toBeDefined();
+    expect(hireSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      phase: 'onboarding',
+      onboardingStep: 'operator-profile',
+    });
+    expect(hireSnapshot!.snapshot.thread.task?.taskStatus).toMatchObject({
+      state: 'input-required',
+    });
+    expect(hireSnapshot!.snapshot.projected).toMatchObject({
+      managedLifecycle: {
+        phase: 'onboarding',
+        onboardingStep: 'operator-profile',
+      },
+    });
 
     expect(persistedThreads.get('thread-1')?.threadState).toHaveProperty('a2ui');
     expect(persistedThreads.get('thread-1')?.threadState).toHaveProperty('projectedState');
@@ -965,50 +958,29 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const resumeDeltas = resumeEvents.filter(isStateDeltaEvent);
-    const resolvedInterruptDelta = resumeDeltas.find((event) =>
-      event.delta.some(
-        (operation) =>
-          operation.op === 'replace' &&
-          operation.path === '/thread/artifacts/current/data/status' &&
-          operation.value === 'resolved',
-      ),
+    const resolvedInterruptSnapshot = findStateSnapshotEvent(
+      resumeEvents,
+      (event) => event.snapshot.thread.artifacts.current?.data?.status === 'resolved',
     );
-    const domainResumeDelta = resumeDeltas.find((event) =>
-      event.delta.some(
-        (operation) =>
-          operation.op === 'replace' &&
-          operation.path === '/thread/lifecycle/onboardingStep' &&
-          operation.value === 'delegation-note',
-      ),
+    const domainResumeSnapshot = findStateSnapshotEvent(
+      resumeEvents,
+      (event) => event.snapshot.thread.lifecycle?.onboardingStep === 'delegation-note',
     );
 
-    expect(resolvedInterruptDelta).toBeDefined();
-    expect(resolvedInterruptDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/task/taskStatus/state',
-      value: 'working',
+    expect(resolvedInterruptSnapshot).toBeDefined();
+    expect(resolvedInterruptSnapshot!.snapshot.thread.task?.taskStatus).toMatchObject({
+      state: 'working',
     });
-    expect(domainResumeDelta).toBeDefined();
-    expect(domainResumeDelta!.delta).toEqual(
-      expect.arrayContaining([
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/onboardingStep',
-          value: 'delegation-note',
-        },
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/operatorNote',
-          value: 'safe window approved',
-        },
-        {
-          op: 'add',
-          path: '/projected/managedLifecycle/operatorNote',
-          value: 'safe window approved',
-        },
-      ]),
-    );
+    expect(domainResumeSnapshot).toBeDefined();
+    expect(domainResumeSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      onboardingStep: 'delegation-note',
+      operatorNote: 'safe window approved',
+    });
+    expect(domainResumeSnapshot!.snapshot.projected).toMatchObject({
+      managedLifecycle: {
+        operatorNote: 'safe window approved',
+      },
+    });
 
     expect(persistedThreads.get('thread-1')?.threadState).not.toHaveProperty('a2ui');
 
@@ -1024,33 +996,21 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const completeDelta = completeEvents.find(isStateDeltaEvent);
+    const completeSnapshot = completeEvents.find(isStateSnapshotEvent);
 
-    expect(completeDelta).toBeDefined();
-    expect(completeDelta!.delta).toEqual(
-      expect.arrayContaining([
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/phase',
-          value: 'hired',
-        },
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/onboardingStep',
-          value: null,
-        },
-        {
-          op: 'replace',
-          path: '/projected/managedLifecycle/phase',
-          value: 'hired',
-        },
-        {
-          op: 'replace',
-          path: '/thread/task/taskStatus/state',
-          value: 'completed',
-        },
-      ]),
-    );
+    expect(completeSnapshot).toBeDefined();
+    expect(completeSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      phase: 'hired',
+      onboardingStep: null,
+    });
+    expect(completeSnapshot!.snapshot.projected).toMatchObject({
+      managedLifecycle: {
+        phase: 'hired',
+      },
+    });
+    expect(completeSnapshot!.snapshot.thread.task?.taskStatus).toMatchObject({
+      state: 'completed',
+    });
 
     const fireEvents = await collectEventSource(
       await runtime.service.run({
@@ -1064,23 +1024,17 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const fireDelta = fireEvents.find(isStateDeltaEvent);
+    const fireSnapshot = fireEvents.find(isStateSnapshotEvent);
 
-    expect(fireDelta).toBeDefined();
-    expect(fireDelta!.delta).toEqual(
-      expect.arrayContaining([
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/phase',
-          value: 'fired',
-        },
-        {
-          op: 'replace',
-          path: '/projected/managedLifecycle/phase',
-          value: 'fired',
-        },
-      ]),
-    );
+    expect(fireSnapshot).toBeDefined();
+    expect(fireSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      phase: 'fired',
+    });
+    expect(fireSnapshot!.snapshot.projected).toMatchObject({
+      managedLifecycle: {
+        phase: 'fired',
+      },
+    });
   });
 
   it('keeps non-thread-surfaced interrupts canonical without mirroring them into transcript activity', async () => {
@@ -1231,40 +1185,23 @@ describe('agent-runtime integration', () => {
         },
       }),
     );
-    const resumeDeltas = resumeEvents.filter(isStateDeltaEvent);
-    const domainResumeDelta = resumeDeltas.find((event) =>
-      event.delta.some(
-        (operation) =>
-          operation.op === 'replace' &&
-          operation.path === '/thread/lifecycle/onboardingStep' &&
-          operation.value === 'delegation-note',
-      ),
+    const domainResumeSnapshot = findStateSnapshotEvent(
+      resumeEvents,
+      (event) => event.snapshot.thread.lifecycle?.onboardingStep === 'delegation-note',
     );
 
-    expect(domainResumeDelta).toBeDefined();
-    expect(domainResumeDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/lifecycle/operatorNote',
-      value: 'safe window approved',
+    expect(domainResumeSnapshot).toBeDefined();
+    expect(domainResumeSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      operatorNote: 'safe window approved',
     });
     expect(
-      resumeDeltas.some((event) =>
-        event.delta.some(
-          (operation) =>
-            operation.path.startsWith('/thread/activity/events/') &&
-            typeof operation.value === 'object' &&
-            operation.value !== null &&
-            'type' in operation.value &&
-            operation.value.type === 'artifact' &&
-            'artifact' in operation.value &&
-            typeof operation.value.artifact === 'object' &&
-            operation.value.artifact !== null &&
-            'data' in operation.value.artifact &&
-            typeof operation.value.artifact.data === 'object' &&
-            operation.value.artifact.data !== null &&
-            'type' in operation.value.artifact.data &&
-            operation.value.artifact.data.type === 'interrupt-status',
-        ),
+      (domainResumeSnapshot!.snapshot.thread.activity?.events ?? []).some(
+        (event) =>
+          event.type === 'artifact' &&
+          typeof event.artifact?.data === 'object' &&
+          event.artifact.data !== null &&
+          'type' in event.artifact.data &&
+          event.artifact.data.type === 'interrupt-status',
       ),
     ).toBe(false);
     expect(persistedThreads.get(threadId)?.threadState).not.toHaveProperty('a2ui');
@@ -1320,24 +1257,24 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const delta = events.find(isStateDeltaEvent);
+    const snapshot = events.find(isStateSnapshotEvent);
 
     expect(inferenceCalls).toBe(0);
-    expect(delta).toBeDefined();
-    expect(delta!.delta).toEqual(
-      expect.arrayContaining([
-        {
-          op: 'replace',
-          path: '/thread/lifecycle/phase',
-          value: 'onboarding',
-        },
-        {
-          op: 'add',
-          path: '/thread/lifecycle/onboardingStep',
-          value: 'operator-profile',
-        },
-      ]),
-    );
+    expect(events.some(isStateDeltaEvent)).toBe(false);
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.snapshot.thread.lifecycle).toMatchObject({
+      phase: 'onboarding',
+      onboardingStep: 'operator-profile',
+    });
+    expect(snapshot!.snapshot.thread.task?.taskStatus).toMatchObject({
+      state: 'input-required',
+    });
+    expect(snapshot!.snapshot.projected).toMatchObject({
+      managedLifecycle: {
+        phase: 'onboarding',
+        onboardingStep: 'operator-profile',
+      },
+    });
   });
 
   it('emits one authoritative state delta when a shared-state update also recomputes projected state', async () => {
@@ -2123,68 +2060,40 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const resumeDeltas = resumeEvents.filter(isStateDeltaEvent);
-    const resolvedInterruptDelta = resumeDeltas.find((event) =>
-      event.delta.some(
-        (operation) =>
-          operation.op === 'add' &&
-          operation.path === '/thread/artifacts/current/data/status' &&
-          operation.value === 'resolved',
-      ),
+    const resolvedInterruptSnapshot = findStateSnapshotEvent(
+      resumeEvents,
+      (event) => event.snapshot.thread.artifacts.current?.data?.status === 'resolved',
     );
-    const domainResumeDelta = resumeDeltas.find((event) =>
-      event.delta.some(
-        (operation) =>
-          operation.op === 'replace' &&
-          operation.path === '/thread/lifecycle/onboardingStep' &&
-          operation.value === 'delegation-note',
-      ),
+    const domainResumeSnapshot = findStateSnapshotEvent(
+      resumeEvents,
+      (event) => event.snapshot.thread.lifecycle?.onboardingStep === 'delegation-note',
     );
 
-    expect(resolvedInterruptDelta).toBeDefined();
-    expect(domainResumeDelta).toBeDefined();
-    expect(domainResumeDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/lifecycle/onboardingStep',
-      value: 'delegation-note',
+    expect(resolvedInterruptSnapshot).toBeDefined();
+    expect(domainResumeSnapshot).toBeDefined();
+    expect(domainResumeSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      onboardingStep: 'delegation-note',
+      operatorNote: 'safe window approved',
     });
-    expect(domainResumeDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/lifecycle/operatorNote',
-      value: 'safe window approved',
-    });
-    expect(resolvedInterruptDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/task/taskStatus/state',
-      value: 'working',
+    expect(resolvedInterruptSnapshot!.snapshot.thread.task?.taskStatus).toMatchObject({
+      state: 'working',
     });
     expect(
-      resolvedInterruptDelta!.delta.some(
-        (operation) =>
-          operation.op === 'add' &&
-          operation.path.startsWith('/thread/activity/events/') &&
-          operation.value &&
-          typeof operation.value === 'object' &&
-          'type' in operation.value &&
-          operation.value.type === 'artifact' &&
-          'artifact' in operation.value &&
-          typeof operation.value.artifact === 'object' &&
-          operation.value.artifact !== null &&
-          'data' in operation.value.artifact &&
-          typeof operation.value.artifact.data === 'object' &&
-          operation.value.artifact.data !== null &&
-          'type' in operation.value.artifact.data &&
-          operation.value.artifact.data.type === 'interrupt-status' &&
-          'status' in operation.value.artifact.data &&
-          operation.value.artifact.data.status === 'resolved' &&
-          'interruptType' in operation.value.artifact.data &&
-          operation.value.artifact.data.interruptType === 'operator-config',
+      (resolvedInterruptSnapshot!.snapshot.thread.activity?.events ?? []).some(
+        (event) =>
+          event.type === 'artifact' &&
+          typeof event.artifact?.data === 'object' &&
+          event.artifact.data !== null &&
+          'type' in event.artifact.data &&
+          event.artifact.data.type === 'interrupt-status' &&
+          'status' in event.artifact.data &&
+          event.artifact.data.status === 'resolved' &&
+          'interruptType' in event.artifact.data &&
+          event.artifact.data.interruptType === 'operator-config',
       ),
     ).toBe(true);
-    expect(domainResumeDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/task/taskStatus/message/content',
-      value: 'Operator note captured. Ready to complete onboarding.',
+    expect(domainResumeSnapshot!.snapshot.thread.task?.taskStatus.message).toMatchObject({
+      content: 'Operator note captured. Ready to complete onboarding.',
     });
 
     expect(
@@ -2247,26 +2156,17 @@ describe('agent-runtime integration', () => {
       }),
     );
 
-    const resumeDeltas = resumeEvents.filter(isStateDeltaEvent);
-    const domainResumeDelta = resumeDeltas.find((event) =>
-      event.delta.some(
-        (operation) =>
-          operation.op === 'replace' &&
-          operation.path === '/thread/lifecycle/onboardingStep' &&
-          operation.value === 'delegation-note',
-      ),
+    const domainResumeSnapshot = findStateSnapshotEvent(
+      resumeEvents,
+      (event) => event.snapshot.thread.lifecycle?.onboardingStep === 'delegation-note',
     );
 
-    expect(domainResumeDelta).toBeDefined();
-    expect(domainResumeDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/lifecycle/operatorNote',
-      value: 'safe window approved',
+    expect(domainResumeSnapshot).toBeDefined();
+    expect(domainResumeSnapshot!.snapshot.thread.lifecycle).toMatchObject({
+      operatorNote: 'safe window approved',
     });
-    expect(domainResumeDelta!.delta).toContainEqual({
-      op: 'replace',
-      path: '/thread/task/taskStatus/message/content',
-      value: 'Operator note captured. Ready to complete onboarding.',
+    expect(domainResumeSnapshot!.snapshot.thread.task?.taskStatus.message).toMatchObject({
+      content: 'Operator note captured. Ready to complete onboarding.',
     });
     expect(
       persistedThreads.get('thread-resume-with-client-scaffolding')?.threadState,

--- a/typescript/agent-runtime/src/index.ts
+++ b/typescript/agent-runtime/src/index.ts
@@ -340,6 +340,8 @@ function buildDomainCommandToolDescription(lifecycle: AgentRuntimeDomainLifecycl
 
   return [
     'Execute one of the declared domain lifecycle commands through the runtime-owned normalized operation pipeline.',
+    'Put any structured command payload in inputJson as a JSON object string.',
+    'Do not rely on the default empty object when the selected command description names required fields.',
     `Available commands: ${commandList}.`,
   ].join(' ');
 }
@@ -2643,7 +2645,11 @@ export async function createAgentRuntime<TState = unknown>(
           description: buildDomainCommandToolDescription(domain.lifecycle),
           parameters: Type.Object({
             name: buildDomainCommandNameSchema(domain.lifecycle),
-            inputJson: Type.String({ default: '{}' }),
+            inputJson: Type.String({
+              description:
+                'JSON object string for the selected command payload. Include all fields required by the command description.',
+              default: '{}',
+            }),
           }) as AgentRuntimeTool['parameters'],
           execute: async (_toolCallId, args) => {
             const toolArgs = parseDomainCommandToolArgs(args);

--- a/typescript/agent-runtime/src/index.ts
+++ b/typescript/agent-runtime/src/index.ts
@@ -11,6 +11,7 @@ import {
   buildPiRuntimeDirectExecutionRecordIds as buildPiRuntimeDirectExecutionRecordIdsInternal,
   buildPiRuntimeGatewayConnectEvents as buildPiRuntimeGatewayConnectEventsInternal,
   buildPiRuntimeGatewayStateDeltaEvent as buildPiRuntimeGatewayStateDeltaEventInternal,
+  buildPiRuntimeGatewayStateRebaselineEvent as buildPiRuntimeGatewayStateRebaselineEventInternal,
   createCanonicalPiRuntimeGatewayControlPlane as createCanonicalPiRuntimeGatewayControlPlaneInternal,
   createPiRuntimeGatewayAgUiHandler as createPiRuntimeGatewayAgUiHandlerInternal,
   createPiRuntimeGatewayFoundation as createPiRuntimeGatewayFoundationInternal,
@@ -2735,7 +2736,7 @@ export async function createAgentRuntime<TState = unknown>(
       }
 
       const nextSession = await runDomainOperation(request.threadId, operation);
-      const stateDeltaEvent = buildPiRuntimeGatewayStateDeltaEventInternal({
+      const stateRebaselineEvent = buildPiRuntimeGatewayStateRebaselineEventInternal({
         previousSession: session,
         session: nextSession,
       });
@@ -2746,7 +2747,7 @@ export async function createAgentRuntime<TState = unknown>(
           threadId: request.threadId,
           runId: request.runId,
         },
-        ...(stateDeltaEvent ? [stateDeltaEvent] : []),
+        ...(stateRebaselineEvent ? [stateRebaselineEvent] : []),
         {
           type: EventType.RUN_FINISHED,
           threadId: request.threadId,
@@ -2794,12 +2795,12 @@ export async function createAgentRuntime<TState = unknown>(
       );
       if (hasResume) {
         const resumedSession = await resumeInterruptedSession(request.threadId);
-        const stateDeltaEvent = buildPiRuntimeGatewayStateDeltaEventInternal({
+        const stateRebaselineEvent = buildPiRuntimeGatewayStateRebaselineEventInternal({
           previousSession: session,
           session: resumedSession,
         });
-        if (stateDeltaEvent) {
-          leadingEvents = [stateDeltaEvent];
+        if (stateRebaselineEvent) {
+          leadingEvents = [stateRebaselineEvent];
         }
       }
 
@@ -2808,7 +2809,7 @@ export async function createAgentRuntime<TState = unknown>(
       if (resumeOperation && domain?.handleOperation) {
         const previousSession = getSession(request.threadId);
         const nextSession = await runDomainOperation(request.threadId, resumeOperation);
-        const stateDeltaEvent = buildPiRuntimeGatewayStateDeltaEventInternal({
+        const stateRebaselineEvent = buildPiRuntimeGatewayStateRebaselineEventInternal({
           previousSession,
           session: nextSession,
         });
@@ -2821,7 +2822,7 @@ export async function createAgentRuntime<TState = unknown>(
                 threadId: request.threadId,
                 runId: request.runId,
               },
-              ...(stateDeltaEvent ? [stateDeltaEvent] : []),
+              ...(stateRebaselineEvent ? [stateRebaselineEvent] : []),
               {
                 type: EventType.RUN_FINISHED,
                 threadId: request.threadId,

--- a/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-ember-lending/src/agUiServer.int.test.ts
@@ -222,15 +222,24 @@ function projectStateSnapshot(input: {
   baseline?: AgUiEventEnvelope;
   events: readonly AgUiEventEnvelope[];
 }) {
-  const projectedSnapshot = cloneJson(
+  let projectedSnapshot = cloneJson(
     (input.baseline && 'snapshot' in input.baseline ? input.baseline.snapshot : { thread: {} }) as Record<
       string,
       unknown
     >,
   );
 
-  for (const event of findStateDeltas(input.events)) {
-    for (const operation of event.delta) {
+  for (const event of input.events) {
+    if (event.type === 'STATE_SNAPSHOT' && isRecord(event.snapshot)) {
+      projectedSnapshot = cloneJson(event.snapshot);
+      continue;
+    }
+
+    if (event.type !== 'STATE_DELTA' || !Array.isArray(event.delta)) {
+      continue;
+    }
+
+    for (const operation of event.delta as JsonPatchOperation[]) {
       applyJsonPatchOperation(projectedSnapshot, operation);
     }
   }

--- a/typescript/clients/web-ag-ui/apps/agent-pi-example/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-pi-example/src/agUiServer.unit.test.ts
@@ -113,6 +113,37 @@ async function collectEventSource<T>(source: readonly T[] | AsyncIterable<T>): P
   return events;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readCurrentArtifactData(event: unknown): unknown {
+  if (!isRecord(event)) {
+    return undefined;
+  }
+
+  if (event['type'] === 'STATE_SNAPSHOT' && isRecord(event['snapshot'])) {
+    const thread = event['snapshot']['thread'];
+    const artifacts = isRecord(thread) ? thread['artifacts'] : undefined;
+    const current = isRecord(artifacts) ? artifacts['current'] : undefined;
+    return isRecord(current) ? current['data'] : undefined;
+  }
+
+  if (event['type'] !== 'STATE_DELTA' || !Array.isArray(event['delta'])) {
+    return undefined;
+  }
+
+  const artifactsDelta = event['delta'].find(
+    (operation) =>
+      isRecord(operation) &&
+      operation['op'] === 'add' &&
+      operation['path'] === '/thread/artifacts',
+  );
+  const value = isRecord(artifactsDelta) ? artifactsDelta['value'] : undefined;
+  const current = isRecord(value) ? value['current'] : undefined;
+  return isRecord(current) ? current['data'] : undefined;
+}
+
 describe('createPiExampleAgUiHandler', () => {
   it('requires real Pi foundation env for default service startup', async () => {
     await expect(createPiExampleGatewayService()).rejects.toThrow('OPENROUTER_API_KEY');
@@ -193,34 +224,9 @@ describe('createPiExampleAgUiHandler', () => {
       }),
     );
 
-    const stateDelta = runEvents.find(
-      (event) =>
-        typeof event === 'object' &&
-        event !== null &&
-        'type' in event &&
-        event.type === 'STATE_DELTA' &&
-        Array.isArray((event as { delta?: unknown[] }).delta),
-    ) as
-      | {
-          delta?: Array<{
-            op?: string;
-            path?: string;
-            value?: {
-              current?: {
-                data?: { type?: string; status?: string };
-              };
-            };
-          }>;
-        }
-      | undefined;
+    const artifactData = [...runEvents].reverse().map(readCurrentArtifactData).find(Boolean);
 
-    const artifactsDelta = stateDelta?.delta?.find(
-      (operation) =>
-        operation.op === 'add' &&
-        operation.path === '/thread/artifacts',
-    );
-
-    expect(artifactsDelta?.value?.current?.data).toMatchObject({
+    expect(artifactData).toMatchObject({
       type: 'automation-status',
       status: 'scheduled',
     });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/.env.example
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/.env.example
@@ -30,3 +30,21 @@ OPENROUTER_API_KEY=
 # PORTFOLIO_MANAGER_OWS_PASSPHRASE=
 # For Docker Compose deployments, this should usually be the mounted in-container path.
 # PORTFOLIO_MANAGER_OWS_VAULT_PATH=/runtime/ows/portfolio-manager
+
+# Optional: override the Onchain Actions API origin used by the hidden PM-owned
+# `agent-oca-executor` swap path. Defaults to `https://api.emberai.xyz`.
+# ONCHAIN_ACTIONS_API_URL=https://api.emberai.xyz
+
+# Optional: RPC overrides used when the hidden OCA executor wraps prepared swap
+# calls in the delegated execution transaction that the runtime-owned signer
+# signs. Defaults are public Arbitrum and Ethereum RPC URLs.
+# ARBITRUM_RPC_URL=https://arb1.arbitrum.io/rpc
+# ETHEREUM_RPC_URL=https://eth.merkle.io
+
+# Optional: select the OWS wallet for the hidden PM-owned Onchain Actions
+# executor. When unset or temporarily unreadable, PM activation still succeeds,
+# but hidden swap dispatch fails closed before signing if the executor identity
+# and wallet cannot be established for that exact request.
+# PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME=portfolio-manager-oca-executor-wallet
+# PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_PASSPHRASE=
+# PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH=/runtime/ows/portfolio-manager-oca-executor

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/README.md
@@ -30,6 +30,15 @@ Runtime wiring:
   vault requires it.
 - `PORTFOLIO_MANAGER_OWS_VAULT_PATH` points the runtime at the vault containing
   the configured controller wallet.
+- `ONCHAIN_ACTIONS_API_URL` optionally overrides the Onchain Actions API origin
+  used by the hidden PM-owned `agent-oca-executor` swap path.
+- `ARBITRUM_RPC_URL` and `ETHEREUM_RPC_URL` optionally override the RPC origins
+  used when the hidden executor wraps OCA swap calls in the delegated execution
+  transaction signed by the runtime-owned signer.
+- `PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME`,
+  `PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_PASSPHRASE`, and
+  `PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH` select the direct OWS wallet
+  for the hidden Onchain Actions executor identity and signing path.
 - when `SHARED_EMBER_BASE_URL` is set for the live managed-onboarding path,
   startup now resolves the configured controller wallet directly from OWS core
   and confirms the
@@ -43,6 +52,12 @@ Runtime wiring:
   echoes back the confirmed `portfolio-manager` / `orchestrator` identity with
   the expected `agent_id`, `role`, and wallet address; if any part of that
   confirmation is missing or mismatched, the runtime fails closed
+- startup also attempts best-effort registration or repair of the hidden
+  `agent-oca-executor` / `subagent` identity with
+  `visibility=internal`, `owner_agent_id=agent-portfolio-manager`,
+  `worker_kind=execution`, `execution_surface=onchain_actions`, and
+  `control_paths=["spot.swap"]`; hidden executor readiness does not block PM
+  activation
 - onboarding re-reads both required durable service identities before rooted
   bootstrap and blocks activation if either `portfolio-manager` /
   `orchestrator` or `ember-lending` / `subagent` is missing or unverified
@@ -53,6 +68,32 @@ Runtime wiring:
 - if OWS is unavailable or does not resolve a controller wallet while Shared
   Ember is configured, the runtime fails closed before managed onboarding can
   proceed
+
+## Hidden Onchain Actions executor
+
+`agent-portfolio-manager` exposes a structured `dispatch_spot_swap` command for
+PM-owned swap execution. The command accepts the Onchain Actions swap fields
+`walletAddress`, `amount`, `amountType`, `fromChain`, `toChain`, `fromToken`,
+`toToken`, and optional `slippageTolerance`, `expiration`, `idempotencyKey`, and
+`rootedWalletContextId`.
+
+The command dispatches a stateless hidden executor implementation for the exact
+request. The executor resolves PM-facing tokens against the Onchain Actions token
+catalog, prepares the swap with `/swap`, creates a Shared Ember `spot.swap`
+transaction plan, requests execution readiness, wraps the returned OCA
+transaction requests in the delegated execution transaction, signs through the
+runtime-owned `oca-executor-wallet` signer, and submits the signed transaction
+back through Shared Ember.
+
+The hidden executor is not registered in the public web agent registry, CopilotKit
+runtime registry, visible routes, or the public direct-command API. PM remains
+the only user-facing imperative control plane for this swap path.
+
+When Shared Ember reports `reserved_for_other_agent`, PM stores the exact pending
+swap and interrupts for conflict-only confirmation. A retry sends the same swap
+with `reservation_conflict_handling.kind` set to either
+`allow_reserved_for_other_agent` or `unassigned_only`. User reserve policy remains
+non-overridable.
 
 ## Shared Ember sidecar testing
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.int.test.ts
@@ -77,13 +77,42 @@ function findStateDeltas(events: readonly AgUiEventEnvelope[]) {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function encodeJsonPointerToken(token: string): string {
+  return token.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function collectSnapshotReplaceOperations(value: unknown, path = ''): JsonPatchOperation[] {
+  if (!isRecord(value) && !Array.isArray(value)) {
+    return [{ op: 'replace', path, value }];
+  }
+
+  const entries = Array.isArray(value) ? [...value.entries()] : Object.entries(value);
+  return entries.flatMap(([key, nestedValue]) =>
+    collectSnapshotReplaceOperations(
+      nestedValue,
+      `${path}/${encodeJsonPointerToken(String(key))}`,
+    ),
+  );
+}
+
 function expectStateDeltaOperation(
   events: readonly AgUiEventEnvelope[],
   predicate: (operation: JsonPatchOperation) => boolean,
 ) {
-  const stateDeltas = findStateDeltas(events);
-  expect(stateDeltas).not.toHaveLength(0);
-  expect(stateDeltas.some((event) => event.delta.some(predicate))).toBe(true);
+  const operations = [
+    ...findStateDeltas(events).flatMap((event) => event.delta),
+    ...events.flatMap((event) =>
+      event.type === 'STATE_SNAPSHOT' && isRecord(event['snapshot'])
+        ? collectSnapshotReplaceOperations(event['snapshot'])
+        : [],
+    ),
+  ];
+  expect(operations).not.toHaveLength(0);
+  expect(operations.some(predicate)).toBe(true);
 }
 
 async function readFirstMatchingSseEvent(

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
@@ -6,15 +6,15 @@ import {
 } from 'agent-runtime/internal';
 
 import {
+  derivePortfolioManagerControllerSmartAccountAddress,
+  ensurePortfolioManagerControllerSmartAccountDeployed,
+} from './controllerIdentity.js';
+import {
   createPortfolioManagerAgentConfig,
   type PortfolioManagerAgentConfig,
   type PortfolioManagerGatewayEnv,
   resolvePortfolioManagerGatewayDependencies,
 } from './portfolioManagerFoundation.js';
-import {
-  derivePortfolioManagerControllerSmartAccountAddress,
-  ensurePortfolioManagerControllerSmartAccountDeployed,
-} from './controllerIdentity.js';
 import { ensurePortfolioManagerServiceIdentities } from './serviceIdentityPreflight.js';
 
 export const PORTFOLIO_MANAGER_AGENT_ID = 'agent-portfolio-manager';
@@ -155,6 +155,7 @@ export async function createPortfolioManagerGatewayService(
       const dependencies = resolvePortfolioManagerGatewayDependencies(options.env);
       let controllerWalletAddress: `0x${string}` | undefined;
       let controllerSignerAddress: `0x${string}` | undefined;
+      let hiddenOcaExecutorWalletAddress: `0x${string}` | undefined;
 
       if (dependencies.protocolHost) {
         controllerSignerAddress = await readRequiredControllerSignerAddress({
@@ -191,7 +192,7 @@ export async function createPortfolioManagerGatewayService(
           options.__internalEnsureServiceIdentity ?? ensurePortfolioManagerServiceIdentities
         )({
           protocolHost: dependencies.protocolHost,
-          readControllerWalletAddress: async () => controllerSmartAccountAddress,
+          readControllerWalletAddress: () => Promise.resolve(controllerSmartAccountAddress),
           readExecutorWalletAddress: async () =>
             await readHiddenOcaExecutorSignerAddress({
               signing,
@@ -205,14 +206,25 @@ export async function createPortfolioManagerGatewayService(
         }
 
         controllerWalletAddress = walletAddress;
+        if (
+          ensuredIdentities.hiddenOcaExecutor &&
+          'identity' in ensuredIdentities.hiddenOcaExecutor
+        ) {
+          const executorWalletAddress = ensuredIdentities.hiddenOcaExecutor.identity.wallet_address;
+          if (executorWalletAddress.startsWith('0x')) {
+            hiddenOcaExecutorWalletAddress = executorWalletAddress;
+          }
+        }
       }
 
       return {
         ...createPortfolioManagerAgentConfig(options.env, {
           runtimeSigning: signing,
           runtimeSignerRef: PORTFOLIO_MANAGER_RUNTIME_SIGNER_REF,
+          hiddenOcaExecutorRuntimeSignerRef: HIDDEN_OCA_EXECUTOR_RUNTIME_SIGNER_REF,
           ...(controllerSignerAddress ? { controllerSignerAddress } : {}),
           ...(controllerWalletAddress ? { controllerWalletAddress } : {}),
+          ...(hiddenOcaExecutorWalletAddress ? { hiddenOcaExecutorWalletAddress } : {}),
         }),
         ...(options.now ? { now: options.now } : {}),
         ...(options.__internalPostgres ? { __internalPostgres: options.__internalPostgres } : {}),

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.ts
@@ -15,11 +15,12 @@ import {
   derivePortfolioManagerControllerSmartAccountAddress,
   ensurePortfolioManagerControllerSmartAccountDeployed,
 } from './controllerIdentity.js';
-import { ensurePortfolioManagerServiceIdentity } from './serviceIdentityPreflight.js';
+import { ensurePortfolioManagerServiceIdentities } from './serviceIdentityPreflight.js';
 
 export const PORTFOLIO_MANAGER_AGENT_ID = 'agent-portfolio-manager';
 export const PORTFOLIO_MANAGER_AG_UI_BASE_PATH = '/ag-ui';
 export const PORTFOLIO_MANAGER_RUNTIME_SIGNER_REF = 'controller-wallet';
+export const HIDDEN_OCA_EXECUTOR_RUNTIME_SIGNER_REF = 'oca-executor-wallet';
 export type PortfolioManagerGatewayService = AgentRuntimeService;
 const CONTROLLER_DEPLOYMENT_INSUFFICIENT_FUNDS_PATTERN =
   /insufficient funds for gas \* price \+ value/i;
@@ -55,7 +56,7 @@ type PortfolioManagerGatewayServiceOptions = {
 
 type PortfolioManagerGatewayInternalOptions = PortfolioManagerGatewayServiceOptions & {
   __internalCreateAgentRuntimeKernel?: typeof createAgentRuntimeKernel;
-  __internalEnsureServiceIdentity?: typeof ensurePortfolioManagerServiceIdentity;
+  __internalEnsureServiceIdentity?: typeof ensurePortfolioManagerServiceIdentities;
   __internalDeriveControllerSmartAccountAddress?: typeof derivePortfolioManagerControllerSmartAccountAddress;
   __internalEnsureControllerSmartAccountDeployed?: typeof ensurePortfolioManagerControllerSmartAccountDeployed;
   __internalPostgres?: AgentRuntimeInternalPostgresHooks;
@@ -89,6 +90,34 @@ async function readRequiredControllerSignerAddress(input: {
   }
 }
 
+async function readHiddenOcaExecutorSignerAddress(input: {
+  signing: {
+    readAddress(input: { signerRef: string }): Promise<`0x${string}`>;
+  };
+}): Promise<`0x${string}`> {
+  try {
+    return await input.signing.readAddress({
+      signerRef: HIDDEN_OCA_EXECUTOR_RUNTIME_SIGNER_REF,
+    });
+  } catch (error) {
+    if (error instanceof AgentRuntimeSigningError) {
+      if (error.code === 'signer_not_declared' || error.code === 'signer_not_configured') {
+        throw new Error(
+          'Hidden Onchain Actions executor identity readiness requires PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME to resolve the configured executor wallet.',
+        );
+      }
+
+      if (error.code === 'wallet_lookup_failed' || error.code === 'identity_address_missing') {
+        throw new Error(
+          'Hidden Onchain Actions executor identity readiness failed because the configured OWS wallet did not resolve an EVM address.',
+        );
+      }
+    }
+
+    throw error;
+  }
+}
+
 export async function createPortfolioManagerGatewayService(
   options?: PortfolioManagerGatewayServiceOptions,
 ): Promise<AgentRuntimeService>;
@@ -106,6 +135,12 @@ export async function createPortfolioManagerGatewayService(
         walletNameOrIdEnvVar: 'PORTFOLIO_MANAGER_OWS_WALLET_NAME',
         passphraseEnvVar: 'PORTFOLIO_MANAGER_OWS_PASSPHRASE',
         vaultPathEnvVar: 'PORTFOLIO_MANAGER_OWS_VAULT_PATH',
+      },
+      {
+        signerRef: HIDDEN_OCA_EXECUTOR_RUNTIME_SIGNER_REF,
+        walletNameOrIdEnvVar: 'PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME',
+        passphraseEnvVar: 'PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_PASSPHRASE',
+        vaultPathEnvVar: 'PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH',
       },
     ],
     createRuntimeOptions: async ({ signing }) => {
@@ -152,13 +187,17 @@ export async function createPortfolioManagerGatewayService(
 
           throw error;
         }
-        const ensuredIdentity = await (
-          options.__internalEnsureServiceIdentity ?? ensurePortfolioManagerServiceIdentity
+        const ensuredIdentities = await (
+          options.__internalEnsureServiceIdentity ?? ensurePortfolioManagerServiceIdentities
         )({
           protocolHost: dependencies.protocolHost,
           readControllerWalletAddress: async () => controllerSmartAccountAddress,
+          readExecutorWalletAddress: async () =>
+            await readHiddenOcaExecutorSignerAddress({
+              signing,
+            }),
         });
-        const walletAddress = ensuredIdentity.identity.wallet_address;
+        const walletAddress = ensuredIdentities.orchestrator.identity.wallet_address;
         if (!walletAddress.startsWith('0x')) {
           throw new Error(
             'Portfolio-manager startup identity preflight failed because Shared Ember did not return a confirmed orchestrator wallet address.',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/agUiServer.unit.test.ts
@@ -24,7 +24,126 @@ function createStubService(): AgentRuntimeService {
 }
 
 describe('createPortfolioManagerGatewayService', () => {
-  it('runs controller-wallet identity preflight before runtime creation when the live Shared Ember path is configured', async () => {
+  it('runs controller-wallet and hidden executor identity preflight before runtime creation when the live Shared Ember path is configured', async () => {
+    const service = createStubService();
+    const deriveControllerSmartAccountAddress = vi.fn(
+      async () => '0x00000000000000000000000000000000000000c2' as const,
+    );
+    const ensureControllerSmartAccountDeployed = vi.fn(
+      async () => '0x00000000000000000000000000000000000000c2' as const,
+    );
+    const ensureServiceIdentity = vi.fn(async (input: {
+      readControllerWalletAddress: () => Promise<`0x${string}`>;
+      readExecutorWalletAddress?: () => Promise<`0x${string}`>;
+    }) => {
+      await expect(input.readControllerWalletAddress()).resolves.toBe(
+        '0x00000000000000000000000000000000000000c2',
+      );
+      await expect(input.readExecutorWalletAddress?.()).resolves.toBe(
+        '0x00000000000000000000000000000000000000e1',
+      );
+
+      return {
+        orchestrator: {
+          revision: 2,
+          wroteIdentity: false,
+          identity: {
+            wallet_address: '0x00000000000000000000000000000000000000c2',
+          },
+        },
+        hiddenOcaExecutor: {
+          revision: 3,
+          wroteIdentity: false,
+          identity: {
+            wallet_address: '0x00000000000000000000000000000000000000e1',
+          },
+        },
+      };
+    });
+    const runtimeCreated = vi.fn();
+    const createAgentRuntimeKernel = vi.fn(async ({ createRuntimeOptions }) => {
+      const signing = {
+        readAddress: vi.fn(async ({ signerRef }: { signerRef: string }) => {
+          if (signerRef === 'controller-wallet') {
+            return '0x00000000000000000000000000000000000000c1' as const;
+          }
+
+          if (signerRef === 'oca-executor-wallet') {
+            return '0x00000000000000000000000000000000000000e1' as const;
+          }
+
+          throw new Error(`unexpected signer ref: ${signerRef}`);
+        }),
+        signPayload: vi.fn(),
+      };
+      await createRuntimeOptions({
+        signing,
+      });
+      runtimeCreated();
+      return {
+        service,
+        signing,
+      };
+    });
+
+    await expect(
+      createPortfolioManagerGatewayService({
+        env: {
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+          SHARED_EMBER_BASE_URL: 'http://127.0.0.1:56436',
+          PORTFOLIO_MANAGER_OWS_WALLET_NAME: 'portfolio-manager-controller-wallet',
+          PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME: 'portfolio-manager-oca-executor-wallet',
+          PORTFOLIO_MANAGER_OWS_VAULT_PATH: '/tmp/portfolio-manager-ows-vault',
+        },
+        __internalEnsureServiceIdentity: ensureServiceIdentity,
+        __internalDeriveControllerSmartAccountAddress: deriveControllerSmartAccountAddress,
+        __internalEnsureControllerSmartAccountDeployed: ensureControllerSmartAccountDeployed,
+        __internalCreateAgentRuntimeKernel: createAgentRuntimeKernel,
+      } as never),
+    ).resolves.toBe(service);
+
+    expect(deriveControllerSmartAccountAddress).toHaveBeenCalledWith({
+      signerAddress: '0x00000000000000000000000000000000000000c1',
+    });
+    expect(ensureControllerSmartAccountDeployed).toHaveBeenCalledWith({
+      signing: expect.objectContaining({
+        readAddress: expect.any(Function),
+        signPayload: expect.any(Function),
+      }),
+      signerRef: 'controller-wallet',
+      signerAddress: '0x00000000000000000000000000000000000000c1',
+    });
+    expect(ensureServiceIdentity).toHaveBeenCalledOnce();
+    expect(createAgentRuntimeKernel).toHaveBeenCalledOnce();
+    expect(createAgentRuntimeKernel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owsSigners: [
+          {
+            signerRef: 'controller-wallet',
+            walletNameOrIdEnvVar: 'PORTFOLIO_MANAGER_OWS_WALLET_NAME',
+            passphraseEnvVar: 'PORTFOLIO_MANAGER_OWS_PASSPHRASE',
+            vaultPathEnvVar: 'PORTFOLIO_MANAGER_OWS_VAULT_PATH',
+          },
+          {
+            signerRef: 'oca-executor-wallet',
+            walletNameOrIdEnvVar: 'PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME',
+            passphraseEnvVar: 'PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_PASSPHRASE',
+            vaultPathEnvVar: 'PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH',
+          },
+        ],
+      }),
+    );
+    const deployCallOrder = ensureControllerSmartAccountDeployed.mock.invocationCallOrder.at(0);
+    const ensureCallOrder = ensureServiceIdentity.mock.invocationCallOrder.at(0);
+    const runtimeCallOrder = runtimeCreated.mock.invocationCallOrder.at(0);
+    expect(deployCallOrder).toBeDefined();
+    expect(ensureCallOrder).toBeDefined();
+    expect(runtimeCallOrder).toBeDefined();
+    expect(deployCallOrder!).toBeLessThan(ensureCallOrder!);
+    expect(ensureCallOrder!).toBeLessThan(runtimeCallOrder!);
+  });
+
+  it('continues runtime creation when hidden executor identity readiness is deferred', async () => {
     const service = createStubService();
     const deriveControllerSmartAccountAddress = vi.fn(
       async () => '0x00000000000000000000000000000000000000c2' as const,
@@ -33,10 +152,16 @@ describe('createPortfolioManagerGatewayService', () => {
       async () => '0x00000000000000000000000000000000000000c2' as const,
     );
     const ensureServiceIdentity = vi.fn(async () => ({
-      revision: 2,
-      wroteIdentity: false,
-      identity: {
-        wallet_address: '0x00000000000000000000000000000000000000c2',
+      orchestrator: {
+        revision: 2,
+        wroteIdentity: false,
+        identity: {
+          wallet_address: '0x00000000000000000000000000000000000000c2',
+        },
+      },
+      hiddenOcaExecutor: {
+        status: 'deferred',
+        reason: 'hidden executor wallet is not configured',
       },
     }));
     const runtimeCreated = vi.fn();
@@ -70,27 +195,8 @@ describe('createPortfolioManagerGatewayService', () => {
       } as never),
     ).resolves.toBe(service);
 
-    expect(deriveControllerSmartAccountAddress).toHaveBeenCalledWith({
-      signerAddress: '0x00000000000000000000000000000000000000c1',
-    });
-    expect(ensureControllerSmartAccountDeployed).toHaveBeenCalledWith({
-      signing: expect.objectContaining({
-        readAddress: expect.any(Function),
-        signPayload: expect.any(Function),
-      }),
-      signerRef: 'controller-wallet',
-      signerAddress: '0x00000000000000000000000000000000000000c1',
-    });
     expect(ensureServiceIdentity).toHaveBeenCalledOnce();
-    expect(createAgentRuntimeKernel).toHaveBeenCalledOnce();
-    const deployCallOrder = ensureControllerSmartAccountDeployed.mock.invocationCallOrder.at(0);
-    const ensureCallOrder = ensureServiceIdentity.mock.invocationCallOrder.at(0);
-    const runtimeCallOrder = runtimeCreated.mock.invocationCallOrder.at(0);
-    expect(deployCallOrder).toBeDefined();
-    expect(ensureCallOrder).toBeDefined();
-    expect(runtimeCallOrder).toBeDefined();
-    expect(deployCallOrder!).toBeLessThan(ensureCallOrder!);
-    expect(ensureCallOrder!).toBeLessThan(runtimeCallOrder!);
+    expect(runtimeCreated).toHaveBeenCalledOnce();
   });
 
   it('fails closed before runtime creation when the controller wallet identity cannot be established', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -482,6 +482,19 @@ function buildInputOnlySwapSummary(
   };
 }
 
+function applyDefaultReservationConflictHandling(
+  request: HiddenOcaSpotSwapInput,
+): HiddenOcaSpotSwapInput {
+  return request.reservationConflictHandling
+    ? request
+    : {
+        ...request,
+        reservationConflictHandling: {
+          kind: 'unassigned_only',
+        },
+      };
+}
+
 function normalizeSpotSwapAmount(input: {
   request: HiddenOcaSpotSwapInput;
   fromToken: OnchainActionsToken;
@@ -744,6 +757,30 @@ function readBlockedConflict(
   };
 }
 
+function appendSentencePunctuation(value: string): string {
+  return /[.!?]$/u.test(value) ? value : `${value}.`;
+}
+
+function readBlockedFailureReason(executionResult: Record<string, unknown>): string {
+  const requestResult = readRecordKey(executionResult, 'request_result');
+  const blockingReasonCode = readString(requestResult?.['blocking_reason_code']);
+  const message = readString(requestResult?.['message']);
+
+  if (blockingReasonCode && message) {
+    return `Shared Ember blocked hidden swap execution (${blockingReasonCode}): ${appendSentencePunctuation(message)}`;
+  }
+
+  if (message) {
+    return `Shared Ember blocked hidden swap execution: ${appendSentencePunctuation(message)}`;
+  }
+
+  if (blockingReasonCode) {
+    return `Shared Ember blocked hidden swap execution (${blockingReasonCode}).`;
+  }
+
+  return 'Shared Ember blocked hidden swap execution.';
+}
+
 function buildBlockedResult(input: {
   request: HiddenOcaSpotSwapInput;
   swapResponse: OnchainActionsSwapResponse;
@@ -764,6 +801,7 @@ function buildBlockedResult(input: {
     requestId: readExecutionRequestId(input.executionResult),
     committedEventIds: input.committedEventIds,
     ...(conflict ? { conflict } : {}),
+    ...(conflict ? {} : { failureReason: readBlockedFailureReason(input.executionResult) }),
   };
 }
 
@@ -1412,10 +1450,10 @@ export function createHiddenOcaSpotSwapExecutor(
         });
       }
 
-      const request: HiddenOcaSpotSwapInput = {
+      const request: HiddenOcaSpotSwapInput = applyDefaultReservationConflictHandling({
         ...input,
         walletAddress,
-      };
+      });
       const idempotencyKey = request.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(request);
       let fromChainId: string;
       let toChainId: string;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -9,7 +9,7 @@ import {
 import { DelegationManager } from '@metamask/delegation-toolkit/contracts';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedEvmTransaction } from 'agent-runtime/internal';
-import { createPublicClient, http, serializeTransaction } from 'viem';
+import { createPublicClient, http, isAddress, isAddressEqual, isHex, serializeTransaction } from 'viem';
 import { arbitrum, mainnet } from 'viem/chains';
 
 import {
@@ -90,6 +90,7 @@ type HiddenOcaSpotSwapExecutionInput = {
 
 export type HiddenOcaSpotSwapResult = {
   status: 'completed' | 'submitted' | 'conflict' | 'awaiting_redelegation' | 'blocked' | 'failed';
+  idempotencyKey?: string;
   swapSummary: {
     fromToken: string;
     toToken: string;
@@ -181,6 +182,14 @@ type SharedEmberRevisionResponse = {
   };
 };
 
+function isSharedEmberRevisionConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('Shared Ember Domain Service JSON-RPC error: protocol_conflict') &&
+    error.message.includes('expected_revision')
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -191,7 +200,9 @@ function readString(value: unknown): string | null {
 
 function readHexAddress(value: unknown): `0x${string}` | null {
   const normalized = readString(value);
-  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+  return normalized && isAddress(normalized, { strict: false })
+    ? (normalized.toLowerCase() as `0x${string}`)
+    : null;
 }
 
 function readInt(value: unknown): number | null {
@@ -378,6 +389,19 @@ function buildSwapSummary(input: {
   };
 }
 
+function buildInputOnlySwapSummary(
+  request: HiddenOcaSpotSwapInput,
+): HiddenOcaSpotSwapResult['swapSummary'] {
+  return {
+    fromToken: request.fromToken,
+    toToken: request.toToken,
+    amount: request.amount,
+    amountType: request.amountType,
+    displayFromAmount: '',
+    displayToAmount: '',
+  };
+}
+
 async function readCurrentSharedEmberRevision(input: {
   protocolHost: PortfolioManagerSharedEmberProtocolHost;
   threadId: string;
@@ -400,10 +424,24 @@ async function runSharedEmberCommandWithResolvedRevision<T>(input: {
   currentRevision: number | null;
   buildRequest: (expectedRevision: number) => unknown;
 }): Promise<T> {
-  const expectedRevision =
+  let expectedRevision =
     input.currentRevision ?? (await readCurrentSharedEmberRevision(input));
 
-  return (await input.protocolHost.handleJsonRpc(input.buildRequest(expectedRevision))) as T;
+  try {
+    return (await input.protocolHost.handleJsonRpc(input.buildRequest(expectedRevision))) as T;
+  } catch (error) {
+    if (!isSharedEmberRevisionConflict(error)) {
+      throw error;
+    }
+
+    const refreshedRevision = await readCurrentSharedEmberRevision(input);
+    if (refreshedRevision === expectedRevision) {
+      throw error;
+    }
+
+    expectedRevision = refreshedRevision;
+    return (await input.protocolHost.handleJsonRpc(input.buildRequest(expectedRevision))) as T;
+  }
 }
 
 function buildCreateTransactionRequest(input: {
@@ -517,11 +555,13 @@ function buildBlockedResult(input: {
   swapResponse: OnchainActionsSwapResponse;
   executionResult: Record<string, unknown>;
   committedEventIds: string[];
+  idempotencyKey?: string;
 }): HiddenOcaSpotSwapResult {
   const conflict = readBlockedConflict(input.executionResult);
 
   return {
     status: conflict ? 'conflict' : 'blocked',
+    ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
     swapSummary: buildSwapSummary({
       request: input.request,
       swapResponse: input.swapResponse,
@@ -546,11 +586,13 @@ function buildCompletedResult(input: {
   swapResponse: OnchainActionsSwapResponse;
   executionResult: Record<string, unknown>;
   committedEventIds: string[];
+  idempotencyKey?: string;
 }): HiddenOcaSpotSwapResult {
   const executionStatus = readCompletedExecutionStatus(input.executionResult);
 
   return {
     status: executionStatus === 'submitted' ? 'submitted' : 'completed',
+    ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
     swapSummary: buildSwapSummary({
       request: input.request,
       swapResponse: input.swapResponse,
@@ -690,13 +732,13 @@ async function signAndSubmitPreparedExecution(input: {
   const executionPreparation = readExecutionPreparation(input.executionResult);
   const executionSigningPackage = readExecutionSigningPackage(input.executionResult);
   const preparedWalletAddress = readHexAddress(executionPreparation?.['agent_wallet']);
-  const expectedWalletAddress = input.options.executorWalletAddress;
+  const expectedWalletAddress = readHexAddress(input.options.executorWalletAddress);
   if (!expectedWalletAddress || !preparedWalletAddress) {
     throw new Error(
       'Hidden swap execution signing could not continue because the executor wallet identity is incomplete.',
     );
   }
-  if (preparedWalletAddress !== expectedWalletAddress) {
+  if (!isAddressEqual(preparedWalletAddress, expectedWalletAddress)) {
     throw new Error(
       'Hidden swap execution signing could not continue because the prepared signing package does not match the hidden executor wallet.',
     );
@@ -775,9 +817,11 @@ function createFailedResult(input: {
   requestId: string | null;
   committedEventIds: string[];
   failureReason: string;
+  idempotencyKey?: string;
 }): HiddenOcaSpotSwapResult {
   return {
     status: 'failed',
+    ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
     swapSummary: buildSwapSummary({
       request: input.request,
       swapResponse: input.swapResponse,
@@ -789,10 +833,27 @@ function createFailedResult(input: {
   };
 }
 
+function createInputFailedResult(input: {
+  request: HiddenOcaSpotSwapInput;
+  idempotencyKey?: string;
+  failureReason: string;
+}): HiddenOcaSpotSwapResult {
+  return {
+    status: 'failed',
+    ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+    swapSummary: buildInputOnlySwapSummary(input.request),
+    transactionPlanId: null,
+    requestId: null,
+    committedEventIds: [],
+    failureReason: input.failureReason,
+  };
+}
+
 async function runExecutionFlow(input: {
   options: HiddenOcaSpotSwapExecutorOptions;
   threadId: string;
   idempotencyKey: string;
+  resultIdempotencyKey: string;
   currentRevision: number | null;
   transactionPlanId: string;
   request: HiddenOcaSpotSwapInput;
@@ -830,6 +891,7 @@ async function runExecutionFlow(input: {
         requestId: null,
         committedEventIds,
         failureReason: 'Shared Ember did not return a hidden swap execution result.',
+        idempotencyKey: input.resultIdempotencyKey,
       });
     }
 
@@ -839,6 +901,7 @@ async function runExecutionFlow(input: {
         swapResponse: input.swapResponse,
         executionResult,
         committedEventIds,
+        idempotencyKey: input.resultIdempotencyKey,
       });
     }
 
@@ -848,29 +911,44 @@ async function runExecutionFlow(input: {
         swapResponse: input.swapResponse,
         executionResult,
         committedEventIds,
+        idempotencyKey: input.resultIdempotencyKey,
       });
     }
 
     if (phase === 'ready_for_redelegation') {
       const requestId = readExecutionRequestId(executionResult);
       if (!requestId || !input.options.requestRedelegationRefresh) {
-        return {
-          status: 'awaiting_redelegation',
-          swapSummary: buildSwapSummary({
-            request: input.request,
-            swapResponse: input.swapResponse,
-          }),
+        return createFailedResult({
+          request: input.request,
+          swapResponse: input.swapResponse,
           transactionPlanId: input.transactionPlanId,
           requestId,
           committedEventIds,
-        };
+          failureReason:
+            'Hidden swap execution reached redelegation readiness, but no redelegation refresh handler is configured.',
+          idempotencyKey: input.resultIdempotencyKey,
+        });
       }
 
-      await input.options.requestRedelegationRefresh({
-        threadId: input.threadId,
-        transactionPlanId: input.transactionPlanId,
-        requestId,
-      });
+      try {
+        await input.options.requestRedelegationRefresh({
+          threadId: input.threadId,
+          transactionPlanId: input.transactionPlanId,
+          requestId,
+        });
+      } catch (error) {
+        return createFailedResult({
+          request: input.request,
+          swapResponse: input.swapResponse,
+          transactionPlanId: input.transactionPlanId,
+          requestId,
+          committedEventIds,
+          failureReason:
+            error instanceof Error ? error.message : 'Unknown hidden swap redelegation failure.',
+          idempotencyKey: input.resultIdempotencyKey,
+        });
+      }
+      revision = null;
       attempt += 1;
       continue;
     }
@@ -897,6 +975,7 @@ async function runExecutionFlow(input: {
           requestId: readExecutionRequestId(executionResult),
           committedEventIds,
           failureReason: error instanceof Error ? error.message : 'Unknown hidden swap signing failure.',
+          idempotencyKey: input.resultIdempotencyKey,
         });
       }
 
@@ -906,6 +985,7 @@ async function runExecutionFlow(input: {
           swapResponse: input.swapResponse,
           executionResult,
           committedEventIds,
+          idempotencyKey: input.resultIdempotencyKey,
         });
       }
 
@@ -916,6 +996,7 @@ async function runExecutionFlow(input: {
         requestId: readExecutionRequestId(executionResult),
         committedEventIds,
         failureReason: 'Shared Ember did not complete hidden swap signed-transaction submission.',
+        idempotencyKey: input.resultIdempotencyKey,
       });
     }
 
@@ -929,6 +1010,7 @@ async function runExecutionFlow(input: {
     requestId: null,
     committedEventIds,
     failureReason: 'Shared Ember did not complete hidden swap execution readiness.',
+    idempotencyKey: input.resultIdempotencyKey,
   });
 }
 
@@ -957,6 +1039,37 @@ function readTokensResponse(value: unknown): OnchainActionsToken[] {
   });
 }
 
+function readSwapTransaction(value: unknown): OnchainActionsTransactionRequest | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const type = readString(value['type']);
+  const to = readHexAddress(value['to']);
+  const chainId = readString(value['chainId']);
+  const data = readString(value['data']);
+  const transactionValue = value['value'] === undefined ? undefined : readString(value['value']);
+
+  if (
+    type === null ||
+    to === null ||
+    chainId === null ||
+    data === null ||
+    !isHex(data) ||
+    (value['value'] !== undefined && transactionValue === null)
+  ) {
+    return null;
+  }
+
+  return {
+    type,
+    to,
+    ...(transactionValue ? { value: transactionValue } : {}),
+    data: data.toLowerCase() as `0x${string}`,
+    chainId,
+  };
+}
+
 function readSwapResponse(value: unknown): OnchainActionsSwapResponse {
   if (!isRecord(value) || !Array.isArray(value['transactions']) || value['transactions'].length === 0) {
     throw new Error('Onchain Actions swap response did not include executable transactions.');
@@ -968,17 +1081,13 @@ function readSwapResponse(value: unknown): OnchainActionsSwapResponse {
   const displayFromAmount = readString(value['displayFromAmount']);
   const exactToAmount = readString(value['exactToAmount']);
   const displayToAmount = readString(value['displayToAmount']);
-  const transactions = value['transactions'].filter(
-    (transaction): transaction is OnchainActionsTransactionRequest =>
-      isRecord(transaction) &&
-      readString(transaction['type']) !== null &&
-      readHexAddress(transaction['to']) !== null &&
-      readString(transaction['chainId']) !== null &&
-      typeof transaction['data'] === 'string' &&
-      transaction['data'].startsWith('0x'),
-  );
+  const transactions = value['transactions'].map(readSwapTransaction);
 
-  if (!fromToken || !toToken || !exactFromAmount || !displayFromAmount || !exactToAmount || !displayToAmount || transactions.length === 0) {
+  if (transactions.some((transaction) => transaction === null)) {
+    throw new Error('Onchain Actions swap response included malformed transaction entries.');
+  }
+
+  if (!fromToken || !toToken || !exactFromAmount || !displayFromAmount || !exactToAmount || !displayToAmount) {
     throw new Error('Onchain Actions swap response was incomplete.');
   }
 
@@ -989,7 +1098,7 @@ function readSwapResponse(value: unknown): OnchainActionsSwapResponse {
     displayFromAmount,
     exactToAmount,
     displayToAmount,
-    transactions,
+    transactions: transactions as OnchainActionsTransactionRequest[],
   };
 }
 
@@ -1055,8 +1164,31 @@ export function createHiddenOcaSpotSwapExecutor(
 
   return {
     async executeSpotSwap({ threadId, currentRevision = null, input }) {
-      const fromChainId = resolveChainId(input.fromChain);
-      const toChainId = resolveChainId(input.toChain);
+      const inputIdempotencyKey = input.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(input);
+      const walletAddress = readHexAddress(input.walletAddress);
+      if (walletAddress === null) {
+        return createInputFailedResult({
+          request: input,
+          idempotencyKey: inputIdempotencyKey,
+          failureReason: 'Hidden OCA spot swap requires a valid EVM wallet address.',
+        });
+      }
+
+      const request: HiddenOcaSpotSwapInput = {
+        ...input,
+        walletAddress,
+      };
+      const idempotencyKey = request.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(request);
+      const fromChainId = resolveChainId(request.fromChain);
+      const toChainId = resolveChainId(request.toChain);
+      if (fromChainId !== toChainId) {
+        return createInputFailedResult({
+          request,
+          idempotencyKey,
+          failureReason: 'Hidden OCA spot swaps currently require fromChain and toChain to match.',
+        });
+      }
+
       const fromTokens = await onchainActionsClient.listTokens({ chainIds: [fromChainId] });
       const toTokens =
         toChainId === fromChainId
@@ -1065,24 +1197,22 @@ export function createHiddenOcaSpotSwapExecutor(
       const fromToken = resolveToken({
         tokens: fromTokens,
         chainId: fromChainId,
-        token: input.fromToken,
+        token: request.fromToken,
       });
       const toToken = resolveToken({
         tokens: toTokens,
         chainId: toChainId,
-        token: input.toToken,
+        token: request.toToken,
       });
       const swapResponse = await onchainActionsClient.createSwap({
-        walletAddress: input.walletAddress,
-        amount: input.amount,
-        amountType: input.amountType,
+        walletAddress: request.walletAddress,
+        amount: request.amount,
+        amountType: request.amountType,
         fromTokenUid: fromToken.tokenUid,
         toTokenUid: toToken.tokenUid,
-        ...(input.slippageTolerance ? { slippageTolerance: input.slippageTolerance } : {}),
-        ...(input.expiration ? { expiration: input.expiration } : {}),
+        ...(request.slippageTolerance ? { slippageTolerance: request.slippageTolerance } : {}),
+        ...(request.expiration ? { expiration: request.expiration } : {}),
       });
-      const idempotencyKey =
-        input.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(input);
       const createResponse = await runSharedEmberCommandWithResolvedRevision({
         protocolHost: options.protocolHost,
         threadId,
@@ -1092,22 +1222,23 @@ export function createHiddenOcaSpotSwapExecutor(
             threadId,
             idempotencyKey,
             expectedRevision,
-            rootedWalletContextId: input.rootedWalletContextId,
-            request: input,
+            rootedWalletContextId: request.rootedWalletContextId,
+            request,
             swapResponse,
             fromToken,
-            network: normalizeNetworkName(input.fromChain),
+            network: normalizeNetworkName(request.fromChain),
           }),
       });
       const transactionPlanId = readCandidatePlanId(createResponse);
       if (!transactionPlanId) {
         return createFailedResult({
-          request: input,
+          request,
           swapResponse,
           transactionPlanId: null,
           requestId: null,
           committedEventIds: readCommittedEventIds(createResponse),
           failureReason: 'Shared Ember did not return a hidden swap transaction plan.',
+          idempotencyKey,
         });
       }
 
@@ -1115,9 +1246,10 @@ export function createHiddenOcaSpotSwapExecutor(
         options,
         threadId,
         idempotencyKey: sanitizeIdSegment(idempotencyKey),
+        resultIdempotencyKey: idempotencyKey,
         currentRevision: readResultRevision(createResponse),
         transactionPlanId,
-        request: input,
+        request,
         swapResponse,
       });
     },

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -9,7 +9,15 @@ import {
 import { DelegationManager } from '@metamask/delegation-toolkit/contracts';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedEvmTransaction } from 'agent-runtime/internal';
-import { createPublicClient, http, isAddress, isAddressEqual, isHex, serializeTransaction } from 'viem';
+import {
+  createPublicClient,
+  http,
+  isAddress,
+  isAddressEqual,
+  isHex,
+  parseUnits,
+  serializeTransaction,
+} from 'viem';
 import { arbitrum, mainnet } from 'viem/chains';
 
 import {
@@ -472,6 +480,31 @@ function buildInputOnlySwapSummary(
     displayFromAmount: '',
     displayToAmount: '',
   };
+}
+
+function normalizeSpotSwapAmount(input: {
+  request: HiddenOcaSpotSwapInput;
+  fromToken: OnchainActionsToken;
+  toToken: OnchainActionsToken;
+}): string {
+  const amount = input.request.amount.trim();
+  if (/^[0-9]+$/u.test(amount)) {
+    return amount;
+  }
+
+  if (!/^[0-9]+(?:\.[0-9]+)?$/u.test(amount)) {
+    throw new Error('Hidden OCA spot swap amount must be a positive decimal or base-unit integer string.');
+  }
+
+  const token = input.request.amountType === 'exactIn' ? input.fromToken : input.toToken;
+  const decimals = token.decimals;
+  if (typeof decimals !== 'number' || !Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(
+      `Hidden OCA spot swap decimal amount requires token decimals for ${token.symbol}.`,
+    );
+  }
+
+  return parseUnits(amount, decimals).toString();
 }
 
 function normalizeChainIdForComparison(chainId: string): string {
@@ -1408,6 +1441,7 @@ export function createHiddenOcaSpotSwapExecutor(
       }
 
       let fromToken: OnchainActionsToken;
+      let normalizedRequest: HiddenOcaSpotSwapInput;
       let swapResponse: OnchainActionsSwapResponse;
       let preparedPayload: PreparedOcaSwapPayload;
       try {
@@ -1426,14 +1460,24 @@ export function createHiddenOcaSpotSwapExecutor(
           chainId: toChainId,
           token: request.toToken,
         });
+        normalizedRequest = {
+          ...request,
+          amount: normalizeSpotSwapAmount({
+            request,
+            fromToken,
+            toToken,
+          }),
+        };
         swapResponse = await onchainActionsClient.createSwap({
-          walletAddress: request.walletAddress,
-          amount: request.amount,
-          amountType: request.amountType,
+          walletAddress: normalizedRequest.walletAddress,
+          amount: normalizedRequest.amount,
+          amountType: normalizedRequest.amountType,
           fromTokenUid: fromToken.tokenUid,
           toTokenUid: toToken.tokenUid,
-          ...(request.slippageTolerance ? { slippageTolerance: request.slippageTolerance } : {}),
-          ...(request.expiration ? { expiration: request.expiration } : {}),
+          ...(normalizedRequest.slippageTolerance
+            ? { slippageTolerance: normalizedRequest.slippageTolerance }
+            : {}),
+          ...(normalizedRequest.expiration ? { expiration: normalizedRequest.expiration } : {}),
         });
         preparedPayload = buildPreparedOcaSwapPayload({
           requestChainId: fromChainId,
@@ -1459,8 +1503,8 @@ export function createHiddenOcaSpotSwapExecutor(
             threadId,
             idempotencyKey,
             expectedRevision,
-            rootedWalletContextId: request.rootedWalletContextId,
-            request,
+            rootedWalletContextId: normalizedRequest.rootedWalletContextId,
+            request: normalizedRequest,
             swapResponse,
             preparedPayload,
             fromToken,
@@ -1487,7 +1531,7 @@ export function createHiddenOcaSpotSwapExecutor(
         resultIdempotencyKey: idempotencyKey,
         currentRevision: readResultRevision(createResponse),
         transactionPlanId,
-        request,
+        request: normalizedRequest,
         swapResponse,
         preparedPayload,
       });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -226,11 +226,20 @@ function readString(value: unknown): string | null {
 
 function readUserFacingFailureReason(error: unknown, fallback: string): string {
   const shortMessage = isRecord(error) ? readString(error['shortMessage']) : null;
+  if (shortMessage === 'Execution reverted for an unknown reason.') {
+    return 'Hidden swap execution reverted during gas estimation before submission. No transaction was sent; try a larger amount or a different route.';
+  }
   if (shortMessage) {
     return shortMessage;
   }
 
-  return error instanceof Error ? error.message : fallback;
+  if (error instanceof Error) {
+    return error.message.includes('Estimate Gas Arguments')
+      ? 'Hidden swap execution reverted during gas estimation before submission. No transaction was sent; try a larger amount or a different route.'
+      : error.message;
+  }
+
+  return fallback;
 }
 
 function readHexAddress(value: unknown): `0x${string}` | null {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -224,6 +224,15 @@ function readString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value : null;
 }
 
+function readUserFacingFailureReason(error: unknown, fallback: string): string {
+  const shortMessage = isRecord(error) ? readString(error['shortMessage']) : null;
+  if (shortMessage) {
+    return shortMessage;
+  }
+
+  return error instanceof Error ? error.message : fallback;
+}
+
 function readHexAddress(value: unknown): `0x${string}` | null {
   const normalized = readString(value);
   return normalized && isAddress(normalized, { strict: false })
@@ -379,6 +388,12 @@ function normalizeNetworkName(chain: string): string {
   }
 }
 
+const TOKEN_ADDRESS_ALIASES_BY_CHAIN: Record<string, Record<string, readonly `0x${string}`[]>> = {
+  '42161': {
+    usdt: ['0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'],
+  },
+};
+
 function uniqueTokensByAddress(tokens: OnchainActionsToken[]): OnchainActionsToken[] {
   const seen = new Set<string>();
   const unique: OnchainActionsToken[] = [];
@@ -451,6 +466,20 @@ function resolveToken(input: {
   });
   if (resolvedName) {
     return resolvedName;
+  }
+
+  const aliasAddresses = TOKEN_ADDRESS_ALIASES_BY_CHAIN[input.chainId]?.[needle] ?? [];
+  for (const aliasAddress of aliasAddresses) {
+    const resolvedAlias = resolveUnambiguousTokenMatch({
+      matches: candidates.filter(
+        (token) => token.tokenUid.address.toLowerCase() === aliasAddress.toLowerCase(),
+      ),
+      token: input.token,
+      chainId: input.chainId,
+    });
+    if (resolvedAlias) {
+      return resolvedAlias;
+    }
   }
 
   throw new Error(
@@ -1265,7 +1294,10 @@ async function runExecutionFlow(input: {
           transactionPlanId: input.transactionPlanId,
           requestId: readExecutionRequestId(executionResult),
           committedEventIds,
-          failureReason: error instanceof Error ? error.message : 'Unknown hidden swap signing failure.',
+          failureReason: readUserFacingFailureReason(
+            error,
+            'Unknown hidden swap signing failure.',
+          ),
           idempotencyKey: input.resultIdempotencyKey,
         });
       }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -380,8 +380,19 @@ function createDefaultExecutionPublicClientResolver(
   };
 }
 
-function buildPayloadDerivedIdempotencyKey(input: HiddenOcaSpotSwapInput): string {
-  const fingerprint = createHash('sha256').update(JSON.stringify(input)).digest('hex').slice(0, 16);
+function buildPayloadDerivedIdempotencyKey(input: {
+  request: HiddenOcaSpotSwapInput;
+  threadId: string;
+}): string {
+  const fingerprint = createHash('sha256')
+    .update(
+      JSON.stringify({
+        threadId: input.threadId,
+        request: input.request,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16);
   return `idem-hidden-oca-swap-${fingerprint}`;
 }
 
@@ -1633,7 +1644,12 @@ export function createHiddenOcaSpotSwapExecutor(
 
   return {
     async executeSpotSwap({ threadId, currentRevision = null, input }) {
-      const inputIdempotencyKey = input.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(input);
+      const inputIdempotencyKey =
+        input.idempotencyKey ??
+        buildPayloadDerivedIdempotencyKey({
+          threadId,
+          request: input,
+        });
       const walletAddress = readHexAddress(input.walletAddress);
       if (walletAddress === null) {
         return createInputFailedResult({
@@ -1647,7 +1663,12 @@ export function createHiddenOcaSpotSwapExecutor(
         ...input,
         walletAddress,
       });
-      const idempotencyKey = request.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(request);
+      const idempotencyKey =
+        request.idempotencyKey ??
+        buildPayloadDerivedIdempotencyKey({
+          threadId,
+          request,
+        });
       let fromChainId: string;
       let toChainId: string;
       let network: string;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -812,8 +812,27 @@ function readCompletedExecutionStatus(executionResult: Record<string, unknown>):
   return readString(readRecordKey(executionResult, 'execution')?.['status']);
 }
 
+function readCompletedExecutionMessage(executionResult: Record<string, unknown>): string | null {
+  return readString(readRecordKey(executionResult, 'execution')?.['message']);
+}
+
 function readCompletedTransactionHash(executionResult: Record<string, unknown>): string | null {
   return readString(readRecordKey(executionResult, 'execution')?.['transaction_hash']);
+}
+
+function buildTerminalExecutionFailureReason(input: {
+  executionStatus: string | null;
+  executionMessage: string | null;
+}): string {
+  if (input.executionMessage) {
+    return input.executionMessage;
+  }
+
+  if (input.executionStatus) {
+    return `Shared Ember terminal hidden swap execution status was "${input.executionStatus}".`;
+  }
+
+  return 'Shared Ember returned terminal hidden swap execution without an execution status.';
 }
 
 function buildCompletedResult(input: {
@@ -824,9 +843,26 @@ function buildCompletedResult(input: {
   idempotencyKey?: string;
 }): HiddenOcaSpotSwapResult {
   const executionStatus = readCompletedExecutionStatus(input.executionResult);
+  const executionMessage = readCompletedExecutionMessage(input.executionResult);
+  const transactionHash = readCompletedTransactionHash(input.executionResult);
+
+  if (executionStatus === 'submitted' || executionStatus === 'confirmed') {
+    return {
+      status: executionStatus === 'submitted' ? 'submitted' : 'completed',
+      ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+      swapSummary: buildSwapSummary({
+        request: input.request,
+        swapResponse: input.swapResponse,
+      }),
+      transactionPlanId: readExecutionTransactionPlanId(input.executionResult),
+      requestId: readExecutionRequestId(input.executionResult),
+      transactionHash,
+      committedEventIds: input.committedEventIds,
+    };
+  }
 
   return {
-    status: executionStatus === 'submitted' ? 'submitted' : 'completed',
+    status: 'failed',
     ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
     swapSummary: buildSwapSummary({
       request: input.request,
@@ -834,8 +870,12 @@ function buildCompletedResult(input: {
     }),
     transactionPlanId: readExecutionTransactionPlanId(input.executionResult),
     requestId: readExecutionRequestId(input.executionResult),
-    transactionHash: readCompletedTransactionHash(input.executionResult),
+    ...(transactionHash ? { transactionHash } : {}),
     committedEventIds: input.committedEventIds,
+    failureReason: buildTerminalExecutionFailureReason({
+      executionStatus,
+      executionMessage,
+    }),
   };
 }
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -1,0 +1,895 @@
+import { createHash } from 'node:crypto';
+
+import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
+import { signPreparedEvmTransaction } from 'agent-runtime/internal';
+
+import type { PortfolioManagerSharedEmberProtocolHost } from './sharedEmberAdapter.js';
+import {
+  HIDDEN_OCA_EXECUTOR_AGENT_ID,
+  HIDDEN_OCA_EXECUTOR_CONTROL_PATH,
+} from './serviceIdentityPreflight.js';
+
+const DEFAULT_ONCHAIN_ACTIONS_API_URL = 'https://api.emberai.xyz';
+const DEFAULT_RUNTIME_SIGNER_REF = 'oca-executor-wallet';
+const OWS_SIGNING_CHAIN = 'evm';
+const MAX_EXECUTION_REQUEST_ATTEMPTS = 4;
+
+type TokenIdentifier = {
+  chainId: string;
+  address: string;
+};
+
+type OnchainActionsToken = {
+  tokenUid: TokenIdentifier;
+  name: string;
+  symbol: string;
+  isNative?: boolean;
+  decimals?: number;
+  isVetted?: boolean;
+};
+
+type OnchainActionsTransactionRequest = {
+  type: string;
+  to: `0x${string}`;
+  value?: string;
+  data: `0x${string}`;
+  chainId: string;
+};
+
+type OnchainActionsSwapResponse = {
+  fromToken: OnchainActionsToken;
+  toToken: OnchainActionsToken;
+  exactFromAmount: string;
+  displayFromAmount: string;
+  exactToAmount: string;
+  displayToAmount: string;
+  transactions: OnchainActionsTransactionRequest[];
+};
+
+export type HiddenOcaReservationConflictHandling =
+  | {
+      kind: 'allow_reserved_for_other_agent';
+    }
+  | {
+      kind: 'unassigned_only';
+    };
+
+export type HiddenOcaSpotSwapInput = {
+  idempotencyKey?: string;
+  rootedWalletContextId?: string;
+  walletAddress: `0x${string}`;
+  amount: string;
+  amountType: 'exactIn' | 'exactOut';
+  fromChain: string;
+  toChain: string;
+  fromToken: string;
+  toToken: string;
+  slippageTolerance?: string;
+  expiration?: string;
+  reservationConflictHandling?: HiddenOcaReservationConflictHandling;
+};
+
+type HiddenOcaSpotSwapExecutionInput = {
+  threadId: string;
+  currentRevision?: number | null;
+  input: HiddenOcaSpotSwapInput;
+};
+
+export type HiddenOcaSpotSwapResult = {
+  status: 'completed' | 'submitted' | 'conflict' | 'awaiting_redelegation' | 'blocked' | 'failed';
+  swapSummary: {
+    fromToken: string;
+    toToken: string;
+    amount: string;
+    amountType: HiddenOcaSpotSwapInput['amountType'];
+    displayFromAmount: string;
+    displayToAmount: string;
+  };
+  transactionPlanId: string | null;
+  requestId: string | null;
+  transactionHash?: string | null;
+  committedEventIds: string[];
+  conflict?: {
+    kind: 'reserved_for_other_agent';
+    blockingReasonCode: string;
+    reservationId: string | null;
+    message: string;
+    retryOptions: Array<HiddenOcaReservationConflictHandling['kind']>;
+  };
+  failureReason?: string;
+};
+
+export type HiddenOcaOnchainActionsClient = {
+  listTokens: (input: { chainIds?: string[] }) => Promise<OnchainActionsToken[]>;
+  createSwap: (input: {
+    walletAddress: `0x${string}`;
+    amount: string;
+    amountType: HiddenOcaSpotSwapInput['amountType'];
+    fromTokenUid: TokenIdentifier;
+    toTokenUid: TokenIdentifier;
+    slippageTolerance?: string;
+    expiration?: string;
+  }) => Promise<OnchainActionsSwapResponse>;
+};
+
+type PreparedUnsignedTransactionResolutionInput = {
+  executionResult: Record<string, unknown>;
+  swapResponse: OnchainActionsSwapResponse;
+};
+
+type HiddenOcaSpotSwapExecutorOptions = {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  onchainActionsClient?: HiddenOcaOnchainActionsClient;
+  onchainActionsBaseUrl?: string;
+  runtimeSigning?: AgentRuntimeSigningService;
+  runtimeSignerRef?: string;
+  executorWalletAddress?: `0x${string}`;
+  resolvePreparedUnsignedTransactionHex?: (
+    input: PreparedUnsignedTransactionResolutionInput,
+  ) => Promise<`0x${string}` | null>;
+  requestRedelegationRefresh?: (input: {
+    threadId: string;
+    transactionPlanId: string;
+    requestId: string;
+  }) => Promise<void>;
+  signPreparedTransaction?: typeof signPreparedEvmTransaction;
+};
+
+type HiddenOcaSpotSwapExecutor = {
+  executeSpotSwap: (input: HiddenOcaSpotSwapExecutionInput) => Promise<HiddenOcaSpotSwapResult>;
+};
+
+type SharedEmberRevisionResponse = {
+  result?: {
+    revision?: number;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readHexAddress(value: unknown): `0x${string}` | null {
+  const normalized = readString(value);
+  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+}
+
+function readInt(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readRecordKey(input: unknown, key: string): Record<string, unknown> | null {
+  return isRecord(input) && isRecord(input[key]) ? input[key] : null;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function sanitizeIdSegment(value: string): string {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-|-$/gu, '');
+
+  return sanitized.length > 0 ? sanitized : 'spot-swap';
+}
+
+function buildPayloadDerivedIdempotencyKey(input: HiddenOcaSpotSwapInput): string {
+  const fingerprint = createHash('sha256').update(JSON.stringify(input)).digest('hex').slice(0, 16);
+  return `idem-hidden-oca-swap-${fingerprint}`;
+}
+
+function resolveChainId(chain: string): string {
+  const normalized = chain.trim().toLowerCase();
+  if (/^[0-9]+$/u.test(normalized)) {
+    return normalized;
+  }
+
+  switch (normalized) {
+    case 'arbitrum':
+    case 'arb':
+    case 'arbitrum-one':
+      return '42161';
+    case 'ethereum':
+    case 'mainnet':
+    case 'eth':
+      return '1';
+    default:
+      throw new Error(`Unsupported Onchain Actions swap chain "${chain}".`);
+  }
+}
+
+function normalizeNetworkName(chain: string): string {
+  const normalized = chain.trim().toLowerCase();
+  switch (resolveChainId(chain)) {
+    case '42161':
+      return 'arbitrum';
+    case '1':
+      return 'mainnet';
+    default:
+      return normalized;
+  }
+}
+
+function resolveToken(input: {
+  tokens: OnchainActionsToken[];
+  chainId: string;
+  token: string;
+}): OnchainActionsToken {
+  const needle = input.token.trim().toLowerCase();
+  const candidates = input.tokens.filter((token) => token.tokenUid.chainId === input.chainId);
+  const resolved =
+    candidates.find((token) => token.tokenUid.address.toLowerCase() === needle) ??
+    candidates.find((token) => token.symbol.toLowerCase() === needle) ??
+    candidates.find((token) => token.name.toLowerCase() === needle) ??
+    null;
+
+  if (!resolved) {
+    throw new Error(
+      `Onchain Actions token resolution failed for ${input.token} on chain ${input.chainId}.`,
+    );
+  }
+
+  return resolved;
+}
+
+function buildSwapSummary(input: {
+  request: HiddenOcaSpotSwapInput;
+  swapResponse: OnchainActionsSwapResponse;
+}): HiddenOcaSpotSwapResult['swapSummary'] {
+  return {
+    fromToken: input.swapResponse.fromToken.symbol,
+    toToken: input.swapResponse.toToken.symbol,
+    amount: input.request.amount,
+    amountType: input.request.amountType,
+    displayFromAmount: input.swapResponse.displayFromAmount,
+    displayToAmount: input.swapResponse.displayToAmount,
+  };
+}
+
+async function readCurrentSharedEmberRevision(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  threadId: string;
+}): Promise<number> {
+  const response = (await input.protocolHost.handleJsonRpc({
+    jsonrpc: '2.0',
+    id: `shared-ember-${input.threadId}-read-hidden-oca-executor-revision`,
+    method: 'subagent.readPortfolioState.v1',
+    params: {
+      agent_id: HIDDEN_OCA_EXECUTOR_AGENT_ID,
+    },
+  })) as SharedEmberRevisionResponse;
+
+  return response.result?.revision ?? 0;
+}
+
+async function runSharedEmberCommandWithResolvedRevision<T>(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  threadId: string;
+  currentRevision: number | null;
+  buildRequest: (expectedRevision: number) => unknown;
+}): Promise<T> {
+  const expectedRevision =
+    input.currentRevision ?? (await readCurrentSharedEmberRevision(input));
+
+  return (await input.protocolHost.handleJsonRpc(input.buildRequest(expectedRevision))) as T;
+}
+
+function buildCreateTransactionRequest(input: {
+  threadId: string;
+  idempotencyKey: string;
+  expectedRevision: number;
+  rootedWalletContextId?: string;
+  request: HiddenOcaSpotSwapInput;
+  swapResponse: OnchainActionsSwapResponse;
+  fromToken: OnchainActionsToken;
+  network: string;
+}) {
+  return {
+    jsonrpc: '2.0',
+    id: `shared-ember-${input.threadId}-create-hidden-oca-swap-transaction`,
+    method: 'subagent.createTransaction.v1',
+    params: {
+      idempotency_key: `${input.idempotencyKey}:create-transaction`,
+      expected_revision: input.expectedRevision,
+      agent_id: HIDDEN_OCA_EXECUTOR_AGENT_ID,
+      ...(input.rootedWalletContextId
+        ? { rooted_wallet_context_id: input.rootedWalletContextId }
+        : {}),
+      request: {
+        control_path: HIDDEN_OCA_EXECUTOR_CONTROL_PATH,
+        asset: input.fromToken.symbol,
+        protocol_system: 'onchain-actions',
+        network: input.network,
+        quantity: {
+          kind: 'exact',
+          value: input.swapResponse.exactFromAmount || input.request.amount,
+        },
+      },
+    },
+  };
+}
+
+function readCandidatePlanId(createTransactionResponse: unknown): string | null {
+  const result = readRecordKey(createTransactionResponse, 'result');
+  const candidatePlan = readRecordKey(result, 'candidate_plan');
+
+  return readString(candidatePlan?.['transaction_plan_id']);
+}
+
+function readResultRevision(response: unknown): number | null {
+  return readInt(readRecordKey(response, 'result')?.['revision']);
+}
+
+function readCommittedEventIds(response: unknown): string[] {
+  const raw = readRecordKey(response, 'result')?.['committed_event_ids'];
+  return Array.isArray(raw) ? raw.filter((eventId): eventId is string => typeof eventId === 'string') : [];
+}
+
+function readExecutionResult(response: unknown): Record<string, unknown> | null {
+  return readRecordKey(readRecordKey(response, 'result'), 'execution_result');
+}
+
+function readExecutionRequestId(executionResult: Record<string, unknown> | null): string | null {
+  return readString(executionResult?.['request_id']);
+}
+
+function readExecutionTransactionPlanId(
+  executionResult: Record<string, unknown> | null,
+): string | null {
+  return readString(executionResult?.['transaction_plan_id']);
+}
+
+function buildRequestExecutionRequest(input: {
+  threadId: string;
+  idempotencyKey: string;
+  expectedRevision: number;
+  transactionPlanId: string;
+  attempt: number;
+  reservationConflictHandling?: HiddenOcaReservationConflictHandling;
+}) {
+  return {
+    jsonrpc: '2.0',
+    id: `shared-ember-${input.threadId}-request-hidden-oca-swap-execution`,
+    method: 'subagent.requestExecution.v1',
+    params: {
+      idempotency_key: `${input.idempotencyKey}:request-execution:${input.attempt}`,
+      expected_revision: input.expectedRevision,
+      transaction_plan_id: input.transactionPlanId,
+      ...(input.reservationConflictHandling
+        ? { reservation_conflict_handling: input.reservationConflictHandling }
+        : {}),
+    },
+  };
+}
+
+function readBlockedConflict(
+  executionResult: Record<string, unknown>,
+): HiddenOcaSpotSwapResult['conflict'] | null {
+  const requestResult = readRecordKey(executionResult, 'request_result');
+  const blockingReasonCode = readString(requestResult?.['blocking_reason_code']);
+  if (blockingReasonCode !== 'reserved_for_other_agent') {
+    return null;
+  }
+
+  return {
+    kind: 'reserved_for_other_agent',
+    blockingReasonCode,
+    reservationId: readString(requestResult?.['reservation_id']),
+    message: readString(requestResult?.['message']) ?? 'Swap execution touches reserved capital.',
+    retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+  };
+}
+
+function buildBlockedResult(input: {
+  request: HiddenOcaSpotSwapInput;
+  swapResponse: OnchainActionsSwapResponse;
+  executionResult: Record<string, unknown>;
+  committedEventIds: string[];
+}): HiddenOcaSpotSwapResult {
+  const conflict = readBlockedConflict(input.executionResult);
+
+  return {
+    status: conflict ? 'conflict' : 'blocked',
+    swapSummary: buildSwapSummary({
+      request: input.request,
+      swapResponse: input.swapResponse,
+    }),
+    transactionPlanId: readExecutionTransactionPlanId(input.executionResult),
+    requestId: readExecutionRequestId(input.executionResult),
+    committedEventIds: input.committedEventIds,
+    ...(conflict ? { conflict } : {}),
+  };
+}
+
+function readCompletedExecutionStatus(executionResult: Record<string, unknown>): string | null {
+  return readString(readRecordKey(executionResult, 'execution')?.['status']);
+}
+
+function readCompletedTransactionHash(executionResult: Record<string, unknown>): string | null {
+  return readString(readRecordKey(executionResult, 'execution')?.['transaction_hash']);
+}
+
+function buildCompletedResult(input: {
+  request: HiddenOcaSpotSwapInput;
+  swapResponse: OnchainActionsSwapResponse;
+  executionResult: Record<string, unknown>;
+  committedEventIds: string[];
+}): HiddenOcaSpotSwapResult {
+  const executionStatus = readCompletedExecutionStatus(input.executionResult);
+
+  return {
+    status: executionStatus === 'submitted' ? 'submitted' : 'completed',
+    swapSummary: buildSwapSummary({
+      request: input.request,
+      swapResponse: input.swapResponse,
+    }),
+    transactionPlanId: readExecutionTransactionPlanId(input.executionResult),
+    requestId: readExecutionRequestId(input.executionResult),
+    transactionHash: readCompletedTransactionHash(input.executionResult),
+    committedEventIds: input.committedEventIds,
+  };
+}
+
+function readExecutionSigningPackage(executionResult: Record<string, unknown>) {
+  return readRecordKey(executionResult, 'execution_signing_package');
+}
+
+function readExecutionPreparation(executionResult: Record<string, unknown>) {
+  return readRecordKey(executionResult, 'execution_preparation');
+}
+
+async function signAndSubmitPreparedExecution(input: {
+  options: HiddenOcaSpotSwapExecutorOptions;
+  threadId: string;
+  idempotencyKey: string;
+  currentRevision: number | null;
+  transactionPlanId: string;
+  executionResult: Record<string, unknown>;
+  swapResponse: OnchainActionsSwapResponse;
+}): Promise<{
+  response: unknown;
+  executionResult: Record<string, unknown> | null;
+}> {
+  if (!input.options.runtimeSigning) {
+    throw new Error('Runtime-owned signing service is not configured for hidden swap execution.');
+  }
+
+  const executionPreparation = readExecutionPreparation(input.executionResult);
+  const executionSigningPackage = readExecutionSigningPackage(input.executionResult);
+  const preparedWalletAddress = readHexAddress(executionPreparation?.['agent_wallet']);
+  const expectedWalletAddress = input.options.executorWalletAddress;
+  if (!expectedWalletAddress || !preparedWalletAddress) {
+    throw new Error(
+      'Hidden swap execution signing could not continue because the executor wallet identity is incomplete.',
+    );
+  }
+  if (preparedWalletAddress !== expectedWalletAddress) {
+    throw new Error(
+      'Hidden swap execution signing could not continue because the prepared signing package does not match the hidden executor wallet.',
+    );
+  }
+
+  const unsignedTransactionHex =
+    (await input.options.resolvePreparedUnsignedTransactionHex?.({
+      executionResult: input.executionResult,
+      swapResponse: input.swapResponse,
+    })) ?? null;
+  if (!unsignedTransactionHex) {
+    throw new Error(
+      'Hidden swap execution signing could not continue because no prepared unsigned transaction was resolved.',
+    );
+  }
+
+  const signer = input.options.signPreparedTransaction ?? signPreparedEvmTransaction;
+  const signed = await signer({
+    signing: input.options.runtimeSigning,
+    signerRef: input.options.runtimeSignerRef ?? DEFAULT_RUNTIME_SIGNER_REF,
+    expectedAddress: expectedWalletAddress,
+    chain: OWS_SIGNING_CHAIN,
+    unsignedTransactionHex,
+  });
+
+  const requestId = readString(executionSigningPackage?.['request_id']);
+  const executionPreparationId = readString(
+    executionSigningPackage?.['execution_preparation_id'],
+  );
+  if (!requestId || !executionPreparationId) {
+    throw new Error(
+      'Hidden swap execution signing could not continue because the signing package is incomplete.',
+    );
+  }
+
+  const response = await runSharedEmberCommandWithResolvedRevision({
+    protocolHost: input.options.protocolHost,
+    threadId: input.threadId,
+    currentRevision: input.currentRevision,
+    buildRequest: (expectedRevision) => ({
+      jsonrpc: '2.0',
+      id: `shared-ember-${input.threadId}-submit-hidden-oca-swap-transaction`,
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key: `${input.idempotencyKey}:submit-signed-transaction:${requestId}:${executionPreparationId}`,
+        expected_revision: expectedRevision,
+        transaction_plan_id: input.transactionPlanId,
+        signed_transaction: {
+          execution_preparation_id: executionPreparationId,
+          transaction_plan_id: input.transactionPlanId,
+          request_id: requestId,
+          active_delegation_id: readString(executionSigningPackage?.['active_delegation_id']),
+          canonical_unsigned_payload_ref: readString(
+            executionSigningPackage?.['canonical_unsigned_payload_ref'],
+          ),
+          signer_address: signed.confirmedAddress,
+          raw_transaction: signed.rawTransaction,
+        },
+      },
+    }),
+  });
+
+  return {
+    response,
+    executionResult: readExecutionResult(response),
+  };
+}
+
+function createFailedResult(input: {
+  request: HiddenOcaSpotSwapInput;
+  swapResponse: OnchainActionsSwapResponse;
+  transactionPlanId: string | null;
+  requestId: string | null;
+  committedEventIds: string[];
+  failureReason: string;
+}): HiddenOcaSpotSwapResult {
+  return {
+    status: 'failed',
+    swapSummary: buildSwapSummary({
+      request: input.request,
+      swapResponse: input.swapResponse,
+    }),
+    transactionPlanId: input.transactionPlanId,
+    requestId: input.requestId,
+    committedEventIds: input.committedEventIds,
+    failureReason: input.failureReason,
+  };
+}
+
+async function runExecutionFlow(input: {
+  options: HiddenOcaSpotSwapExecutorOptions;
+  threadId: string;
+  idempotencyKey: string;
+  currentRevision: number | null;
+  transactionPlanId: string;
+  request: HiddenOcaSpotSwapInput;
+  swapResponse: OnchainActionsSwapResponse;
+}): Promise<HiddenOcaSpotSwapResult> {
+  let revision = input.currentRevision;
+  let attempt = 1;
+  const committedEventIds: string[] = [];
+
+  while (attempt <= MAX_EXECUTION_REQUEST_ATTEMPTS) {
+    const requestResponse = await runSharedEmberCommandWithResolvedRevision({
+      protocolHost: input.options.protocolHost,
+      threadId: input.threadId,
+      currentRevision: revision,
+      buildRequest: (expectedRevision) =>
+        buildRequestExecutionRequest({
+          threadId: input.threadId,
+          idempotencyKey: input.idempotencyKey,
+          expectedRevision,
+          transactionPlanId: input.transactionPlanId,
+          attempt,
+          reservationConflictHandling: input.request.reservationConflictHandling,
+        }),
+    });
+    revision = readResultRevision(requestResponse);
+    committedEventIds.push(...readCommittedEventIds(requestResponse));
+
+    let executionResult = readExecutionResult(requestResponse);
+    const phase = readString(executionResult?.['phase']);
+    if (!executionResult || !phase) {
+      return createFailedResult({
+        request: input.request,
+        swapResponse: input.swapResponse,
+        transactionPlanId: input.transactionPlanId,
+        requestId: null,
+        committedEventIds,
+        failureReason: 'Shared Ember did not return a hidden swap execution result.',
+      });
+    }
+
+    if (phase === 'blocked') {
+      return buildBlockedResult({
+        request: input.request,
+        swapResponse: input.swapResponse,
+        executionResult,
+        committedEventIds,
+      });
+    }
+
+    if (phase === 'completed') {
+      return buildCompletedResult({
+        request: input.request,
+        swapResponse: input.swapResponse,
+        executionResult,
+        committedEventIds,
+      });
+    }
+
+    if (phase === 'ready_for_redelegation') {
+      const requestId = readExecutionRequestId(executionResult);
+      if (!requestId || !input.options.requestRedelegationRefresh) {
+        return {
+          status: 'awaiting_redelegation',
+          swapSummary: buildSwapSummary({
+            request: input.request,
+            swapResponse: input.swapResponse,
+          }),
+          transactionPlanId: input.transactionPlanId,
+          requestId,
+          committedEventIds,
+        };
+      }
+
+      await input.options.requestRedelegationRefresh({
+        threadId: input.threadId,
+        transactionPlanId: input.transactionPlanId,
+        requestId,
+      });
+      attempt += 1;
+      continue;
+    }
+
+    if (phase === 'ready_for_execution_signing') {
+      try {
+        const submitResult = await signAndSubmitPreparedExecution({
+          options: input.options,
+          threadId: input.threadId,
+          idempotencyKey: input.idempotencyKey,
+          currentRevision: revision,
+          transactionPlanId: input.transactionPlanId,
+          executionResult,
+          swapResponse: input.swapResponse,
+        });
+        revision = readResultRevision(submitResult.response);
+        committedEventIds.push(...readCommittedEventIds(submitResult.response));
+        executionResult = submitResult.executionResult;
+      } catch (error) {
+        return createFailedResult({
+          request: input.request,
+          swapResponse: input.swapResponse,
+          transactionPlanId: input.transactionPlanId,
+          requestId: readExecutionRequestId(executionResult),
+          committedEventIds,
+          failureReason: error instanceof Error ? error.message : 'Unknown hidden swap signing failure.',
+        });
+      }
+
+      if (executionResult && readString(executionResult['phase']) === 'completed') {
+        return buildCompletedResult({
+          request: input.request,
+          swapResponse: input.swapResponse,
+          executionResult,
+          committedEventIds,
+        });
+      }
+
+      return createFailedResult({
+        request: input.request,
+        swapResponse: input.swapResponse,
+        transactionPlanId: input.transactionPlanId,
+        requestId: readExecutionRequestId(executionResult),
+        committedEventIds,
+        failureReason: 'Shared Ember did not complete hidden swap signed-transaction submission.',
+      });
+    }
+
+    attempt += 1;
+  }
+
+  return createFailedResult({
+    request: input.request,
+    swapResponse: input.swapResponse,
+    transactionPlanId: input.transactionPlanId,
+    requestId: null,
+    committedEventIds,
+    failureReason: 'Shared Ember did not complete hidden swap execution readiness.',
+  });
+}
+
+async function parseJsonResponse(response: Response, endpoint: string): Promise<unknown> {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Onchain Actions request failed (${response.status}) for ${endpoint}: ${text}`);
+  }
+
+  return text.length > 0 ? (JSON.parse(text) as unknown) : {};
+}
+
+function readTokensResponse(value: unknown): OnchainActionsToken[] {
+  const tokens = isRecord(value) && Array.isArray(value['tokens']) ? value['tokens'] : [];
+  return tokens.filter((token): token is OnchainActionsToken => {
+    if (!isRecord(token) || !isRecord(token['tokenUid'])) {
+      return false;
+    }
+
+    return (
+      typeof token['tokenUid']['chainId'] === 'string' &&
+      typeof token['tokenUid']['address'] === 'string' &&
+      typeof token['name'] === 'string' &&
+      typeof token['symbol'] === 'string'
+    );
+  });
+}
+
+function readSwapResponse(value: unknown): OnchainActionsSwapResponse {
+  if (!isRecord(value) || !Array.isArray(value['transactions']) || value['transactions'].length === 0) {
+    throw new Error('Onchain Actions swap response did not include executable transactions.');
+  }
+
+  const fromToken = readTokensResponse({ tokens: [value['fromToken']] })[0];
+  const toToken = readTokensResponse({ tokens: [value['toToken']] })[0];
+  const exactFromAmount = readString(value['exactFromAmount']);
+  const displayFromAmount = readString(value['displayFromAmount']);
+  const exactToAmount = readString(value['exactToAmount']);
+  const displayToAmount = readString(value['displayToAmount']);
+  const transactions = value['transactions'].filter(
+    (transaction): transaction is OnchainActionsTransactionRequest =>
+      isRecord(transaction) &&
+      readString(transaction['type']) !== null &&
+      readHexAddress(transaction['to']) !== null &&
+      readString(transaction['chainId']) !== null &&
+      typeof transaction['data'] === 'string' &&
+      transaction['data'].startsWith('0x'),
+  );
+
+  if (!fromToken || !toToken || !exactFromAmount || !displayFromAmount || !exactToAmount || !displayToAmount || transactions.length === 0) {
+    throw new Error('Onchain Actions swap response was incomplete.');
+  }
+
+  return {
+    fromToken,
+    toToken,
+    exactFromAmount,
+    displayFromAmount,
+    exactToAmount,
+    displayToAmount,
+    transactions,
+  };
+}
+
+export function resolveHiddenOcaOnchainActionsApiUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const endpoint = trimTrailingSlash(
+    env.ONCHAIN_ACTIONS_API_URL?.trim() || DEFAULT_ONCHAIN_ACTIONS_API_URL,
+  );
+
+  return endpoint.endsWith('/openapi.json') ? endpoint.slice(0, -'/openapi.json'.length) : endpoint;
+}
+
+export function createHiddenOcaOnchainActionsClient(input: {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+} = {}): HiddenOcaOnchainActionsClient {
+  const baseUrl = trimTrailingSlash(input.baseUrl ?? resolveHiddenOcaOnchainActionsApiUrl());
+  const fetchImpl = input.fetch ?? fetch;
+
+  return {
+    async listTokens(params) {
+      const query = new URLSearchParams();
+      for (const chainId of params.chainIds ?? []) {
+        query.append('chainIds', chainId);
+      }
+      const endpoint = query.toString() ? `/tokens?${query.toString()}` : '/tokens';
+      return readTokensResponse(await parseJsonResponse(await fetchImpl(`${baseUrl}${endpoint}`), endpoint));
+    },
+    async createSwap(params) {
+      const payload = {
+        walletAddress: params.walletAddress,
+        amount: params.amount,
+        amountType: params.amountType,
+        fromTokenUid: params.fromTokenUid,
+        toTokenUid: params.toTokenUid,
+        ...(params.slippageTolerance ? { slippageTolerance: params.slippageTolerance } : {}),
+        ...(params.expiration ? { expiration: params.expiration } : {}),
+      };
+      const endpoint = '/swap';
+      return readSwapResponse(
+        await parseJsonResponse(
+          await fetchImpl(`${baseUrl}${endpoint}`, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+          }),
+          endpoint,
+        ),
+      );
+    },
+  };
+}
+
+export function createHiddenOcaSpotSwapExecutor(
+  options: HiddenOcaSpotSwapExecutorOptions,
+): HiddenOcaSpotSwapExecutor {
+  const onchainActionsClient =
+    options.onchainActionsClient ??
+    createHiddenOcaOnchainActionsClient({
+      baseUrl: options.onchainActionsBaseUrl,
+    });
+
+  return {
+    async executeSpotSwap({ threadId, currentRevision = null, input }) {
+      const fromChainId = resolveChainId(input.fromChain);
+      const toChainId = resolveChainId(input.toChain);
+      const fromTokens = await onchainActionsClient.listTokens({ chainIds: [fromChainId] });
+      const toTokens =
+        toChainId === fromChainId
+          ? fromTokens
+          : await onchainActionsClient.listTokens({ chainIds: [toChainId] });
+      const fromToken = resolveToken({
+        tokens: fromTokens,
+        chainId: fromChainId,
+        token: input.fromToken,
+      });
+      const toToken = resolveToken({
+        tokens: toTokens,
+        chainId: toChainId,
+        token: input.toToken,
+      });
+      const swapResponse = await onchainActionsClient.createSwap({
+        walletAddress: input.walletAddress,
+        amount: input.amount,
+        amountType: input.amountType,
+        fromTokenUid: fromToken.tokenUid,
+        toTokenUid: toToken.tokenUid,
+        ...(input.slippageTolerance ? { slippageTolerance: input.slippageTolerance } : {}),
+        ...(input.expiration ? { expiration: input.expiration } : {}),
+      });
+      const idempotencyKey =
+        input.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(input);
+      const createResponse = await runSharedEmberCommandWithResolvedRevision({
+        protocolHost: options.protocolHost,
+        threadId,
+        currentRevision,
+        buildRequest: (expectedRevision) =>
+          buildCreateTransactionRequest({
+            threadId,
+            idempotencyKey,
+            expectedRevision,
+            rootedWalletContextId: input.rootedWalletContextId,
+            request: input,
+            swapResponse,
+            fromToken,
+            network: normalizeNetworkName(input.fromChain),
+          }),
+      });
+      const transactionPlanId = readCandidatePlanId(createResponse);
+      if (!transactionPlanId) {
+        return createFailedResult({
+          request: input,
+          swapResponse,
+          transactionPlanId: null,
+          requestId: null,
+          committedEventIds: readCommittedEventIds(createResponse),
+          failureReason: 'Shared Ember did not return a hidden swap transaction plan.',
+        });
+      }
+
+      return await runExecutionFlow({
+        options,
+        threadId,
+        idempotencyKey: sanitizeIdSegment(idempotencyKey),
+        currentRevision: readResultRevision(createResponse),
+        transactionPlanId,
+        request: input,
+        swapResponse,
+      });
+    },
+  };
+}

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -11,6 +11,8 @@ import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedEvmTransaction } from 'agent-runtime/internal';
 import {
   createPublicClient,
+  encodeFunctionData,
+  erc20Abi,
   http,
   isAddress,
   isAddressEqual,
@@ -34,6 +36,24 @@ const OWS_SIGNING_CHAIN = 'evm';
 const MAX_EXECUTION_REQUEST_ATTEMPTS = 4;
 const RPC_RETRY_COUNT = 2;
 const RPC_TIMEOUT_MS = 8_000;
+const PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3' as const;
+const PERMIT2_MAX_EXPIRATION = 281_474_976_710_655;
+const PERMIT2_MAX_UINT160_AMOUNT = (1n << 160n) - 1n;
+const OCA_FUND_AND_RUN_MULTICALL_SELECTOR = '0x58181a80';
+const PERMIT2_APPROVE_ABI = [
+  {
+    type: 'function',
+    name: 'approve',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'token', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint160' },
+      { name: 'expiration', type: 'uint48' },
+    ],
+    outputs: [],
+  },
+] as const;
 
 type TokenIdentifier = {
   chainId: string;
@@ -600,12 +620,101 @@ function normalizeOcaSwapTransaction(
   };
 }
 
+function readPositiveBaseUnitAmount(value: string): bigint {
+  if (!/^[0-9]+$/u.test(value)) {
+    throw new Error(
+      `OCA funded multicall approval requires an integer exact-from amount, received "${value}".`,
+    );
+  }
+
+  const amount = BigInt(value);
+  if (amount <= 0n) {
+    throw new Error('OCA funded multicall approval requires a positive exact-from amount.');
+  }
+
+  if (amount > PERMIT2_MAX_UINT160_AMOUNT) {
+    throw new Error('OCA funded multicall approval amount exceeds the Permit2 uint160 limit.');
+  }
+
+  return amount;
+}
+
+function isOcaFundAndRunMulticallTransaction(
+  transaction: OnchainActionsTransactionRequest,
+): boolean {
+  return transaction.data.toLowerCase().startsWith(OCA_FUND_AND_RUN_MULTICALL_SELECTOR);
+}
+
+function buildPermit2ApprovalTransactions(input: {
+  fromToken: OnchainActionsToken;
+  exactFromAmount: string;
+  spender: `0x${string}`;
+  chainId: string;
+}): OnchainActionsTransactionRequest[] {
+  const fromTokenAddress = readHexAddress(input.fromToken.tokenUid.address);
+  if (!fromTokenAddress) {
+    throw new Error('OCA funded multicall approval requires an EVM ERC20 source token address.');
+  }
+
+  const amount = readPositiveBaseUnitAmount(input.exactFromAmount);
+
+  return [
+    {
+      type: 'EVM_TX',
+      to: fromTokenAddress,
+      value: '0',
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [PERMIT2_ADDRESS, amount],
+      }),
+      chainId: input.chainId,
+    },
+    {
+      type: 'EVM_TX',
+      to: PERMIT2_ADDRESS,
+      value: '0',
+      data: encodeFunctionData({
+        abi: PERMIT2_APPROVE_ABI,
+        functionName: 'approve',
+        args: [fromTokenAddress, input.spender, amount, PERMIT2_MAX_EXPIRATION],
+      }),
+      chainId: input.chainId,
+    },
+  ];
+}
+
+function buildExecutableOcaSwapTransactions(input: {
+  requestChainId: string;
+  swapResponse: OnchainActionsSwapResponse;
+}): OnchainActionsTransactionRequest[] {
+  const normalizedTransactions = input.swapResponse.transactions.map(normalizeOcaSwapTransaction);
+  const fundedMulticallTransaction = normalizedTransactions.find(isOcaFundAndRunMulticallTransaction);
+
+  if (!fundedMulticallTransaction || input.swapResponse.fromToken.isNative === true) {
+    return normalizedTransactions;
+  }
+
+  return [
+    ...buildPermit2ApprovalTransactions({
+      fromToken: input.swapResponse.fromToken,
+      exactFromAmount: input.swapResponse.exactFromAmount,
+      spender: fundedMulticallTransaction.to,
+      chainId: input.requestChainId,
+    }),
+    ...normalizedTransactions,
+  ];
+}
+
 function buildPreparedOcaSwapPayload(input: {
   requestChainId: string;
   network: string;
   swapResponse: OnchainActionsSwapResponse;
 }): PreparedOcaSwapPayload {
-  const normalizedTransactions = input.swapResponse.transactions.map(normalizeOcaSwapTransaction);
+  const normalizedTransactions = buildExecutableOcaSwapTransactions({
+    requestChainId: input.requestChainId,
+    swapResponse: input.swapResponse,
+  });
   if (normalizedTransactions.length === 0) {
     throw new Error('Hidden swap execution signing requires at least one OCA transaction request.');
   }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -1,18 +1,31 @@
 import { createHash } from 'node:crypto';
 
+import {
+  createExecution,
+  type Delegation,
+  ExecutionMode,
+  getDeleGatorEnvironment,
+} from '@metamask/delegation-toolkit';
+import { DelegationManager } from '@metamask/delegation-toolkit/contracts';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedEvmTransaction } from 'agent-runtime/internal';
+import { createPublicClient, http, serializeTransaction } from 'viem';
+import { arbitrum, mainnet } from 'viem/chains';
 
-import type { PortfolioManagerSharedEmberProtocolHost } from './sharedEmberAdapter.js';
 import {
   HIDDEN_OCA_EXECUTOR_AGENT_ID,
   HIDDEN_OCA_EXECUTOR_CONTROL_PATH,
 } from './serviceIdentityPreflight.js';
+import type { PortfolioManagerSharedEmberProtocolHost } from './sharedEmberAdapter.js';
 
 const DEFAULT_ONCHAIN_ACTIONS_API_URL = 'https://api.emberai.xyz';
+const DEFAULT_ARBITRUM_RPC_URL = 'https://arb1.arbitrum.io/rpc';
+const DEFAULT_ETHEREUM_RPC_URL = 'https://eth.merkle.io';
 const DEFAULT_RUNTIME_SIGNER_REF = 'oca-executor-wallet';
 const OWS_SIGNING_CHAIN = 'evm';
 const MAX_EXECUTION_REQUEST_ATTEMPTS = 4;
+const RPC_RETRY_COUNT = 2;
+const RPC_TIMEOUT_MS = 8_000;
 
 type TokenIdentifier = {
   chainId: string;
@@ -121,12 +134,14 @@ type HiddenOcaSpotSwapExecutorOptions = {
   protocolHost: PortfolioManagerSharedEmberProtocolHost;
   onchainActionsClient?: HiddenOcaOnchainActionsClient;
   onchainActionsBaseUrl?: string;
+  env?: NodeJS.ProcessEnv;
   runtimeSigning?: AgentRuntimeSigningService;
   runtimeSignerRef?: string;
   executorWalletAddress?: `0x${string}`;
   resolvePreparedUnsignedTransactionHex?: (
     input: PreparedUnsignedTransactionResolutionInput,
   ) => Promise<`0x${string}` | null>;
+  resolveExecutionPublicClient?: ResolveHiddenOcaExecutionPublicClient;
   requestRedelegationRefresh?: (input: {
     threadId: string;
     transactionPlanId: string;
@@ -138,6 +153,27 @@ type HiddenOcaSpotSwapExecutorOptions = {
 type HiddenOcaSpotSwapExecutor = {
   executeSpotSwap: (input: HiddenOcaSpotSwapExecutionInput) => Promise<HiddenOcaSpotSwapResult>;
 };
+
+type HiddenOcaExecutionPublicClient = {
+  getTransactionCount: (input: { address: `0x${string}`; blockTag?: 'pending' }) => Promise<number>;
+  estimateFeesPerGas: () => Promise<{
+    gasPrice?: bigint;
+    maxFeePerGas?: bigint;
+    maxPriorityFeePerGas?: bigint;
+  }>;
+  estimateGas: (input: {
+    account: `0x${string}`;
+    to: `0x${string}`;
+    value: bigint;
+    data: `0x${string}`;
+  }) => Promise<bigint>;
+};
+
+type SupportedExecutionNetwork = 'arbitrum' | 'mainnet';
+
+type ResolveHiddenOcaExecutionPublicClient = (
+  network: SupportedExecutionNetwork,
+) => HiddenOcaExecutionPublicClient;
 
 type SharedEmberRevisionResponse = {
   result?: {
@@ -177,6 +213,96 @@ function sanitizeIdSegment(value: string): string {
     .replace(/^-|-$/gu, '');
 
   return sanitized.length > 0 ? sanitized : 'spot-swap';
+}
+
+function bufferDelegatedExecutionGas(gasEstimate: bigint): bigint {
+  return (gasEstimate * 3n) / 2n;
+}
+
+function normalizeDelegationSignature(signature: string): `0x${string}` {
+  const normalized = signature.trim().toLowerCase();
+  return normalized.startsWith('0x')
+    ? (normalized as `0x${string}`)
+    : (`0x${normalized}` as `0x${string}`);
+}
+
+function decodeDelegationArtifactRef(artifactRef: string): Delegation {
+  const prefix = 'metamask-delegation:';
+  if (!artifactRef.startsWith(prefix)) {
+    throw new Error(`Unsupported delegation artifact ref "${artifactRef}".`);
+  }
+
+  const decoded = JSON.parse(
+    Buffer.from(artifactRef.slice(prefix.length), 'base64url').toString('utf8'),
+  ) as Delegation;
+  decoded.signature = normalizeDelegationSignature(decoded.signature);
+
+  return decoded;
+}
+
+function requireDelegationArtifactRef(input: { label: string; value?: string | null }): string {
+  if (typeof input.value === 'string' && input.value.trim().length > 0) {
+    return input.value;
+  }
+
+  throw new Error(
+    `Hidden swap execution signing requires ${input.label} to build the delegated transaction wrapper.`,
+  );
+}
+
+function createRpcTransport(url: string): ReturnType<typeof http> {
+  const baseTransport = http(url);
+  const baseTransportValue: unknown = baseTransport;
+  if (typeof baseTransportValue !== 'function') {
+    return baseTransport;
+  }
+
+  return ((params: Parameters<typeof baseTransport>[0]) =>
+    baseTransport({
+      ...params,
+      retryCount: RPC_RETRY_COUNT,
+      timeout: RPC_TIMEOUT_MS,
+    })) as ReturnType<typeof http>;
+}
+
+function resolveSupportedExecutionNetworkForChainId(chainId: number): SupportedExecutionNetwork {
+  switch (chainId) {
+    case arbitrum.id:
+      return 'arbitrum';
+    case mainnet.id:
+      return 'mainnet';
+    default:
+      throw new Error(`Unsupported hidden OCA execution chain id "${chainId}".`);
+  }
+}
+
+function resolveRpcUrl(network: SupportedExecutionNetwork, env: NodeJS.ProcessEnv): string {
+  switch (network) {
+    case 'arbitrum':
+      return env['ARBITRUM_RPC_URL']?.trim() || DEFAULT_ARBITRUM_RPC_URL;
+    case 'mainnet':
+      return env['ETHEREUM_RPC_URL']?.trim() || DEFAULT_ETHEREUM_RPC_URL;
+  }
+}
+
+function createDefaultExecutionPublicClientResolver(
+  env: NodeJS.ProcessEnv,
+): ResolveHiddenOcaExecutionPublicClient {
+  const clients = new Map<SupportedExecutionNetwork, HiddenOcaExecutionPublicClient>();
+
+  return (network) => {
+    const existingClient = clients.get(network);
+    if (existingClient) {
+      return existingClient;
+    }
+
+    const client = createPublicClient({
+      chain: network === 'arbitrum' ? arbitrum : mainnet,
+      transport: createRpcTransport(resolveRpcUrl(network, env)),
+    }) as HiddenOcaExecutionPublicClient;
+    clients.set(network, client);
+    return client;
+  };
 }
 
 function buildPayloadDerivedIdempotencyKey(input: HiddenOcaSpotSwapInput): string {
@@ -444,6 +570,107 @@ function readExecutionPreparation(executionResult: Record<string, unknown>) {
   return readRecordKey(executionResult, 'execution_preparation');
 }
 
+async function resolvePreparedUnsignedTransactionHexFromSwapResponse(input: {
+  executionSigningPackage: Record<string, unknown> | null;
+  swapResponse: OnchainActionsSwapResponse;
+  walletAddress: `0x${string}`;
+  resolveExecutionPublicClient: ResolveHiddenOcaExecutionPublicClient;
+}): Promise<`0x${string}`> {
+  const [firstTransaction, ...remainingTransactions] = input.swapResponse.transactions;
+  if (!firstTransaction) {
+    throw new Error('Hidden swap execution signing requires at least one OCA transaction request.');
+  }
+
+  const chainId = Number(firstTransaction.chainId);
+  if (!Number.isFinite(chainId) || chainId <= 0) {
+    throw new Error(`Invalid hidden swap transaction chain id "${firstTransaction.chainId}".`);
+  }
+
+  for (const transaction of remainingTransactions) {
+    if (Number(transaction.chainId) !== chainId) {
+      throw new Error(
+        'Hidden swap execution signing requires all OCA transaction requests to use the same chain id.',
+      );
+    }
+  }
+
+  const network = resolveSupportedExecutionNetworkForChainId(chainId);
+  const publicClient = input.resolveExecutionPublicClient(network);
+  const delegationManager = getDeleGatorEnvironment(
+    chainId,
+  ).DelegationManager.toLowerCase() as `0x${string}`;
+  const executions = input.swapResponse.transactions.map((transaction) =>
+    createExecution({
+      target: transaction.to.toLowerCase() as `0x${string}`,
+      value: BigInt(transaction.value ?? '0'),
+      callData: transaction.data.toLowerCase() as `0x${string}`,
+    }),
+  );
+  const activeDelegationArtifactRef = requireDelegationArtifactRef({
+    label: 'active delegation artifact ref',
+    value: readString(input.executionSigningPackage?.['delegation_artifact_ref']),
+  });
+  const rootDelegationArtifactRef = requireDelegationArtifactRef({
+    label: 'root delegation artifact ref',
+    value: readString(input.executionSigningPackage?.['root_delegation_artifact_ref']),
+  });
+  const delegatedTransactionData = DelegationManager.encode.redeemDelegations({
+    delegations: [
+      [
+        decodeDelegationArtifactRef(activeDelegationArtifactRef),
+        decodeDelegationArtifactRef(rootDelegationArtifactRef),
+      ],
+    ],
+    modes: [executions.length === 1 ? ExecutionMode.SingleDefault : ExecutionMode.BatchDefault],
+    executions: [executions],
+  });
+  const [nonce, feeEstimate, gasEstimate] = await Promise.all([
+    publicClient.getTransactionCount({
+      address: input.walletAddress,
+      blockTag: 'pending',
+    }),
+    publicClient.estimateFeesPerGas(),
+    publicClient.estimateGas({
+      account: input.walletAddress,
+      to: delegationManager,
+      value: 0n,
+      data: delegatedTransactionData,
+    }),
+  ]);
+  const gas = bufferDelegatedExecutionGas(gasEstimate);
+
+  if (
+    typeof feeEstimate.maxFeePerGas === 'bigint' &&
+    typeof feeEstimate.maxPriorityFeePerGas === 'bigint'
+  ) {
+    return serializeTransaction({
+      chainId,
+      type: 'eip1559',
+      nonce,
+      gas,
+      maxFeePerGas: feeEstimate.maxFeePerGas,
+      maxPriorityFeePerGas: feeEstimate.maxPriorityFeePerGas,
+      to: delegationManager,
+      value: 0n,
+      data: delegatedTransactionData,
+    });
+  }
+
+  if (typeof feeEstimate.gasPrice === 'bigint') {
+    return serializeTransaction({
+      chainId,
+      nonce,
+      gas,
+      gasPrice: feeEstimate.gasPrice,
+      to: delegationManager,
+      value: 0n,
+      data: delegatedTransactionData,
+    });
+  }
+
+  throw new Error('RPC fee estimation did not return a signable gas price or EIP-1559 fee pair.');
+}
+
 async function signAndSubmitPreparedExecution(input: {
   options: HiddenOcaSpotSwapExecutorOptions;
   threadId: string;
@@ -479,12 +706,15 @@ async function signAndSubmitPreparedExecution(input: {
     (await input.options.resolvePreparedUnsignedTransactionHex?.({
       executionResult: input.executionResult,
       swapResponse: input.swapResponse,
-    })) ?? null;
-  if (!unsignedTransactionHex) {
-    throw new Error(
-      'Hidden swap execution signing could not continue because no prepared unsigned transaction was resolved.',
-    );
-  }
+    })) ??
+    (await resolvePreparedUnsignedTransactionHexFromSwapResponse({
+      executionSigningPackage,
+      swapResponse: input.swapResponse,
+      walletAddress: expectedWalletAddress,
+      resolveExecutionPublicClient:
+        input.options.resolveExecutionPublicClient ??
+        createDefaultExecutionPublicClientResolver(input.options.env ?? process.env),
+    }));
 
   const signer = input.options.signPreparedTransaction ?? signPreparedEvmTransaction;
   const signed = await signer({
@@ -765,7 +995,7 @@ function readSwapResponse(value: unknown): OnchainActionsSwapResponse {
 
 export function resolveHiddenOcaOnchainActionsApiUrl(env: NodeJS.ProcessEnv = process.env): string {
   const endpoint = trimTrailingSlash(
-    env.ONCHAIN_ACTIONS_API_URL?.trim() || DEFAULT_ONCHAIN_ACTIONS_API_URL,
+    env['ONCHAIN_ACTIONS_API_URL']?.trim() || DEFAULT_ONCHAIN_ACTIONS_API_URL,
   );
 
   return endpoint.endsWith('/openapi.json') ? endpoint.slice(0, -'/openapi.json'.length) : endpoint;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -89,6 +89,8 @@ export type HiddenOcaReservationConflictHandling =
       kind: 'unassigned_only';
     };
 
+export type HiddenOcaSpotSwapCapitalPool = 'unassigned_only' | 'reserved_or_assigned' | 'all';
+
 export type HiddenOcaSpotSwapInput = {
   idempotencyKey?: string;
   rootedWalletContextId?: string;
@@ -101,6 +103,7 @@ export type HiddenOcaSpotSwapInput = {
   toToken: string;
   slippageTolerance?: string;
   expiration?: string;
+  capitalPool?: HiddenOcaSpotSwapCapitalPool;
   reservationConflictHandling?: HiddenOcaReservationConflictHandling;
 };
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.ts
@@ -59,6 +59,20 @@ type OnchainActionsSwapResponse = {
   transactions: OnchainActionsTransactionRequest[];
 };
 
+type OnchainActionsTokensPage = {
+  tokens: OnchainActionsToken[];
+  currentPage?: number;
+  totalPages?: number;
+};
+
+type PreparedOcaSwapPayload = {
+  transactionPayloadRef: string;
+  canonicalUnsignedPayloadRef: string;
+  chainId: string;
+  network: string;
+  transactions: OnchainActionsTransactionRequest[];
+};
+
 export type HiddenOcaReservationConflictHandling =
   | {
       kind: 'allow_reserved_for_other_agent';
@@ -129,6 +143,7 @@ export type HiddenOcaOnchainActionsClient = {
 type PreparedUnsignedTransactionResolutionInput = {
   executionResult: Record<string, unknown>;
   swapResponse: OnchainActionsSwapResponse;
+  preparedPayload: PreparedOcaSwapPayload;
 };
 
 type HiddenOcaSpotSwapExecutorOptions = {
@@ -353,6 +368,43 @@ function normalizeNetworkName(chain: string): string {
   }
 }
 
+function uniqueTokensByAddress(tokens: OnchainActionsToken[]): OnchainActionsToken[] {
+  const seen = new Set<string>();
+  const unique: OnchainActionsToken[] = [];
+  for (const token of tokens) {
+    const addressKey = token.tokenUid.address.toLowerCase();
+    if (seen.has(addressKey)) {
+      continue;
+    }
+
+    seen.add(addressKey);
+    unique.push(token);
+  }
+
+  return unique;
+}
+
+function resolveUnambiguousTokenMatch(input: {
+  matches: OnchainActionsToken[];
+  token: string;
+  chainId: string;
+}): OnchainActionsToken | null {
+  if (input.matches.length === 0) {
+    return null;
+  }
+
+  const vettedMatches = input.matches.filter((token) => token.isVetted === true);
+  const preferredMatches = vettedMatches.length > 0 ? vettedMatches : input.matches;
+  const uniqueMatches = uniqueTokensByAddress(preferredMatches);
+  if (uniqueMatches.length === 1) {
+    return uniqueMatches[0]!;
+  }
+
+  throw new Error(
+    `Ambiguous Onchain Actions token resolution for ${input.token} on chain ${input.chainId}; use an exact token address.`,
+  );
+}
+
 function resolveToken(input: {
   tokens: OnchainActionsToken[];
   chainId: string;
@@ -360,19 +412,39 @@ function resolveToken(input: {
 }): OnchainActionsToken {
   const needle = input.token.trim().toLowerCase();
   const candidates = input.tokens.filter((token) => token.tokenUid.chainId === input.chainId);
-  const resolved =
-    candidates.find((token) => token.tokenUid.address.toLowerCase() === needle) ??
-    candidates.find((token) => token.symbol.toLowerCase() === needle) ??
-    candidates.find((token) => token.name.toLowerCase() === needle) ??
-    null;
-
-  if (!resolved) {
-    throw new Error(
-      `Onchain Actions token resolution failed for ${input.token} on chain ${input.chainId}.`,
-    );
+  const exactAddressMatches = candidates.filter(
+    (token) => token.tokenUid.address.toLowerCase() === needle,
+  );
+  const resolvedAddress = resolveUnambiguousTokenMatch({
+    matches: exactAddressMatches,
+    token: input.token,
+    chainId: input.chainId,
+  });
+  if (resolvedAddress) {
+    return resolvedAddress;
   }
 
-  return resolved;
+  const resolvedSymbol = resolveUnambiguousTokenMatch({
+    matches: candidates.filter((token) => token.symbol.toLowerCase() === needle),
+    token: input.token,
+    chainId: input.chainId,
+  });
+  if (resolvedSymbol) {
+    return resolvedSymbol;
+  }
+
+  const resolvedName = resolveUnambiguousTokenMatch({
+    matches: candidates.filter((token) => token.name.toLowerCase() === needle),
+    token: input.token,
+    chainId: input.chainId,
+  });
+  if (resolvedName) {
+    return resolvedName;
+  }
+
+  throw new Error(
+    `Onchain Actions token resolution failed for ${input.token} on chain ${input.chainId}.`,
+  );
 }
 
 function buildSwapSummary(input: {
@@ -399,6 +471,89 @@ function buildInputOnlySwapSummary(
     amountType: request.amountType,
     displayFromAmount: '',
     displayToAmount: '',
+  };
+}
+
+function normalizeChainIdForComparison(chainId: string): string {
+  const normalized = chainId.trim();
+  if (!/^[0-9]+$/u.test(normalized)) {
+    throw new Error(`Invalid hidden swap transaction chain id "${chainId}".`);
+  }
+
+  const parsed = BigInt(normalized);
+  if (parsed <= 0n) {
+    throw new Error(`Invalid hidden swap transaction chain id "${chainId}".`);
+  }
+
+  return parsed.toString();
+}
+
+function normalizeOcaSwapTransaction(
+  transaction: OnchainActionsTransactionRequest,
+): OnchainActionsTransactionRequest {
+  const to = readHexAddress(transaction.to);
+  const data = readString(transaction.data);
+  const chainId = readString(transaction.chainId);
+  const transactionValue =
+    transaction.value === undefined ? undefined : readString(transaction.value);
+
+  if (!to || !data || !isHex(data) || !chainId) {
+    throw new Error('Onchain Actions swap response included malformed transaction entries.');
+  }
+  if (transaction.value !== undefined && transactionValue === null) {
+    throw new Error('Onchain Actions swap response included malformed transaction entries.');
+  }
+
+  return {
+    type: transaction.type,
+    to,
+    ...(transactionValue ? { value: transactionValue } : {}),
+    data: data.toLowerCase() as `0x${string}`,
+    chainId: normalizeChainIdForComparison(chainId),
+  };
+}
+
+function buildPreparedOcaSwapPayload(input: {
+  requestChainId: string;
+  network: string;
+  swapResponse: OnchainActionsSwapResponse;
+}): PreparedOcaSwapPayload {
+  const normalizedTransactions = input.swapResponse.transactions.map(normalizeOcaSwapTransaction);
+  if (normalizedTransactions.length === 0) {
+    throw new Error('Hidden swap execution signing requires at least one OCA transaction request.');
+  }
+
+  for (const transaction of normalizedTransactions) {
+    if (transaction.chainId !== input.requestChainId) {
+      throw new Error(
+        `Onchain Actions swap response chain id "${transaction.chainId}" did not match requested chain id "${input.requestChainId}".`,
+      );
+    }
+  }
+
+  const payloadFingerprint = createHash('sha256')
+    .update(
+      JSON.stringify({
+        controlPath: HIDDEN_OCA_EXECUTOR_CONTROL_PATH,
+        transactions: normalizedTransactions.map((transaction) => ({
+          type: transaction.type,
+          to: transaction.to,
+          value: transaction.value ?? '0',
+          data: transaction.data,
+          chainId: transaction.chainId,
+        })),
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16);
+  const transactionPayloadRef = `txpayload-hidden-oca-swap-${payloadFingerprint}`;
+
+  return {
+    transactionPayloadRef,
+    canonicalUnsignedPayloadRef: `unsigned-${transactionPayloadRef}`,
+    chainId: input.requestChainId,
+    network: input.network,
+    transactions: normalizedTransactions,
   };
 }
 
@@ -451,6 +606,7 @@ function buildCreateTransactionRequest(input: {
   rootedWalletContextId?: string;
   request: HiddenOcaSpotSwapInput;
   swapResponse: OnchainActionsSwapResponse;
+  preparedPayload: PreparedOcaSwapPayload;
   fromToken: OnchainActionsToken;
   network: string;
 }) {
@@ -474,6 +630,11 @@ function buildCreateTransactionRequest(input: {
           kind: 'exact',
           value: input.swapResponse.exactFromAmount || input.request.amount,
         },
+      },
+      payload_builder_output: {
+        transaction_payload_ref: input.preparedPayload.transactionPayloadRef,
+        required_control_path: HIDDEN_OCA_EXECUTOR_CONTROL_PATH,
+        network: input.preparedPayload.network,
       },
     },
   };
@@ -614,26 +775,18 @@ function readExecutionPreparation(executionResult: Record<string, unknown>) {
 
 async function resolvePreparedUnsignedTransactionHexFromSwapResponse(input: {
   executionSigningPackage: Record<string, unknown> | null;
-  swapResponse: OnchainActionsSwapResponse;
+  preparedPayload: PreparedOcaSwapPayload;
   walletAddress: `0x${string}`;
   resolveExecutionPublicClient: ResolveHiddenOcaExecutionPublicClient;
 }): Promise<`0x${string}`> {
-  const [firstTransaction, ...remainingTransactions] = input.swapResponse.transactions;
+  const [firstTransaction] = input.preparedPayload.transactions;
   if (!firstTransaction) {
     throw new Error('Hidden swap execution signing requires at least one OCA transaction request.');
   }
 
-  const chainId = Number(firstTransaction.chainId);
+  const chainId = Number(input.preparedPayload.chainId);
   if (!Number.isFinite(chainId) || chainId <= 0) {
     throw new Error(`Invalid hidden swap transaction chain id "${firstTransaction.chainId}".`);
-  }
-
-  for (const transaction of remainingTransactions) {
-    if (Number(transaction.chainId) !== chainId) {
-      throw new Error(
-        'Hidden swap execution signing requires all OCA transaction requests to use the same chain id.',
-      );
-    }
   }
 
   const network = resolveSupportedExecutionNetworkForChainId(chainId);
@@ -641,7 +794,7 @@ async function resolvePreparedUnsignedTransactionHexFromSwapResponse(input: {
   const delegationManager = getDeleGatorEnvironment(
     chainId,
   ).DelegationManager.toLowerCase() as `0x${string}`;
-  const executions = input.swapResponse.transactions.map((transaction) =>
+  const executions = input.preparedPayload.transactions.map((transaction) =>
     createExecution({
       target: transaction.to.toLowerCase() as `0x${string}`,
       value: BigInt(transaction.value ?? '0'),
@@ -721,6 +874,7 @@ async function signAndSubmitPreparedExecution(input: {
   transactionPlanId: string;
   executionResult: Record<string, unknown>;
   swapResponse: OnchainActionsSwapResponse;
+  preparedPayload: PreparedOcaSwapPayload;
 }): Promise<{
   response: unknown;
   executionResult: Record<string, unknown> | null;
@@ -744,14 +898,37 @@ async function signAndSubmitPreparedExecution(input: {
     );
   }
 
+  const preparedNetwork = readString(executionPreparation?.['network']);
+  if (!preparedNetwork) {
+    throw new Error(
+      'Hidden swap execution signing could not continue because Shared Ember did not return a prepared network.',
+    );
+  }
+  const normalizedPreparedNetwork = normalizeNetworkName(preparedNetwork);
+  if (normalizedPreparedNetwork !== input.preparedPayload.network) {
+    throw new Error(
+      `Shared Ember prepared hidden swap execution for network "${preparedNetwork}", but the OCA payload was prepared for network "${input.preparedPayload.network}".`,
+    );
+  }
+
+  const canonicalUnsignedPayloadRef = readString(
+    executionSigningPackage?.['canonical_unsigned_payload_ref'],
+  );
+  if (canonicalUnsignedPayloadRef !== input.preparedPayload.canonicalUnsignedPayloadRef) {
+    throw new Error(
+      'Hidden swap execution signing could not continue because Shared Ember canonical unsigned payload ref does not match the prepared OCA payload.',
+    );
+  }
+
   const unsignedTransactionHex =
     (await input.options.resolvePreparedUnsignedTransactionHex?.({
       executionResult: input.executionResult,
       swapResponse: input.swapResponse,
+      preparedPayload: input.preparedPayload,
     })) ??
     (await resolvePreparedUnsignedTransactionHexFromSwapResponse({
       executionSigningPackage,
-      swapResponse: input.swapResponse,
+      preparedPayload: input.preparedPayload,
       walletAddress: expectedWalletAddress,
       resolveExecutionPublicClient:
         input.options.resolveExecutionPublicClient ??
@@ -794,9 +971,7 @@ async function signAndSubmitPreparedExecution(input: {
           transaction_plan_id: input.transactionPlanId,
           request_id: requestId,
           active_delegation_id: readString(executionSigningPackage?.['active_delegation_id']),
-          canonical_unsigned_payload_ref: readString(
-            executionSigningPackage?.['canonical_unsigned_payload_ref'],
-          ),
+          canonical_unsigned_payload_ref: canonicalUnsignedPayloadRef,
           signer_address: signed.confirmedAddress,
           raw_transaction: signed.rawTransaction,
         },
@@ -858,6 +1033,7 @@ async function runExecutionFlow(input: {
   transactionPlanId: string;
   request: HiddenOcaSpotSwapInput;
   swapResponse: OnchainActionsSwapResponse;
+  preparedPayload: PreparedOcaSwapPayload;
 }): Promise<HiddenOcaSpotSwapResult> {
   let revision = input.currentRevision;
   let attempt = 1;
@@ -963,6 +1139,7 @@ async function runExecutionFlow(input: {
           transactionPlanId: input.transactionPlanId,
           executionResult,
           swapResponse: input.swapResponse,
+          preparedPayload: input.preparedPayload,
         });
         revision = readResultRevision(submitResult.response);
         committedEventIds.push(...readCommittedEventIds(submitResult.response));
@@ -1023,20 +1200,31 @@ async function parseJsonResponse(response: Response, endpoint: string): Promise<
   return text.length > 0 ? (JSON.parse(text) as unknown) : {};
 }
 
-function readTokensResponse(value: unknown): OnchainActionsToken[] {
+function readTokensPage(value: unknown): OnchainActionsTokensPage {
   const tokens = isRecord(value) && Array.isArray(value['tokens']) ? value['tokens'] : [];
-  return tokens.filter((token): token is OnchainActionsToken => {
-    if (!isRecord(token) || !isRecord(token['tokenUid'])) {
-      return false;
-    }
+  const currentPage = isRecord(value) ? readInt(value['currentPage']) : null;
+  const totalPages = isRecord(value) ? readInt(value['totalPages']) : null;
 
-    return (
-      typeof token['tokenUid']['chainId'] === 'string' &&
-      typeof token['tokenUid']['address'] === 'string' &&
-      typeof token['name'] === 'string' &&
-      typeof token['symbol'] === 'string'
-    );
-  });
+  return {
+    tokens: tokens.filter((token): token is OnchainActionsToken => {
+      if (!isRecord(token) || !isRecord(token['tokenUid'])) {
+        return false;
+      }
+
+      return (
+        typeof token['tokenUid']['chainId'] === 'string' &&
+        typeof token['tokenUid']['address'] === 'string' &&
+        typeof token['name'] === 'string' &&
+        typeof token['symbol'] === 'string'
+      );
+    }),
+    ...(currentPage === null ? {} : { currentPage }),
+    ...(totalPages === null ? {} : { totalPages }),
+  };
+}
+
+function readTokensResponse(value: unknown): OnchainActionsToken[] {
+  return readTokensPage(value).tokens;
 }
 
 function readSwapTransaction(value: unknown): OnchainActionsTransactionRequest | null {
@@ -1119,12 +1307,29 @@ export function createHiddenOcaOnchainActionsClient(input: {
 
   return {
     async listTokens(params) {
-      const query = new URLSearchParams();
-      for (const chainId of params.chainIds ?? []) {
-        query.append('chainIds', chainId);
+      const tokens: OnchainActionsToken[] = [];
+      let page = 1;
+
+      while (true) {
+        const query = new URLSearchParams();
+        for (const chainId of params.chainIds ?? []) {
+          query.append('chainIds', chainId);
+        }
+        query.append('page', String(page));
+        const endpoint = `/tokens?${query.toString()}`;
+        const tokenPage = readTokensPage(
+          await parseJsonResponse(await fetchImpl(`${baseUrl}${endpoint}`), endpoint),
+        );
+        tokens.push(...tokenPage.tokens);
+
+        const currentPage = tokenPage.currentPage ?? page;
+        const totalPages = tokenPage.totalPages ?? currentPage;
+        if (currentPage >= totalPages) {
+          return tokens;
+        }
+
+        page = currentPage + 1;
       }
-      const endpoint = query.toString() ? `/tokens?${query.toString()}` : '/tokens';
-      return readTokensResponse(await parseJsonResponse(await fetchImpl(`${baseUrl}${endpoint}`), endpoint));
     },
     async createSwap(params) {
       const payload = {
@@ -1179,8 +1384,21 @@ export function createHiddenOcaSpotSwapExecutor(
         walletAddress,
       };
       const idempotencyKey = request.idempotencyKey ?? buildPayloadDerivedIdempotencyKey(request);
-      const fromChainId = resolveChainId(request.fromChain);
-      const toChainId = resolveChainId(request.toChain);
+      let fromChainId: string;
+      let toChainId: string;
+      let network: string;
+      try {
+        fromChainId = resolveChainId(request.fromChain);
+        toChainId = resolveChainId(request.toChain);
+        network = normalizeNetworkName(request.fromChain);
+      } catch (error) {
+        return createInputFailedResult({
+          request,
+          idempotencyKey,
+          failureReason:
+            error instanceof Error ? error.message : 'Unknown hidden OCA swap chain resolution failure.',
+        });
+      }
       if (fromChainId !== toChainId) {
         return createInputFailedResult({
           request,
@@ -1189,30 +1407,49 @@ export function createHiddenOcaSpotSwapExecutor(
         });
       }
 
-      const fromTokens = await onchainActionsClient.listTokens({ chainIds: [fromChainId] });
-      const toTokens =
-        toChainId === fromChainId
-          ? fromTokens
-          : await onchainActionsClient.listTokens({ chainIds: [toChainId] });
-      const fromToken = resolveToken({
-        tokens: fromTokens,
-        chainId: fromChainId,
-        token: request.fromToken,
-      });
-      const toToken = resolveToken({
-        tokens: toTokens,
-        chainId: toChainId,
-        token: request.toToken,
-      });
-      const swapResponse = await onchainActionsClient.createSwap({
-        walletAddress: request.walletAddress,
-        amount: request.amount,
-        amountType: request.amountType,
-        fromTokenUid: fromToken.tokenUid,
-        toTokenUid: toToken.tokenUid,
-        ...(request.slippageTolerance ? { slippageTolerance: request.slippageTolerance } : {}),
-        ...(request.expiration ? { expiration: request.expiration } : {}),
-      });
+      let fromToken: OnchainActionsToken;
+      let swapResponse: OnchainActionsSwapResponse;
+      let preparedPayload: PreparedOcaSwapPayload;
+      try {
+        const fromTokens = await onchainActionsClient.listTokens({ chainIds: [fromChainId] });
+        const toTokens =
+          toChainId === fromChainId
+            ? fromTokens
+            : await onchainActionsClient.listTokens({ chainIds: [toChainId] });
+        fromToken = resolveToken({
+          tokens: fromTokens,
+          chainId: fromChainId,
+          token: request.fromToken,
+        });
+        const toToken = resolveToken({
+          tokens: toTokens,
+          chainId: toChainId,
+          token: request.toToken,
+        });
+        swapResponse = await onchainActionsClient.createSwap({
+          walletAddress: request.walletAddress,
+          amount: request.amount,
+          amountType: request.amountType,
+          fromTokenUid: fromToken.tokenUid,
+          toTokenUid: toToken.tokenUid,
+          ...(request.slippageTolerance ? { slippageTolerance: request.slippageTolerance } : {}),
+          ...(request.expiration ? { expiration: request.expiration } : {}),
+        });
+        preparedPayload = buildPreparedOcaSwapPayload({
+          requestChainId: fromChainId,
+          network,
+          swapResponse,
+        });
+      } catch (error) {
+        return createInputFailedResult({
+          request,
+          idempotencyKey,
+          failureReason:
+            error instanceof Error
+              ? error.message
+              : 'Unknown hidden OCA swap preparation failure.',
+        });
+      }
       const createResponse = await runSharedEmberCommandWithResolvedRevision({
         protocolHost: options.protocolHost,
         threadId,
@@ -1225,8 +1462,9 @@ export function createHiddenOcaSpotSwapExecutor(
             rootedWalletContextId: request.rootedWalletContextId,
             request,
             swapResponse,
+            preparedPayload,
             fromToken,
-            network: normalizeNetworkName(request.fromChain),
+            network,
           }),
       });
       const transactionPlanId = readCandidatePlanId(createResponse);
@@ -1251,6 +1489,7 @@ export function createHiddenOcaSpotSwapExecutor(
         transactionPlanId,
         request,
         swapResponse,
+        preparedPayload,
       });
     },
   };

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -152,6 +152,26 @@ function createSwapResponse() {
   };
 }
 
+function createWethToUsdcSwapResponse() {
+  return {
+    fromToken: createTokens()[1]!,
+    toToken: createTokens()[0]!,
+    exactFromAmount: '894102247158860',
+    displayFromAmount: '0.00089410224715886',
+    exactToAmount: '3100000',
+    displayToAmount: '3.10',
+    transactions: [
+      {
+        type: 'EVM_TX',
+        to: '0x00000000000000000000000000000000000000d1',
+        value: '0',
+        data: '0xabcdef',
+        chainId: '42161',
+      },
+    ],
+  };
+}
+
 function createCandidatePlanResponse() {
   return {
     jsonrpc: '2.0',
@@ -327,6 +347,111 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         transaction_plan_id: 'txplan-hidden-swap-001',
       },
     });
+  });
+
+  it('normalizes decimal exact-in token amounts to OCA base-unit amounts', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createWethToUsdcSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null
+            ? (request as { method?: string })
+            : {};
+
+        if (jsonRpcRequest.method === 'subagent.createTransaction.v1') {
+          return createCandidatePlanResponse();
+        }
+
+        if (jsonRpcRequest.method === 'subagent.requestExecution.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              committed_event_ids: ['evt-hidden-swap-execution-1'],
+              execution_result: {
+                phase: 'completed',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                execution: {
+                  execution_id: 'exec-hidden-swap-001',
+                  status: 'confirmed',
+                  transaction_hash: '0xswapconfirmed',
+                  successor_unit_ids: [],
+                },
+              },
+            },
+          };
+        }
+
+        throw new Error(`unexpected method: ${String(jsonRpcRequest.method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '0.00089410224715886',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'WETH',
+          toToken: 'USDC',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      swapSummary: {
+        amount: '894102247158860',
+        fromToken: 'WETH',
+        toToken: 'USDC',
+      },
+    });
+
+    expect(onchainActionsClient.createSwap).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000a1',
+      amount: '894102247158860',
+      amountType: 'exactIn',
+      fromTokenUid: {
+        chainId: '42161',
+        address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+      },
+      toTokenUid: {
+        chainId: '42161',
+        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: 'subagent.createTransaction.v1',
+        params: expect.objectContaining({
+          request: expect.objectContaining({
+            asset: 'WETH',
+            quantity: {
+              kind: 'exact',
+              value: '894102247158860',
+            },
+          }),
+        }),
+      }),
+    );
   });
 
   it('retries a stale Shared Ember expected revision once with the current hidden executor revision', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -457,6 +457,128 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
     );
   });
 
+  it('resolves Arbitrum USDT requests to the OCA USDT0 token alias', async () => {
+    const wbtcToken = {
+      tokenUid: {
+        chainId: '42161',
+        address: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+      },
+      name: 'Arbitrum Bridged WBTC',
+      symbol: 'WBTC',
+      isNative: false,
+      decimals: 8,
+      isVetted: true,
+    };
+    const usdt0Token = {
+      tokenUid: {
+        chainId: '42161',
+        address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+      },
+      name: 'USDT0',
+      symbol: 'USDT0',
+      isNative: false,
+      decimals: 6,
+      isVetted: true,
+    };
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => [wbtcToken, usdt0Token]),
+      createSwap: vi.fn(async () => ({
+        fromToken: wbtcToken,
+        toToken: usdt0Token,
+        exactFromAmount: '3',
+        displayFromAmount: '0.00000003',
+        exactToAmount: '1541',
+        displayToAmount: '0.001541',
+        transactions: [
+          {
+            type: 'EVM_TX',
+            to: '0x00000000000000000000000000000000000000d1',
+            value: '0',
+            data: '0xabcdef',
+            chainId: '42161',
+          },
+        ],
+      })),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null
+            ? (request as { method?: string })
+            : {};
+
+        if (jsonRpcRequest.method === 'subagent.createTransaction.v1') {
+          return createCandidatePlanResponse();
+        }
+
+        if (jsonRpcRequest.method === 'subagent.requestExecution.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              committed_event_ids: ['evt-hidden-swap-execution-1'],
+              execution_result: {
+                phase: 'completed',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                execution: {
+                  execution_id: 'exec-hidden-swap-001',
+                  status: 'confirmed',
+                  transaction_hash: '0xswapconfirmed',
+                  successor_unit_ids: [],
+                },
+              },
+            },
+          };
+        }
+
+        throw new Error(`unexpected method: ${String(jsonRpcRequest.method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '3',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'WBTC',
+          toToken: 'USDT',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      swapSummary: {
+        fromToken: 'WBTC',
+        toToken: 'USDT0',
+      },
+    });
+
+    expect(onchainActionsClient.createSwap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toTokenUid: {
+          chainId: '42161',
+          address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+        },
+      }),
+    );
+  });
+
   it('retries a stale Shared Ember expected revision once with the current hidden executor revision', async () => {
     const onchainActionsClient = {
       listTokens: vi.fn(async () => createTokens()),
@@ -1503,6 +1625,97 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
       requestId: 'req-hidden-swap-001',
       failureReason:
         'send_insufficient_funds: rpc_-32000: insufficient funds for gas * price + value',
+    });
+  });
+
+  it('keeps viem estimate failures concise in user-facing results', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const estimateError = new Error(
+      'Execution reverted for an unknown reason.\n\nEstimate Gas Arguments:\n  data: 0xabcdef',
+    ) as Error & { shortMessage: string };
+    estimateError.shortMessage = 'Execution reverted for an unknown reason.';
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'ready_for_execution_signing',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution_preparation: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                agent_id: 'agent-oca-executor',
+                agent_wallet: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                network: 'arbitrum',
+                reservation_id: 'res-hidden-swap-001',
+                required_control_path: 'spot.swap',
+                active_delegation_id: 'del-hidden-swap-001',
+                root_delegation_id: 'root-delegation-001',
+                prepared_at: '2026-04-10T12:00:00.000Z',
+              },
+              execution_signing_package: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                active_delegation_id: 'del-hidden-swap-001',
+                canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      runtimeSigning,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      resolvePreparedUnsignedTransactionHex: vi.fn(async () => {
+        throw estimateError;
+      }),
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'Execution reverted for an unknown reason.',
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import {
+  createExecution,
+  type Delegation,
+  ExecutionMode,
+  getDeleGatorEnvironment,
+} from '@metamask/delegation-toolkit';
+import { DelegationManager } from '@metamask/delegation-toolkit/contracts';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
+import { serializeTransaction } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createHiddenOcaSpotSwapExecutor } from './hiddenOcaSwapExecutor.js';
 
@@ -7,12 +15,89 @@ const TEST_UNSIGNED_TRANSACTION_HEX =
   '0x02e982a4b1018405f5e100843b9aca008252089400000000000000000000000000000000000000c18080c0' as const;
 const TEST_TRANSACTION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
+const TEST_ROOT_DELEGATION = createSignedDelegation({
+  delegate: '0x00000000000000000000000000000000000000c1',
+  delegator: '0x00000000000000000000000000000000000000a1',
+});
+const TEST_ACTIVE_DELEGATION = createSignedDelegation({
+  delegate: '0x00000000000000000000000000000000000000e1',
+  delegator: '0x00000000000000000000000000000000000000c1',
+});
+const TEST_ROOT_DELEGATION_ARTIFACT_REF = encodeDelegationArtifactRef(TEST_ROOT_DELEGATION);
+const TEST_ACTIVE_DELEGATION_ARTIFACT_REF = encodeDelegationArtifactRef(TEST_ACTIVE_DELEGATION);
 
 function createRuntimeSigningStub(signPayload: AgentRuntimeSigningService['signPayload']) {
   return {
     readAddress: vi.fn<AgentRuntimeSigningService['readAddress']>(),
     signPayload,
   };
+}
+
+function createSignedDelegation(input: {
+  delegate: `0x${string}`;
+  delegator: `0x${string}`;
+  authority?: `0x${string}`;
+}): Delegation {
+  return {
+    delegate: input.delegate,
+    delegator: input.delegator,
+    authority:
+      input.authority ?? '0x0000000000000000000000000000000000000000000000000000000000000000',
+    caveats: [],
+    salt: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    signature: '0x1234',
+  };
+}
+
+function encodeDelegationArtifactRef(delegation: Delegation): string {
+  return `metamask-delegation:${Buffer.from(JSON.stringify(delegation), 'utf8').toString(
+    'base64url',
+  )}`;
+}
+
+function buildExpectedDelegatedUnsignedTransactionHex(input: {
+  transaction: {
+    to: `0x${string}`;
+    value: string;
+    data: `0x${string}`;
+    chainId: string;
+  };
+  nonce: number;
+  gas: bigint;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+}): `0x${string}` {
+  const chainId = Number(input.transaction.chainId);
+  const { DelegationManager: delegationManager } = getDeleGatorEnvironment(chainId);
+  const data = DelegationManager.encode.redeemDelegations({
+    delegations: [[TEST_ACTIVE_DELEGATION, TEST_ROOT_DELEGATION]],
+    modes: [ExecutionMode.SingleDefault],
+    executions: [
+      [
+        createExecution({
+          target: input.transaction.to,
+          value: BigInt(input.transaction.value),
+          callData: input.transaction.data,
+        }),
+      ],
+    ],
+  });
+
+  return serializeTransaction({
+    chainId,
+    type: 'eip1559',
+    nonce: input.nonce,
+    gas: input.gas,
+    maxFeePerGas: input.maxFeePerGas,
+    maxPriorityFeePerGas: input.maxPriorityFeePerGas,
+    to: delegationManager,
+    value: 0n,
+    data,
+  });
+}
+
+function bufferDelegatedExecutionGas(gasEstimate: bigint): bigint {
+  return (gasEstimate * 3n) / 2n;
 }
 
 function createTokens() {
@@ -542,5 +627,159 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         },
       },
     });
+  });
+
+  it('derives the delegated unsigned transaction from OCA swap transactions by default', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const swapResponse = createSwapResponse();
+    const executionPublicClient = {
+      getTransactionCount: vi.fn(async () => 7),
+      estimateFeesPerGas: vi.fn(async () => ({
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 3n,
+      })),
+      estimateGas: vi.fn(async () => 55_000n),
+    };
+    const expectedUnsignedTransactionHex = buildExpectedDelegatedUnsignedTransactionHex({
+      transaction: swapResponse.transactions[0]!,
+      nonce: 7,
+      gas: bufferDelegatedExecutionGas(55_000n),
+      maxFeePerGas: 200n,
+      maxPriorityFeePerGas: 3n,
+    });
+    const signPreparedTransaction = vi.fn(async () => ({
+      confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+      rawTransaction: '0xfeed' as const,
+    }));
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'ready_for_execution_signing',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution_preparation: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                agent_id: 'agent-oca-executor',
+                agent_wallet: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                network: 'arbitrum',
+                reservation_id: 'res-hidden-swap-001',
+                required_control_path: 'spot.swap',
+                active_delegation_id: 'del-hidden-swap-001',
+                root_delegation_id: 'root-delegation-001',
+                prepared_at: '2026-04-10T12:00:00.000Z',
+              },
+              execution_signing_package: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                active_delegation_id: 'del-hidden-swap-001',
+                delegation_artifact_ref: TEST_ACTIVE_DELEGATION_ARTIFACT_REF,
+                root_delegation_artifact_ref: TEST_ROOT_DELEGATION_ARTIFACT_REF,
+                canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-hidden-oca-swap-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 6,
+            committed_event_ids: ['evt-hidden-swap-submitted-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'submitted',
+                transaction_hash: '0xsubmittedswap',
+                successor_unit_ids: [],
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => swapResponse),
+      },
+      runtimeSigning,
+      runtimeSignerRef: 'oca-executor-wallet',
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      resolveExecutionPublicClient: vi.fn(() => executionPublicClient),
+      signPreparedTransaction,
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'submitted',
+      transactionHash: '0xsubmittedswap',
+    });
+
+    expect(signPreparedTransaction).toHaveBeenCalledWith({
+      signing: runtimeSigning,
+      signerRef: 'oca-executor-wallet',
+      expectedAddress: '0x00000000000000000000000000000000000000e1',
+      chain: 'evm',
+      unsignedTransactionHex: expectedUnsignedTransactionHex,
+    });
+    expect(executionPublicClient.estimateGas).toHaveBeenCalledWith({
+      account: '0x00000000000000000000000000000000000000e1',
+      to: getDeleGatorEnvironment(42161).DelegationManager.toLowerCase(),
+      value: 0n,
+      data: expect.stringMatching(/^0x[0-9a-f]+$/),
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: 'subagent.submitSignedTransaction.v1',
+        params: expect.objectContaining({
+          signed_transaction: expect.objectContaining({
+            raw_transaction: '0xfeed',
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -345,6 +345,9 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         idempotency_key: 'idem-hidden-swap-001:request-execution:1',
         expected_revision: 4,
         transaction_plan_id: 'txplan-hidden-swap-001',
+        reservation_conflict_handling: {
+          kind: 'unassigned_only',
+        },
       },
     });
   });
@@ -885,6 +888,85 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         reservationId: 'res-ember-lending-001',
         retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
       },
+    });
+  });
+
+  it('surfaces non-conflict blocked execution reasons from Shared Ember', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const method =
+          typeof request === 'object' && request !== null
+            ? (request as { method?: string }).method
+            : null;
+
+        if (method === 'subagent.createTransaction.v1') {
+          return createCandidatePlanResponse();
+        }
+
+        if (method === 'subagent.requestExecution.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              committed_event_ids: ['evt-hidden-swap-blocked-1'],
+              execution_result: {
+                phase: 'blocked',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                request_result: {
+                  result: 'denied',
+                  request_id: 'req-hidden-swap-001',
+                  message: 'no active reservation admits the requested execution',
+                  active_delegation_id: null,
+                  reservation_id: null,
+                  blocking_reason_code: 'no_active_reservation',
+                  next_action: 'stop',
+                },
+                portfolio_state: {},
+              },
+            },
+          };
+        }
+
+        throw new Error(`unexpected method: ${String(method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'blocked',
+      failureReason:
+        'Shared Ember blocked hidden swap execution (no_active_reservation): no active reservation admits the requested execution.',
+      transactionPlanId: 'txplan-hidden-swap-001',
+      requestId: 'req-hidden-swap-001',
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -1231,6 +1231,58 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
     );
   });
 
+  it('derives generated idempotency keys from the AG-UI thread id', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-hidden-oca-swap-create-transaction',
+        result: {
+          protocol_version: 'v1',
+          revision: 4,
+          committed_event_ids: [],
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+    const input = {
+      rootedWalletContextId: 'rwc-user-spot-001',
+      walletAddress: '0x00000000000000000000000000000000000000a1' as const,
+      amount: '1000000',
+      amountType: 'exactIn' as const,
+      fromChain: 'arbitrum',
+      toChain: 'arbitrum',
+      fromToken: 'USDC',
+      toToken: 'WETH',
+      capitalPool: 'all' as const,
+    };
+
+    await executor.executeSpotSwap({
+      threadId: 'thread-1',
+      currentRevision: 3,
+      input,
+    });
+    await executor.executeSpotSwap({
+      threadId: 'thread-2',
+      currentRevision: 3,
+      input,
+    });
+
+    const firstCreateParams = protocolHost.handleJsonRpc.mock.calls[0]?.[0].params;
+    const secondCreateParams = protocolHost.handleJsonRpc.mock.calls[1]?.[0].params;
+    expect(firstCreateParams.idempotency_key).toMatch(/^idem-hidden-oca-swap-/);
+    expect(secondCreateParams.idempotency_key).toMatch(/^idem-hidden-oca-swap-/);
+    expect(firstCreateParams.idempotency_key).not.toEqual(secondCreateParams.idempotency_key);
+  });
+
   it('continues through redelegation refresh before signing and submitting the hidden swap', async () => {
     const runtimeSigning = createRuntimeSigningStub(
       vi.fn(async () => ({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -9,7 +9,10 @@ import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { serializeTransaction } from 'viem';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createHiddenOcaSpotSwapExecutor } from './hiddenOcaSwapExecutor.js';
+import {
+  createHiddenOcaOnchainActionsClient,
+  createHiddenOcaSpotSwapExecutor,
+} from './hiddenOcaSwapExecutor.js';
 
 const TEST_UNSIGNED_TRANSACTION_HEX =
   '0x02e982a4b1018405f5e100843b9aca008252089400000000000000000000000000000000000000c18080c0' as const;
@@ -319,6 +322,146 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
     });
   });
 
+  it('retries a stale Shared Ember expected revision once with the current hidden executor revision', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            'Shared Ember Domain Service JSON-RPC error: protocol_conflict: expected_revision must match the current service revision',
+          ),
+        )
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-read-hidden-oca-executor-revision',
+          result: {
+            revision: 9,
+          },
+        })
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'confirmed',
+                transaction_hash: '0xswapconfirmed',
+                successor_unit_ids: [],
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      transactionHash: '0xswapconfirmed',
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: 'subagent.createTransaction.v1',
+        params: expect.objectContaining({
+          expected_revision: 3,
+        }),
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-read-hidden-oca-executor-revision',
+      method: 'subagent.readPortfolioState.v1',
+      params: {
+        agent_id: 'agent-oca-executor',
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: 'subagent.createTransaction.v1',
+        params: expect.objectContaining({
+          expected_revision: 9,
+        }),
+      }),
+    );
+  });
+
+  it('fails closed before OCA planning for unsupported cross-chain swap inputs', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost: {
+        handleJsonRpc: vi.fn(),
+        readCommittedEventOutbox: vi.fn(),
+        acknowledgeCommittedEventOutbox: vi.fn(),
+      },
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'mainnet',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'Hidden OCA spot swaps currently require fromChain and toChain to match.',
+      transactionPlanId: null,
+      requestId: null,
+    });
+
+    expect(onchainActionsClient.listTokens).not.toHaveBeenCalled();
+    expect(onchainActionsClient.createSwap).not.toHaveBeenCalled();
+  });
+
   it('returns structured reserved-capital conflict details without retrying automatically', async () => {
     const onchainActionsClient = {
       listTokens: vi.fn(async () => createTokens()),
@@ -476,6 +619,202 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
     );
   });
 
+  it('continues through redelegation refresh before signing and submitting the hidden swap', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const requestRedelegationRefresh = vi.fn(async () => undefined);
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-redelegation-1'],
+            execution_result: {
+              phase: 'ready_for_redelegation',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-read-hidden-oca-executor-revision',
+          result: {
+            revision: 6,
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 7,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'ready_for_execution_signing',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution_preparation: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                agent_id: 'agent-oca-executor',
+                agent_wallet: '0x00000000000000000000000000000000000000e1',
+              },
+              execution_signing_package: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                active_delegation_id: 'del-hidden-swap-001',
+                canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-hidden-oca-swap-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 8,
+            committed_event_ids: ['evt-hidden-swap-submitted-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'submitted',
+                transaction_hash: '0xsubmittedswap',
+                successor_unit_ids: [],
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      runtimeSigning,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      requestRedelegationRefresh,
+      resolvePreparedUnsignedTransactionHex: vi.fn(async () => TEST_UNSIGNED_TRANSACTION_HEX),
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'submitted',
+      transactionHash: '0xsubmittedswap',
+    });
+
+    expect(requestRedelegationRefresh).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      transactionPlanId: 'txplan-hidden-swap-001',
+      requestId: 'req-hidden-swap-001',
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: 'subagent.readPortfolioState.v1',
+      }),
+    );
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        method: 'subagent.requestExecution.v1',
+        params: expect.objectContaining({
+          expected_revision: 6,
+        }),
+      }),
+    );
+  });
+
+  it('fails closed instead of waiting indefinitely when redelegation refresh is not configured', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-redelegation-1'],
+            execution_result: {
+              phase: 'ready_for_redelegation',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason:
+        'Hidden swap execution reached redelegation readiness, but no redelegation refresh handler is configured.',
+    });
+  });
+
   it('signs and submits an execution-signing package with the hidden executor wallet', async () => {
     const runtimeSigning = createRuntimeSigningStub(
       vi.fn(async () => ({
@@ -506,7 +845,7 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
                 transaction_plan_id: 'txplan-hidden-swap-001',
                 request_id: 'req-hidden-swap-001',
                 agent_id: 'agent-oca-executor',
-                agent_wallet: '0x00000000000000000000000000000000000000e1',
+                agent_wallet: '0x00000000000000000000000000000000000000E1',
                 root_user_wallet: '0x00000000000000000000000000000000000000a1',
                 network: 'arbitrum',
                 reservation_id: 'res-hidden-swap-001',
@@ -781,5 +1120,51 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         }),
       }),
     );
+  });
+
+  it('rejects an OCA swap response with any malformed transaction entry', async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          ...createSwapResponse(),
+          transactions: [
+            createSwapResponse().transactions[0],
+            {
+              type: 'EVM_TX',
+              to: '0xnot-an-address',
+              value: '0',
+              data: '0xabcdef',
+              chainId: '42161',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      );
+    });
+    const client = createHiddenOcaOnchainActionsClient({
+      baseUrl: 'https://onchain-actions.test',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    await expect(
+      client.createSwap({
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '1000000',
+        amountType: 'exactIn',
+        fromTokenUid: {
+          chainId: '42161',
+          address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        },
+        toTokenUid: {
+          chainId: '42161',
+          address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+        },
+      }),
+    ).rejects.toThrow('Onchain Actions swap response included malformed transaction entries.');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -1628,7 +1628,7 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
     });
   });
 
-  it('keeps viem estimate failures concise in user-facing results', async () => {
+  it('explains viem estimate reverts as pre-submission route failures', async () => {
     const runtimeSigning = createRuntimeSigningStub(
       vi.fn(async () => ({
         confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
@@ -1715,7 +1715,8 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
       }),
     ).resolves.toMatchObject({
       status: 'failed',
-      failureReason: 'Execution reverted for an unknown reason.',
+      failureReason:
+        'Hidden swap execution reverted during gas estimation before submission. No transaction was sent; try a larger amount or a different route.',
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -1396,6 +1396,116 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
     });
   });
 
+  it('reports failed terminal execution results as failed instead of completed', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'ready_for_execution_signing',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution_preparation: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                agent_id: 'agent-oca-executor',
+                agent_wallet: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                network: 'arbitrum',
+                reservation_id: 'res-hidden-swap-001',
+                required_control_path: 'spot.swap',
+                active_delegation_id: 'del-hidden-swap-001',
+                root_delegation_id: 'root-delegation-001',
+                prepared_at: '2026-04-10T12:00:00.000Z',
+              },
+              execution_signing_package: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                active_delegation_id: 'del-hidden-swap-001',
+                canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-hidden-oca-swap-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 6,
+            committed_event_ids: ['evt-hidden-swap-failed-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'failed_before_submission',
+                message:
+                  'send_insufficient_funds: rpc_-32000: insufficient funds for gas * price + value',
+                transaction_hash: null,
+                successor_unit_ids: [],
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      runtimeSigning,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      resolvePreparedUnsignedTransactionHex: vi.fn(async () => TEST_UNSIGNED_TRANSACTION_HEX),
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      transactionPlanId: 'txplan-hidden-swap-001',
+      requestId: 'req-hidden-swap-001',
+      failureReason:
+        'send_insufficient_funds: rpc_-32000: insufficient funds for gas * price + value',
+    });
+  });
+
   it('fails signing when Shared Ember prepares the OCA payload for a different network', async () => {
     const runtimeSigning = createRuntimeSigningStub(
       vi.fn(async () => ({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@metamask/delegation-toolkit';
 import { DelegationManager } from '@metamask/delegation-toolkit/contracts';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
-import { serializeTransaction } from 'viem';
+import { encodeFunctionData, erc20Abi, serializeTransaction } from 'viem';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -20,6 +20,23 @@ const TEST_PREPARED_TRANSACTION_PAYLOAD_REF = 'txpayload-hidden-oca-swap-1f18f9b
 const TEST_CANONICAL_UNSIGNED_PAYLOAD_REF = `unsigned-${TEST_PREPARED_TRANSACTION_PAYLOAD_REF}`;
 const TEST_TRANSACTION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
+const TEST_PERMIT2_ADDRESS = '0x000000000022d473030f116ddee9f6b43ac78ba3' as const;
+const TEST_PERMIT2_MAX_EXPIRATION = 281_474_976_710_655;
+const TEST_OCA_FUND_AND_RUN_MULTICALL = '0xce16f69375520ab01377ce7b88f5ba8c48f8d666' as const;
+const TEST_PERMIT2_APPROVE_ABI = [
+  {
+    type: 'function',
+    name: 'approve',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'token', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint160' },
+      { name: 'expiration', type: 'uint48' },
+    ],
+    outputs: [],
+  },
+] as const;
 const TEST_ROOT_DELEGATION = createSignedDelegation({
   delegate: '0x00000000000000000000000000000000000000c1',
   delegator: '0x00000000000000000000000000000000000000a1',
@@ -61,30 +78,42 @@ function encodeDelegationArtifactRef(delegation: Delegation): string {
 }
 
 function buildExpectedDelegatedUnsignedTransactionHex(input: {
-  transaction: {
+  transaction?: {
     to: `0x${string}`;
     value: string;
     data: `0x${string}`;
     chainId: string;
   };
+  transactions?: Array<{
+    to: `0x${string}`;
+    value: string;
+    data: `0x${string}`;
+    chainId: string;
+  }>;
   nonce: number;
   gas: bigint;
   maxFeePerGas: bigint;
   maxPriorityFeePerGas: bigint;
 }): `0x${string}` {
-  const chainId = Number(input.transaction.chainId);
+  const transactions = input.transactions ?? (input.transaction ? [input.transaction] : []);
+  const firstTransaction = transactions[0];
+  if (!firstTransaction) {
+    throw new Error('Expected at least one delegated transaction.');
+  }
+
+  const chainId = Number(firstTransaction.chainId);
   const { DelegationManager: delegationManager } = getDeleGatorEnvironment(chainId);
   const data = DelegationManager.encode.redeemDelegations({
     delegations: [[TEST_ACTIVE_DELEGATION, TEST_ROOT_DELEGATION]],
-    modes: [ExecutionMode.SingleDefault],
+    modes: [transactions.length === 1 ? ExecutionMode.SingleDefault : ExecutionMode.BatchDefault],
     executions: [
-      [
+      transactions.map((transaction) =>
         createExecution({
-          target: input.transaction.to,
-          value: BigInt(input.transaction.value),
-          callData: input.transaction.data,
+          target: transaction.to,
+          value: BigInt(transaction.value),
+          callData: transaction.data,
         }),
-      ],
+      ),
     ],
   });
 
@@ -132,6 +161,20 @@ function createTokens() {
   ];
 }
 
+function createWbtcToken() {
+  return {
+    tokenUid: {
+      chainId: '42161',
+      address: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+    },
+    name: 'Arbitrum Bridged WBTC',
+    symbol: 'WBTC',
+    isNative: false,
+    decimals: 8,
+    isVetted: true,
+  };
+}
+
 function createSwapResponse() {
   return {
     fromToken: createTokens()[0]!,
@@ -166,6 +209,26 @@ function createWethToUsdcSwapResponse() {
         to: '0x00000000000000000000000000000000000000d1',
         value: '0',
         data: '0xabcdef',
+        chainId: '42161',
+      },
+    ],
+  };
+}
+
+function createWbtcFundedMulticallSwapResponse() {
+  return {
+    fromToken: createWbtcToken(),
+    toToken: createTokens()[0]!,
+    exactFromAmount: '2795',
+    displayFromAmount: '0.00002795',
+    exactToAmount: '2163774',
+    displayToAmount: '2.163774',
+    transactions: [
+      {
+        type: 'EVM_TX',
+        to: TEST_OCA_FUND_AND_RUN_MULTICALL,
+        value: '0',
+        data: '0x58181a80' as const,
         chainId: '42161',
       },
     ],
@@ -1967,6 +2030,203 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         }),
       }),
     );
+  });
+
+  it('prepends exact Permit2 approvals for OCA funded multicall ERC20 swaps', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const swapResponse = createWbtcFundedMulticallSwapResponse();
+    const wbtcToken = createWbtcToken();
+    const wbtcApprovePermit2Data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'approve',
+      args: [TEST_PERMIT2_ADDRESS, 2795n],
+    });
+    const permit2ApproveFunderData = encodeFunctionData({
+      abi: TEST_PERMIT2_APPROVE_ABI,
+      functionName: 'approve',
+      args: [
+        wbtcToken.tokenUid.address as `0x${string}`,
+        TEST_OCA_FUND_AND_RUN_MULTICALL,
+        2795n,
+        TEST_PERMIT2_MAX_EXPIRATION,
+      ],
+    });
+    const expectedOcaTransactions = [
+      {
+        to: wbtcToken.tokenUid.address as `0x${string}`,
+        value: '0',
+        data: wbtcApprovePermit2Data,
+        chainId: '42161',
+      },
+      {
+        to: TEST_PERMIT2_ADDRESS,
+        value: '0',
+        data: permit2ApproveFunderData,
+        chainId: '42161',
+      },
+      swapResponse.transactions[0]!,
+    ];
+    const executionPublicClient = {
+      getTransactionCount: vi.fn(async () => 7),
+      estimateFeesPerGas: vi.fn(async () => ({
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 3n,
+      })),
+      estimateGas: vi.fn(async () => 55_000n),
+    };
+    const expectedUnsignedTransactionHex = buildExpectedDelegatedUnsignedTransactionHex({
+      transactions: expectedOcaTransactions,
+      nonce: 7,
+      gas: bufferDelegatedExecutionGas(55_000n),
+      maxFeePerGas: 200n,
+      maxPriorityFeePerGas: 3n,
+    });
+    const signPreparedTransaction = vi.fn(async () => ({
+      confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+      rawTransaction: '0xfeed' as const,
+    }));
+    let preparedPayloadRef: string | null = null;
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null
+            ? (request as { method?: string; params?: Record<string, unknown> })
+            : {};
+
+        if (jsonRpcRequest.method === 'subagent.createTransaction.v1') {
+          const payloadBuilderOutput =
+            jsonRpcRequest.params?.['payload_builder_output'] as
+              | Record<string, unknown>
+              | undefined;
+          preparedPayloadRef =
+            typeof payloadBuilderOutput?.['transaction_payload_ref'] === 'string'
+              ? payloadBuilderOutput['transaction_payload_ref']
+              : null;
+
+          return createCandidatePlanResponse();
+        }
+
+        if (jsonRpcRequest.method === 'subagent.requestExecution.v1') {
+          if (!preparedPayloadRef) {
+            throw new Error('Expected prepared payload ref before execution request.');
+          }
+
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              committed_event_ids: ['evt-hidden-swap-execution-1'],
+              execution_result: {
+                phase: 'ready_for_execution_signing',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                execution_preparation: {
+                  execution_preparation_id: 'execprep-hidden-swap-001',
+                  transaction_plan_id: 'txplan-hidden-swap-001',
+                  request_id: 'req-hidden-swap-001',
+                  agent_id: 'agent-oca-executor',
+                  agent_wallet: '0x00000000000000000000000000000000000000e1',
+                  root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                  network: 'arbitrum',
+                  reservation_id: 'res-hidden-swap-001',
+                  required_control_path: 'spot.swap',
+                  active_delegation_id: 'del-hidden-swap-001',
+                  root_delegation_id: 'root-delegation-001',
+                  prepared_at: '2026-04-10T12:00:00.000Z',
+                },
+                execution_signing_package: {
+                  execution_preparation_id: 'execprep-hidden-swap-001',
+                  transaction_plan_id: 'txplan-hidden-swap-001',
+                  request_id: 'req-hidden-swap-001',
+                  active_delegation_id: 'del-hidden-swap-001',
+                  delegation_artifact_ref: TEST_ACTIVE_DELEGATION_ARTIFACT_REF,
+                  root_delegation_artifact_ref: TEST_ROOT_DELEGATION_ARTIFACT_REF,
+                  canonical_unsigned_payload_ref: `unsigned-${preparedPayloadRef}`,
+                },
+              },
+            },
+          };
+        }
+
+        if (jsonRpcRequest.method === 'subagent.submitSignedTransaction.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-submit-hidden-oca-swap-transaction',
+            result: {
+              protocol_version: 'v1',
+              revision: 6,
+              committed_event_ids: ['evt-hidden-swap-submitted-1'],
+              execution_result: {
+                phase: 'completed',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                execution: {
+                  execution_id: 'exec-hidden-swap-001',
+                  status: 'submitted',
+                  transaction_hash: '0xsubmittedswap',
+                  successor_unit_ids: [],
+                },
+              },
+            },
+          };
+        }
+
+        throw new Error(`unexpected method: ${String(jsonRpcRequest.method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => [createWbtcToken(), createTokens()[0]!]),
+        createSwap: vi.fn(async () => swapResponse),
+      },
+      runtimeSigning,
+      runtimeSignerRef: 'oca-executor-wallet',
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      resolveExecutionPublicClient: vi.fn(() => executionPublicClient),
+      signPreparedTransaction,
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '2795',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'WBTC',
+          toToken: 'USDC',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'submitted',
+      transactionHash: '0xsubmittedswap',
+    });
+
+    expect(signPreparedTransaction).toHaveBeenCalledWith({
+      signing: runtimeSigning,
+      signerRef: 'oca-executor-wallet',
+      expectedAddress: '0x00000000000000000000000000000000000000e1',
+      chain: 'evm',
+      unsignedTransactionHex: expectedUnsignedTransactionHex,
+    });
   });
 
   it('rejects an OCA swap response with any malformed transaction entry', async () => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -1,0 +1,546 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
+
+import { createHiddenOcaSpotSwapExecutor } from './hiddenOcaSwapExecutor.js';
+
+const TEST_UNSIGNED_TRANSACTION_HEX =
+  '0x02e982a4b1018405f5e100843b9aca008252089400000000000000000000000000000000000000c18080c0' as const;
+const TEST_TRANSACTION_SIGNATURE =
+  '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
+
+function createRuntimeSigningStub(signPayload: AgentRuntimeSigningService['signPayload']) {
+  return {
+    readAddress: vi.fn<AgentRuntimeSigningService['readAddress']>(),
+    signPayload,
+  };
+}
+
+function createTokens() {
+  return [
+    {
+      tokenUid: {
+        chainId: '42161',
+        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      },
+      name: 'USD Coin',
+      symbol: 'USDC',
+      isNative: false,
+      decimals: 6,
+      isVetted: true,
+    },
+    {
+      tokenUid: {
+        chainId: '42161',
+        address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+      },
+      name: 'Wrapped Ether',
+      symbol: 'WETH',
+      isNative: false,
+      decimals: 18,
+      isVetted: true,
+    },
+  ];
+}
+
+function createSwapResponse() {
+  return {
+    fromToken: createTokens()[0]!,
+    toToken: createTokens()[1]!,
+    exactFromAmount: '1000000',
+    displayFromAmount: '1',
+    exactToAmount: '300000000000000',
+    displayToAmount: '0.0003',
+    transactions: [
+      {
+        type: 'EVM_TX',
+        to: '0x00000000000000000000000000000000000000d1',
+        value: '0',
+        data: '0xabcdef',
+        chainId: '42161',
+      },
+    ],
+  };
+}
+
+function createCandidatePlanResponse() {
+  return {
+    jsonrpc: '2.0',
+    id: 'shared-ember-thread-1-create-hidden-oca-swap-transaction',
+    result: {
+      protocol_version: 'v1',
+      revision: 4,
+      committed_event_ids: ['evt-hidden-swap-plan-1'],
+      candidate_plan: {
+        planning_kind: 'subagent_handoff',
+        candidate_plan_id: 'candidate-hidden-swap-001',
+        transaction_plan_id: 'txplan-hidden-swap-001',
+        semantic_request: {
+          control_path: 'spot.swap',
+          asset: 'USDC',
+          protocol_system: 'onchain-actions',
+          network: 'arbitrum',
+          quantity: {
+            kind: 'exact',
+            value: '1000000',
+          },
+        },
+        payload_builder_output: {
+          transaction_payload_ref: 'txpayload-hidden-swap-001',
+          required_control_path: 'spot.swap',
+          network: 'arbitrum',
+        },
+        compact_plan_summary: {
+          control_path: 'spot.swap',
+          asset: 'USDC',
+          amount: '1000000',
+          summary: 'swap USDC to WETH through Onchain Actions',
+        },
+      },
+    },
+  };
+}
+
+describe('createHiddenOcaSpotSwapExecutor', () => {
+  it('prepares a structured OCA swap and hands the spot.swap plan to Shared Ember', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const jsonRpcRequest =
+          typeof request === 'object' && request !== null
+            ? (request as { method?: string; params?: Record<string, unknown> })
+            : {};
+
+        if (jsonRpcRequest.method === 'subagent.createTransaction.v1') {
+          return createCandidatePlanResponse();
+        }
+
+        if (jsonRpcRequest.method === 'subagent.requestExecution.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              committed_event_ids: ['evt-hidden-swap-execution-1'],
+              execution_result: {
+                phase: 'completed',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                execution: {
+                  execution_id: 'exec-hidden-swap-001',
+                  status: 'confirmed',
+                  transaction_hash: '0xswapconfirmed',
+                  successor_unit_ids: [],
+                },
+                compact_artifact: {
+                  control_path: 'spot.swap',
+                  asset: 'USDC',
+                  amount: '1000000',
+                  summary: 'swap USDC to WETH through Onchain Actions',
+                },
+              },
+            },
+          };
+        }
+
+        throw new Error(`unexpected method: ${String(jsonRpcRequest.method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+          slippageTolerance: '0.5',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'completed',
+      swapSummary: {
+        fromToken: 'USDC',
+        toToken: 'WETH',
+        displayFromAmount: '1',
+        displayToAmount: '0.0003',
+      },
+      transactionPlanId: 'txplan-hidden-swap-001',
+      requestId: 'req-hidden-swap-001',
+      transactionHash: '0xswapconfirmed',
+    });
+
+    expect(onchainActionsClient.createSwap).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000a1',
+      amount: '1000000',
+      amountType: 'exactIn',
+      fromTokenUid: {
+        chainId: '42161',
+        address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      },
+      toTokenUid: {
+        chainId: '42161',
+        address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+      },
+      slippageTolerance: '0.5',
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(1, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-create-hidden-oca-swap-transaction',
+      method: 'subagent.createTransaction.v1',
+      params: {
+        idempotency_key: 'idem-hidden-swap-001:create-transaction',
+        expected_revision: 3,
+        agent_id: 'agent-oca-executor',
+        rooted_wallet_context_id: 'rwc-user-spot-001',
+        request: {
+          control_path: 'spot.swap',
+          asset: 'USDC',
+          protocol_system: 'onchain-actions',
+          network: 'arbitrum',
+          quantity: {
+            kind: 'exact',
+            value: '1000000',
+          },
+        },
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(2, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+      method: 'subagent.requestExecution.v1',
+      params: {
+        idempotency_key: 'idem-hidden-swap-001:request-execution:1',
+        expected_revision: 4,
+        transaction_plan_id: 'txplan-hidden-swap-001',
+      },
+    });
+  });
+
+  it('returns structured reserved-capital conflict details without retrying automatically', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async (request: unknown) => {
+        const method =
+          typeof request === 'object' && request !== null
+            ? (request as { method?: string }).method
+            : null;
+
+        if (method === 'subagent.createTransaction.v1') {
+          return createCandidatePlanResponse();
+        }
+
+        if (method === 'subagent.requestExecution.v1') {
+          return {
+            jsonrpc: '2.0',
+            id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+            result: {
+              protocol_version: 'v1',
+              revision: 5,
+              committed_event_ids: ['evt-hidden-swap-conflict-1'],
+              execution_result: {
+                phase: 'blocked',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                request_result: {
+                  result: 'needs_release_or_transfer',
+                  request_id: 'req-hidden-swap-001',
+                  message: 'USDC is reserved for another agent.',
+                  active_delegation_id: null,
+                  reservation_id: 'res-ember-lending-001',
+                  blocking_reason_code: 'reserved_for_other_agent',
+                  next_action: 'confirm_or_retry',
+                },
+                portfolio_state: {},
+              },
+            },
+          };
+        }
+
+        throw new Error(`unexpected method: ${String(method)}`);
+      }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'conflict',
+      conflict: {
+        kind: 'reserved_for_other_agent',
+        blockingReasonCode: 'reserved_for_other_agent',
+        reservationId: 'res-ember-lending-001',
+        retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+      },
+    });
+  });
+
+  it('passes exact conflict retry handling through to Shared Ember execution readiness', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'confirmed',
+                transaction_hash: '0xswapconfirmed',
+                successor_unit_ids: [],
+              },
+              compact_artifact: {
+                control_path: 'spot.swap',
+                asset: 'USDC',
+                amount: '1000000',
+                summary: 'swap USDC to WETH through Onchain Actions',
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await executor.executeSpotSwap({
+      threadId: 'thread-1',
+      currentRevision: 3,
+      input: {
+        idempotencyKey: 'idem-hidden-swap-001',
+        rootedWalletContextId: 'rwc-user-spot-001',
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '1000000',
+        amountType: 'exactIn',
+        fromChain: 'arbitrum',
+        toChain: 'arbitrum',
+        fromToken: 'USDC',
+        toToken: 'WETH',
+        reservationConflictHandling: {
+          kind: 'unassigned_only',
+        },
+      },
+    });
+
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'subagent.requestExecution.v1',
+        params: expect.objectContaining({
+          reservation_conflict_handling: {
+            kind: 'unassigned_only',
+          },
+        }),
+      }),
+    );
+  });
+
+  it('signs and submits an execution-signing package with the hidden executor wallet', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'ready_for_execution_signing',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution_preparation: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                agent_id: 'agent-oca-executor',
+                agent_wallet: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                network: 'arbitrum',
+                reservation_id: 'res-hidden-swap-001',
+                required_control_path: 'spot.swap',
+                active_delegation_id: 'del-hidden-swap-001',
+                root_delegation_id: 'root-delegation-001',
+                prepared_at: '2026-04-10T12:00:00.000Z',
+                metadata: {
+                  planned_transaction_payload_ref: 'txpayload-hidden-swap-001',
+                },
+              },
+              execution_signing_package: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                active_delegation_id: 'del-hidden-swap-001',
+                delegation_artifact_ref: 'metamask-delegation:active',
+                root_delegation_artifact_ref: 'metamask-delegation:root',
+                canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+              },
+              compact_artifact: {
+                control_path: 'spot.swap',
+                asset: 'USDC',
+                amount: '1000000',
+                summary: 'swap USDC to WETH through Onchain Actions',
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-submit-hidden-oca-swap-transaction',
+          result: {
+            protocol_version: 'v1',
+            revision: 6,
+            committed_event_ids: ['evt-hidden-swap-submitted-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'submitted',
+                transaction_hash: '0xsubmittedswap',
+                successor_unit_ids: [],
+              },
+              compact_artifact: {
+                control_path: 'spot.swap',
+                asset: 'USDC',
+                amount: '1000000',
+                summary: 'swap USDC to WETH through Onchain Actions',
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      runtimeSigning,
+      runtimeSignerRef: 'oca-executor-wallet',
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      resolvePreparedUnsignedTransactionHex: vi.fn(async () => TEST_UNSIGNED_TRANSACTION_HEX),
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'submitted',
+      transactionHash: '0xsubmittedswap',
+    });
+
+    expect(runtimeSigning.signPayload).toHaveBeenCalledWith({
+      signerRef: 'oca-executor-wallet',
+      expectedAddress: '0x00000000000000000000000000000000000000e1',
+      payloadKind: 'transaction',
+      payload: {
+        chain: 'evm',
+        unsignedTransactionHex: TEST_UNSIGNED_TRANSACTION_HEX,
+      },
+    });
+    expect(protocolHost.handleJsonRpc).toHaveBeenNthCalledWith(3, {
+      jsonrpc: '2.0',
+      id: 'shared-ember-thread-1-submit-hidden-oca-swap-transaction',
+      method: 'subagent.submitSignedTransaction.v1',
+      params: {
+        idempotency_key:
+          'idem-hidden-swap-001:submit-signed-transaction:req-hidden-swap-001:execprep-hidden-swap-001',
+        expected_revision: 5,
+        transaction_plan_id: 'txplan-hidden-swap-001',
+        signed_transaction: {
+          execution_preparation_id: 'execprep-hidden-swap-001',
+          transaction_plan_id: 'txplan-hidden-swap-001',
+          request_id: 'req-hidden-swap-001',
+          active_delegation_id: 'del-hidden-swap-001',
+          canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+          signer_address: '0x00000000000000000000000000000000000000e1',
+          raw_transaction: expect.stringMatching(/^0x[0-9a-f]+$/),
+        },
+      },
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/hiddenOcaSwapExecutor.unit.test.ts
@@ -16,6 +16,8 @@ import {
 
 const TEST_UNSIGNED_TRANSACTION_HEX =
   '0x02e982a4b1018405f5e100843b9aca008252089400000000000000000000000000000000000000c18080c0' as const;
+const TEST_PREPARED_TRANSACTION_PAYLOAD_REF = 'txpayload-hidden-oca-swap-1f18f9b7adf1df1d';
+const TEST_CANONICAL_UNSIGNED_PAYLOAD_REF = `unsigned-${TEST_PREPARED_TRANSACTION_PAYLOAD_REF}`;
 const TEST_TRANSACTION_SIGNATURE =
   '0x464a27f0b9166323a2d686a053ac34e74c318b59854dcc7de4221837437214870c365e2d8e5060f092656d3bd06f78c324ed296792df9c60f76c68bca5551eb601';
 const TEST_ROOT_DELEGATION = createSignedDelegation({
@@ -173,7 +175,7 @@ function createCandidatePlanResponse() {
           },
         },
         payload_builder_output: {
-          transaction_payload_ref: 'txpayload-hidden-swap-001',
+          transaction_payload_ref: TEST_PREPARED_TRANSACTION_PAYLOAD_REF,
           required_control_path: 'spot.swap',
           network: 'arbitrum',
         },
@@ -189,7 +191,7 @@ function createCandidatePlanResponse() {
 }
 
 describe('createHiddenOcaSpotSwapExecutor', () => {
-  it('prepares a structured OCA swap and hands the spot.swap plan to Shared Ember', async () => {
+  it('prepares a structured OCA swap and hands the prepared payload ref to Shared Ember', async () => {
     const onchainActionsClient = {
       listTokens: vi.fn(async () => createTokens()),
       createSwap: vi.fn(async () => createSwapResponse()),
@@ -307,6 +309,11 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
             kind: 'exact',
             value: '1000000',
           },
+        },
+        payload_builder_output: {
+          transaction_payload_ref: TEST_PREPARED_TRANSACTION_PAYLOAD_REF,
+          required_control_path: 'spot.swap',
+          network: 'arbitrum',
         },
       },
     });
@@ -460,6 +467,219 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
 
     expect(onchainActionsClient.listTokens).not.toHaveBeenCalled();
     expect(onchainActionsClient.createSwap).not.toHaveBeenCalled();
+  });
+
+  it('returns a compact failed result when OCA token lookup fails', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => {
+        throw new Error('Onchain Actions token catalog is unavailable.');
+      }),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason: 'Onchain Actions token catalog is unavailable.',
+      transactionPlanId: null,
+      requestId: null,
+    });
+
+    expect(onchainActionsClient.createSwap).not.toHaveBeenCalled();
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalled();
+  });
+
+  it('returns a compact failed result for ambiguous token symbols', async () => {
+    const ambiguousUsdc = {
+      ...createTokens()[0]!,
+      tokenUid: {
+        chainId: '42161',
+        address: '0x1111111111111111111111111111111111111111',
+      },
+      isVetted: true,
+    };
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => [createTokens()[0]!, ambiguousUsdc, createTokens()[1]!]),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason:
+        'Ambiguous Onchain Actions token resolution for USDC on chain 42161; use an exact token address.',
+    });
+
+    expect(onchainActionsClient.createSwap).not.toHaveBeenCalled();
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalled();
+  });
+
+  it('prefers the single vetted token when a symbol matches unvetted catalog entries', async () => {
+    const unvettedUsdc = {
+      ...createTokens()[0]!,
+      tokenUid: {
+        chainId: '42161',
+        address: '0x2222222222222222222222222222222222222222',
+      },
+      isVetted: false,
+    };
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => [unvettedUsdc, ...createTokens()]),
+      createSwap: vi.fn(async () => createSwapResponse()),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'completed',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution: {
+                execution_id: 'exec-hidden-swap-001',
+                status: 'confirmed',
+                transaction_hash: '0xswapconfirmed',
+                successor_unit_ids: [],
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await executor.executeSpotSwap({
+      threadId: 'thread-1',
+      currentRevision: 3,
+      input: {
+        rootedWalletContextId: 'rwc-user-spot-001',
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '1000000',
+        amountType: 'exactIn',
+        fromChain: 'arbitrum',
+        toChain: 'arbitrum',
+        fromToken: 'USDC',
+        toToken: 'WETH',
+      },
+    });
+
+    expect(onchainActionsClient.createSwap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromTokenUid: {
+          chainId: '42161',
+          address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+        },
+      }),
+    );
+  });
+
+  it('returns a compact failed result when OCA prepares a transaction for the wrong chain', async () => {
+    const onchainActionsClient = {
+      listTokens: vi.fn(async () => createTokens()),
+      createSwap: vi.fn(async () => ({
+        ...createSwapResponse(),
+        transactions: [
+          {
+            ...createSwapResponse().transactions[0]!,
+            chainId: '1',
+          },
+        ],
+      })),
+    };
+    const protocolHost = {
+      handleJsonRpc: vi.fn(),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason:
+        'Onchain Actions swap response chain id "1" did not match requested chain id "42161".',
+    });
+
+    expect(protocolHost.handleJsonRpc).not.toHaveBeenCalled();
   });
 
   it('returns structured reserved-capital conflict details without retrying automatically', async () => {
@@ -672,13 +892,14 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
                 request_id: 'req-hidden-swap-001',
                 agent_id: 'agent-oca-executor',
                 agent_wallet: '0x00000000000000000000000000000000000000e1',
+                network: 'arbitrum',
               },
               execution_signing_package: {
                 execution_preparation_id: 'execprep-hidden-swap-001',
                 transaction_plan_id: 'txplan-hidden-swap-001',
                 request_id: 'req-hidden-swap-001',
                 active_delegation_id: 'del-hidden-swap-001',
-                canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+                canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
               },
             },
           },
@@ -854,7 +1075,7 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
                 root_delegation_id: 'root-delegation-001',
                 prepared_at: '2026-04-10T12:00:00.000Z',
                 metadata: {
-                  planned_transaction_payload_ref: 'txpayload-hidden-swap-001',
+                  planned_transaction_payload_ref: TEST_PREPARED_TRANSACTION_PAYLOAD_REF,
                 },
               },
               execution_signing_package: {
@@ -864,7 +1085,7 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
                 active_delegation_id: 'del-hidden-swap-001',
                 delegation_artifact_ref: 'metamask-delegation:active',
                 root_delegation_artifact_ref: 'metamask-delegation:root',
-                canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+                canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
               },
               compact_artifact: {
                 control_path: 'spot.swap',
@@ -960,12 +1181,107 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
           transaction_plan_id: 'txplan-hidden-swap-001',
           request_id: 'req-hidden-swap-001',
           active_delegation_id: 'del-hidden-swap-001',
-          canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+          canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
           signer_address: '0x00000000000000000000000000000000000000e1',
           raw_transaction: expect.stringMatching(/^0x[0-9a-f]+$/),
         },
       },
     });
+  });
+
+  it('fails signing when Shared Ember prepares the OCA payload for a different network', async () => {
+    const runtimeSigning = createRuntimeSigningStub(
+      vi.fn(async () => ({
+        confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+        signedPayload: {
+          signature: TEST_TRANSACTION_SIGNATURE,
+          recoveryId: 1,
+        },
+      })),
+    );
+    const resolvePreparedUnsignedTransactionHex = vi.fn(async () => TEST_UNSIGNED_TRANSACTION_HEX);
+    const signPreparedTransaction = vi.fn(async () => ({
+      confirmedAddress: '0x00000000000000000000000000000000000000e1' as const,
+      rawTransaction: '0xfeed' as const,
+    }));
+    const protocolHost = {
+      handleJsonRpc: vi
+        .fn()
+        .mockResolvedValueOnce(createCandidatePlanResponse())
+        .mockResolvedValueOnce({
+          jsonrpc: '2.0',
+          id: 'shared-ember-thread-1-request-hidden-oca-swap-execution',
+          result: {
+            protocol_version: 'v1',
+            revision: 5,
+            committed_event_ids: ['evt-hidden-swap-execution-1'],
+            execution_result: {
+              phase: 'ready_for_execution_signing',
+              transaction_plan_id: 'txplan-hidden-swap-001',
+              request_id: 'req-hidden-swap-001',
+              execution_preparation: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                agent_id: 'agent-oca-executor',
+                agent_wallet: '0x00000000000000000000000000000000000000e1',
+                root_user_wallet: '0x00000000000000000000000000000000000000a1',
+                network: 'mainnet',
+                reservation_id: 'res-hidden-swap-001',
+                required_control_path: 'spot.swap',
+                active_delegation_id: 'del-hidden-swap-001',
+                root_delegation_id: 'root-delegation-001',
+                prepared_at: '2026-04-10T12:00:00.000Z',
+              },
+              execution_signing_package: {
+                execution_preparation_id: 'execprep-hidden-swap-001',
+                transaction_plan_id: 'txplan-hidden-swap-001',
+                request_id: 'req-hidden-swap-001',
+                active_delegation_id: 'del-hidden-swap-001',
+                canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
+              },
+            },
+          },
+        }),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+    const executor = createHiddenOcaSpotSwapExecutor({
+      protocolHost,
+      onchainActionsClient: {
+        listTokens: vi.fn(async () => createTokens()),
+        createSwap: vi.fn(async () => createSwapResponse()),
+      },
+      runtimeSigning,
+      executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+      resolvePreparedUnsignedTransactionHex,
+      signPreparedTransaction,
+    });
+
+    await expect(
+      executor.executeSpotSwap({
+        threadId: 'thread-1',
+        currentRevision: 3,
+        input: {
+          idempotencyKey: 'idem-hidden-swap-001',
+          rootedWalletContextId: 'rwc-user-spot-001',
+          walletAddress: '0x00000000000000000000000000000000000000a1',
+          amount: '1000000',
+          amountType: 'exactIn',
+          fromChain: 'arbitrum',
+          toChain: 'arbitrum',
+          fromToken: 'USDC',
+          toToken: 'WETH',
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failureReason:
+        'Shared Ember prepared hidden swap execution for network "mainnet", but the OCA payload was prepared for network "arbitrum".',
+    });
+
+    expect(resolvePreparedUnsignedTransactionHex).not.toHaveBeenCalled();
+    expect(signPreparedTransaction).not.toHaveBeenCalled();
   });
 
   it('derives the delegated unsigned transaction from OCA swap transactions by default', async () => {
@@ -1034,7 +1350,7 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
                 active_delegation_id: 'del-hidden-swap-001',
                 delegation_artifact_ref: TEST_ACTIVE_DELEGATION_ARTIFACT_REF,
                 root_delegation_artifact_ref: TEST_ROOT_DELEGATION_ARTIFACT_REF,
-                canonical_unsigned_payload_ref: 'unsigned-hidden-swap-001',
+                canonical_unsigned_payload_ref: TEST_CANONICAL_UNSIGNED_PAYLOAD_REF,
               },
             },
           },
@@ -1166,5 +1482,41 @@ describe('createHiddenOcaSpotSwapExecutor', () => {
         },
       }),
     ).rejects.toThrow('Onchain Actions swap response included malformed transaction entries.');
+  });
+
+  it('paginates the OCA token catalog before resolving PM-facing token names', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const page = new URL(String(url)).searchParams.get('page');
+      const tokenPage = page === '2' ? [createTokens()[1]] : [createTokens()[0]];
+
+      return new Response(
+        JSON.stringify({
+          tokens: tokenPage,
+          currentPage: page === '2' ? 2 : 1,
+          totalPages: 2,
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
+      );
+    });
+    const client = createHiddenOcaOnchainActionsClient({
+      baseUrl: 'https://onchain-actions.test',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    await expect(client.listTokens({ chainIds: ['42161'] })).resolves.toHaveLength(2);
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'https://onchain-actions.test/tokens?chainIds=42161&page=1',
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://onchain-actions.test/tokens?chainIds=42161&page=2',
+    );
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -5,13 +5,14 @@ import {
   createPortfolioManagerDomain,
   type PortfolioManagerLifecycleState,
 } from './sharedEmberAdapter.js';
+import { createPortfolioManagerDiagnosticTool } from './diagnosticTool.js';
+import { createHiddenOcaSpotSwapExecutor } from './hiddenOcaSwapExecutor.js';
 import {
   createPortfolioManagerSharedEmberHttpHost,
   resolvePortfolioManagerSharedEmberBaseUrl,
 } from './sharedEmberHttpHost.js';
-import { createPortfolioManagerDiagnosticTool } from './diagnosticTool.js';
-import { createPortfolioManagerWalletAccountingTool } from './walletAccountingTool.js';
 import { PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID } from './sharedEmberOnboardingState.js';
+import { createPortfolioManagerWalletAccountingTool } from './walletAccountingTool.js';
 
 const DEFAULT_PORTFOLIO_MANAGER_MODEL = 'openai/gpt-5.4';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
@@ -27,6 +28,12 @@ export type PortfolioManagerGatewayEnv = NodeJS.ProcessEnv & {
   PORTFOLIO_MANAGER_OWS_WALLET_NAME?: string;
   PORTFOLIO_MANAGER_OWS_PASSPHRASE?: string;
   PORTFOLIO_MANAGER_OWS_VAULT_PATH?: string;
+  PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME?: string;
+  PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_PASSPHRASE?: string;
+  PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH?: string;
+  ONCHAIN_ACTIONS_API_URL?: string;
+  ARBITRUM_RPC_URL?: string;
+  ETHEREUM_RPC_URL?: string;
 };
 
 type PortfolioManagerAgentRuntimeOptions = CreateAgentRuntimeOptions<PortfolioManagerLifecycleState>;
@@ -47,6 +54,8 @@ type CreatePortfolioManagerAgentConfigOptions = {
   controllerSignerAddress?: `0x${string}`;
   runtimeSigning?: AgentRuntimeSigningService;
   runtimeSignerRef?: string;
+  hiddenOcaExecutorWalletAddress?: `0x${string}`;
+  hiddenOcaExecutorRuntimeSignerRef?: string;
 };
 
 function requireEnvValue(
@@ -129,6 +138,24 @@ export function createPortfolioManagerAgentConfig(
       ...(options.controllerSignerAddress
         ? {
             controllerSignerAddress: options.controllerSignerAddress,
+          }
+        : {}),
+      ...(protocolHost && options.runtimeSigning
+        ? {
+            hiddenOcaSpotSwapExecutor: createHiddenOcaSpotSwapExecutor({
+              protocolHost,
+              env,
+              runtimeSigning: options.runtimeSigning,
+              ...(options.hiddenOcaExecutorRuntimeSignerRef
+                ? { runtimeSignerRef: options.hiddenOcaExecutorRuntimeSignerRef }
+                : {}),
+              ...(options.hiddenOcaExecutorWalletAddress
+                ? { executorWalletAddress: options.hiddenOcaExecutorWalletAddress }
+                : {}),
+              ...(env.ONCHAIN_ACTIONS_API_URL
+                ? { onchainActionsBaseUrl: env.ONCHAIN_ACTIONS_API_URL }
+                : {}),
+            }),
           }
         : {}),
     }),

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -22,7 +22,7 @@ const PORTFOLIO_MANAGER_SYSTEM_PROMPT = [
   'Stay concise, keep onboarding state explicit, and use read_wallet_accounting_state whenever the user asks about wallet contents, reservations, or account status in Shared Ember.',
   'For spot swaps, when the user asks to use reserved or assigned units, or when their selected asset pool includes reserved units, dispatch with the appropriate capitalPool so the reserved-capital confirmation interrupt can run.',
   'Never suggest releasing or adjusting a reservation for a spot swap; confirmed reserved-capital execution belongs to the hidden executor path.',
-  'When a pending_spot_swap_conflict is present and the user replies yes, confirm, or proceed, Do not call dispatch_spot_swap again; answer the pending portfolio-manager-swap-reservation-conflict-request interrupt with outcome allow_reserved_for_other_agent.',
+  'When a pending_spot_swap_conflict is present and the user replies yes, confirm, or proceed, Do not call dispatch_spot_swap again; use confirm_spot_swap_reserved_capital with outcome allow_reserved_for_other_agent.',
 ].join(' ');
 
 export type PortfolioManagerGatewayEnv = NodeJS.ProcessEnv & {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -22,6 +22,7 @@ const PORTFOLIO_MANAGER_SYSTEM_PROMPT = [
   'Stay concise, keep onboarding state explicit, and use read_wallet_accounting_state whenever the user asks about wallet contents, reservations, or account status in Shared Ember.',
   'For spot swaps, when the user asks to use reserved or assigned units, or when their selected asset pool includes reserved units, dispatch with the appropriate capitalPool so the reserved-capital confirmation interrupt can run.',
   'Never suggest releasing or adjusting a reservation for a spot swap; confirmed reserved-capital execution belongs to the hidden executor path.',
+  'When a pending_spot_swap_conflict is present and the user replies yes, confirm, or proceed, Do not call dispatch_spot_swap again; answer the pending portfolio-manager-swap-reservation-conflict-request interrupt with outcome allow_reserved_for_other_agent.',
 ].join(' ');
 
 export type PortfolioManagerGatewayEnv = NodeJS.ProcessEnv & {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -3,6 +3,7 @@ import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 
 import {
   createPortfolioManagerDomain,
+  refreshPortfolioManagerRedelegationWork,
   type PortfolioManagerLifecycleState,
 } from './sharedEmberAdapter.js';
 import { createPortfolioManagerDiagnosticTool } from './diagnosticTool.js';
@@ -152,6 +153,23 @@ export function createPortfolioManagerAgentConfig(
               ...(options.hiddenOcaExecutorWalletAddress
                 ? { executorWalletAddress: options.hiddenOcaExecutorWalletAddress }
                 : {}),
+              requestRedelegationRefresh: async ({ threadId, transactionPlanId, requestId }) => {
+                const result = await refreshPortfolioManagerRedelegationWork({
+                  protocolHost,
+                  threadId,
+                  agentId: 'portfolio-manager',
+                  runtimeSigning: options.runtimeSigning,
+                  runtimeSignerRef: options.runtimeSignerRef,
+                  controllerWalletAddress: options.controllerWalletAddress,
+                  controllerSignerAddress: options.controllerSignerAddress,
+                  expectedRequestId: requestId,
+                  expectedTransactionPlanId: transactionPlanId,
+                });
+
+                if (result.status !== 'completed') {
+                  throw new Error(result.statusMessage);
+                }
+              },
               ...(env.ONCHAIN_ACTIONS_API_URL
                 ? { onchainActionsBaseUrl: env.ONCHAIN_ACTIONS_API_URL }
                 : {}),

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -17,8 +17,12 @@ import { createPortfolioManagerWalletAccountingTool } from './walletAccountingTo
 
 const DEFAULT_PORTFOLIO_MANAGER_MODEL = 'openai/gpt-5.4';
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
-const PORTFOLIO_MANAGER_SYSTEM_PROMPT =
-  'You are the portfolio manager orchestrator running on agent-runtime. Stay concise, keep onboarding state explicit, and use read_wallet_accounting_state whenever the user asks about wallet contents, reservations, or account status in Shared Ember.';
+const PORTFOLIO_MANAGER_SYSTEM_PROMPT = [
+  'You are the portfolio manager orchestrator running on agent-runtime.',
+  'Stay concise, keep onboarding state explicit, and use read_wallet_accounting_state whenever the user asks about wallet contents, reservations, or account status in Shared Ember.',
+  'For spot swaps, when the user asks to use reserved or assigned units, or when their selected asset pool includes reserved units, dispatch with the appropriate capitalPool so the reserved-capital confirmation interrupt can run.',
+  'Never suggest releasing or adjusting a reservation for a spot swap; confirmed reserved-capital execution belongs to the hidden executor path.',
+].join(' ');
 
 export type PortfolioManagerGatewayEnv = NodeJS.ProcessEnv & {
   OPENROUTER_API_KEY?: string;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.ts
@@ -22,6 +22,7 @@ const PORTFOLIO_MANAGER_SYSTEM_PROMPT = [
   'Stay concise, keep onboarding state explicit, and use read_wallet_accounting_state whenever the user asks about wallet contents, reservations, or account status in Shared Ember.',
   'For spot swaps, when the user asks to use reserved or assigned units, or when their selected asset pool includes reserved units, dispatch with the appropriate capitalPool so the reserved-capital confirmation interrupt can run.',
   'Never suggest releasing or adjusting a reservation for a spot swap; confirmed reserved-capital execution belongs to the hidden executor path.',
+  'After dispatch_spot_swap returns a reserved-capital confirmation, stop and ask the user to confirm; do not call confirm_spot_swap_reserved_capital in the same assistant turn that opened the confirmation.',
   'When a pending_spot_swap_conflict is present and the user replies yes, confirm, or proceed, Do not call dispatch_spot_swap again; use confirm_spot_swap_reserved_capital with outcome allow_reserved_for_other_agent.',
 ].join(' ');
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -46,6 +46,7 @@ describe('createPortfolioManagerAgentConfig', () => {
       maxTokens: 4_096,
     });
     expect(config.systemPrompt).toContain('portfolio manager orchestrator');
+    expect(config.systemPrompt).toContain('Never suggest releasing or adjusting a reservation');
     expect(config.databaseUrl).toBe('postgresql://portfolio:secret@db.internal:5432/pi_runtime');
     expect(config.tools).toEqual([]);
     expect(config.domain?.lifecycle).toMatchObject({
@@ -103,6 +104,9 @@ describe('createPortfolioManagerAgentConfig', () => {
     expect(spotSwapCommand?.description).toContain('fromChain');
     expect(spotSwapCommand?.description).toContain('toToken');
     expect(spotSwapCommand?.description).toContain('base-unit');
+    expect(spotSwapCommand?.description).toContain('capitalPool');
+    expect(spotSwapCommand?.description).toContain('reserved_or_assigned');
+    expect(spotSwapCommand?.description).toContain('Never suggest releasing or adjusting');
     expect(config.agentOptions?.getApiKey?.(undefined as never)).toBe('test-openrouter-key');
     expect(
       await config.domain?.systemContext?.({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -54,6 +54,9 @@ describe('createPortfolioManagerAgentConfig', () => {
           name: 'refresh_redelegation_work',
         },
         {
+          name: 'dispatch_spot_swap',
+        },
+        {
           name: 'complete_rooted_bootstrap_from_user_signing',
         },
       ],
@@ -64,6 +67,9 @@ describe('createPortfolioManagerAgentConfig', () => {
         },
         {
           type: 'portfolio-manager-delegation-signing-request',
+        },
+        {
+          type: 'portfolio-manager-swap-reservation-conflict-request',
         },
       ],
     });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -47,6 +47,7 @@ describe('createPortfolioManagerAgentConfig', () => {
     });
     expect(config.systemPrompt).toContain('portfolio manager orchestrator');
     expect(config.systemPrompt).toContain('Never suggest releasing or adjusting a reservation');
+    expect(config.systemPrompt).toContain('Do not call dispatch_spot_swap again');
     expect(config.databaseUrl).toBe('postgresql://portfolio:secret@db.internal:5432/pi_runtime');
     expect(config.tools).toEqual([]);
     expect(config.domain?.lifecycle).toMatchObject({
@@ -107,6 +108,12 @@ describe('createPortfolioManagerAgentConfig', () => {
     expect(spotSwapCommand?.description).toContain('capitalPool');
     expect(spotSwapCommand?.description).toContain('reserved_or_assigned');
     expect(spotSwapCommand?.description).toContain('Never suggest releasing or adjusting');
+    const swapConflictInterrupt = config.domain?.lifecycle.interrupts.find(
+      (interrupt) => interrupt.type === 'portfolio-manager-swap-reservation-conflict-request',
+    );
+    expect(swapConflictInterrupt?.description).toContain('yes');
+    expect(swapConflictInterrupt?.description).toContain('allow_reserved_for_other_agent');
+    expect(swapConflictInterrupt?.description).toContain('Do not repeat dispatch_spot_swap');
     expect(config.agentOptions?.getApiKey?.(undefined as never)).toBe('test-openrouter-key');
     expect(
       await config.domain?.systemContext?.({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -47,7 +47,7 @@ describe('createPortfolioManagerAgentConfig', () => {
     });
     expect(config.systemPrompt).toContain('portfolio manager orchestrator');
     expect(config.systemPrompt).toContain('Never suggest releasing or adjusting a reservation');
-    expect(config.systemPrompt).toContain('Do not call dispatch_spot_swap again');
+    expect(config.systemPrompt).toContain('confirm_spot_swap_reserved_capital');
     expect(config.databaseUrl).toBe('postgresql://portfolio:secret@db.internal:5432/pi_runtime');
     expect(config.tools).toEqual([]);
     expect(config.domain?.lifecycle).toMatchObject({
@@ -75,6 +75,9 @@ describe('createPortfolioManagerAgentConfig', () => {
         },
         {
           name: 'dispatch_spot_swap',
+        },
+        {
+          name: 'confirm_spot_swap_reserved_capital',
         },
         {
           name: 'complete_rooted_bootstrap_from_user_signing',
@@ -108,6 +111,13 @@ describe('createPortfolioManagerAgentConfig', () => {
     expect(spotSwapCommand?.description).toContain('capitalPool');
     expect(spotSwapCommand?.description).toContain('reserved_or_assigned');
     expect(spotSwapCommand?.description).toContain('Never suggest releasing or adjusting');
+    const spotSwapConfirmationCommand = config.domain?.lifecycle.commands.find(
+      (command) => command.name === 'confirm_spot_swap_reserved_capital',
+    );
+    expect(spotSwapConfirmationCommand?.description).toContain('allow_reserved_for_other_agent');
+    expect(spotSwapConfirmationCommand?.description).toContain('unassigned_only');
+    expect(spotSwapConfirmationCommand?.description).toContain('cancel');
+    expect(spotSwapConfirmationCommand?.description).toContain('yes');
     const swapConflictInterrupt = config.domain?.lifecycle.interrupts.find(
       (interrupt) => interrupt.type === 'portfolio-manager-swap-reservation-conflict-request',
     );

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -1,8 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createHiddenOcaSpotSwapExecutorMock } = vi.hoisted(() => ({
+  createHiddenOcaSpotSwapExecutorMock: vi.fn(() => ({
+    executeSpotSwap: vi.fn(),
+  })),
+}));
+
+vi.mock('./hiddenOcaSwapExecutor.js', () => ({
+  createHiddenOcaSpotSwapExecutor: createHiddenOcaSpotSwapExecutorMock,
+}));
 
 import { createPortfolioManagerAgentConfig } from './portfolioManagerFoundation.js';
 
 describe('createPortfolioManagerAgentConfig', () => {
+  beforeEach(() => {
+    createHiddenOcaSpotSwapExecutorMock.mockClear();
+    createHiddenOcaSpotSwapExecutorMock.mockImplementation(() => ({
+      executeSpotSwap: vi.fn(),
+    }));
+  });
+
   it('builds an OpenRouter-backed agent-runtime config for portfolio-manager startup', async () => {
     const config = createPortfolioManagerAgentConfig({
       OPENROUTER_API_KEY: 'test-openrouter-key',
@@ -115,6 +133,37 @@ describe('createPortfolioManagerAgentConfig', () => {
           name: 'read_wallet_accounting_state',
         }),
       ]),
+    );
+  });
+
+  it('wires the hidden OCA swap executor with PM-owned redelegation refresh', () => {
+    const runtimeSigning = {
+      readAddress: vi.fn<AgentRuntimeSigningService['readAddress']>(),
+      signPayload: vi.fn<AgentRuntimeSigningService['signPayload']>(),
+    };
+
+    createPortfolioManagerAgentConfig(
+      {
+        OPENROUTER_API_KEY: 'test-openrouter-key',
+        SHARED_EMBER_BASE_URL: 'http://127.0.0.1:56436',
+      },
+      {
+        runtimeSigning,
+        runtimeSignerRef: 'controller-wallet',
+        controllerWalletAddress: '0x00000000000000000000000000000000000000c2',
+        controllerSignerAddress: '0x00000000000000000000000000000000000000c1',
+        hiddenOcaExecutorWalletAddress: '0x00000000000000000000000000000000000000e1',
+        hiddenOcaExecutorRuntimeSignerRef: 'oca-executor-wallet',
+      },
+    );
+
+    expect(createHiddenOcaSpotSwapExecutorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeSigning,
+        runtimeSignerRef: 'oca-executor-wallet',
+        executorWalletAddress: '0x00000000000000000000000000000000000000e1',
+        requestRedelegationRefresh: expect.any(Function),
+      }),
     );
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -47,6 +47,9 @@ describe('createPortfolioManagerAgentConfig', () => {
     });
     expect(config.systemPrompt).toContain('portfolio manager orchestrator');
     expect(config.systemPrompt).toContain('Never suggest releasing or adjusting a reservation');
+    expect(config.systemPrompt).toContain(
+      'do not call confirm_spot_swap_reserved_capital in the same assistant turn',
+    );
     expect(config.systemPrompt).toContain('confirm_spot_swap_reserved_capital');
     expect(config.databaseUrl).toBe('postgresql://portfolio:secret@db.internal:5432/pi_runtime');
     expect(config.tools).toEqual([]);
@@ -111,6 +114,7 @@ describe('createPortfolioManagerAgentConfig', () => {
     expect(spotSwapCommand?.description).toContain('capitalPool');
     expect(spotSwapCommand?.description).toContain('reserved_or_assigned');
     expect(spotSwapCommand?.description).toContain('Never suggest releasing or adjusting');
+    expect(spotSwapCommand?.description).toContain('stop the current assistant turn');
     const spotSwapConfirmationCommand = config.domain?.lifecycle.commands.find(
       (command) => command.name === 'confirm_spot_swap_reserved_capital',
     );

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/portfolioManagerFoundation.unit.test.ts
@@ -94,6 +94,15 @@ describe('createPortfolioManagerAgentConfig', () => {
     expect(config.agentOptions?.initialState).toMatchObject({
       thinkingLevel: 'low',
     });
+    const spotSwapCommand = config.domain?.lifecycle.commands.find(
+      (command) => command.name === 'dispatch_spot_swap',
+    );
+    expect(spotSwapCommand?.description).toContain('inputJson');
+    expect(spotSwapCommand?.description).toContain('walletAddress');
+    expect(spotSwapCommand?.description).toContain('amountType');
+    expect(spotSwapCommand?.description).toContain('fromChain');
+    expect(spotSwapCommand?.description).toContain('toToken');
+    expect(spotSwapCommand?.description).toContain('base-unit');
     expect(config.agentOptions?.getApiKey?.(undefined as never)).toBe('test-openrouter-key');
     expect(
       await config.domain?.systemContext?.({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/runtimePrep.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/runtimePrep.unit.test.ts
@@ -81,4 +81,57 @@ describe('resolveManagedSharedEmberBootstrap', () => {
     );
     expect(bootstrap.plannerAgentIds).toBe('ember-lending');
   });
+
+  it('seeds submission bindings for multiple managed agents', async () => {
+    const resolveReferenceBootstrap = vi
+      .fn()
+      .mockImplementation(async (env?: NodeJS.ProcessEnv) => ({
+        plannerAgentIds: env?.SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS ?? null,
+      }));
+    const createManagedOnboardingIssuers = vi.fn(
+      async ({ managedAgentId }: { managedAgentId: string }) => ({
+        [managedAgentId]: { issueDelegation: vi.fn() },
+      }),
+    );
+    const createSubagentRuntimes = vi.fn(
+      async ({ managedAgentId }: { managedAgentId: string }) => ({
+        [managedAgentId]: {
+          submissionBackend: {
+            submitSignedTransaction: vi.fn(),
+          },
+        },
+      }),
+    );
+
+    const bootstrap = await resolveManagedSharedEmberBootstrap(
+      {
+        specRoot: '/tmp/spec-root',
+        vibekitRoot: '/tmp/vibekit-root',
+        managedAgentIds: ['ember-lending', 'agent-oca-executor'],
+      },
+      {
+        resolveReferenceBootstrap,
+        createManagedOnboardingIssuers,
+        createSubagentRuntimes,
+      },
+    );
+
+    expect(resolveReferenceBootstrap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SHARED_EMBER_ONCHAIN_ACTIONS_PLANNER_AGENT_IDS:
+          'ember-lending,agent-oca-executor',
+      }),
+    );
+    expect(createManagedOnboardingIssuers).toHaveBeenCalledTimes(2);
+    expect(createSubagentRuntimes).toHaveBeenCalledTimes(2);
+    expect(bootstrap.plannerAgentIds).toBe('ember-lending,agent-oca-executor');
+    expect(bootstrap.subagentRuntimes).toMatchObject({
+      'ember-lending': expect.objectContaining({
+        submissionBackend: expect.any(Object),
+      }),
+      'agent-oca-executor': expect.objectContaining({
+        submissionBackend: expect.any(Object),
+      }),
+    });
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
@@ -9,10 +9,22 @@ type EnsurePortfolioManagerServiceIdentityInput = {
   now?: () => Date;
 };
 
+type EnsureHiddenOcaExecutorServiceIdentityInput = {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  readExecutorWalletAddress: () => Promise<`0x${string}`>;
+  now?: () => Date;
+};
+
+type EnsurePortfolioManagerServiceIdentitiesInput = EnsurePortfolioManagerServiceIdentityInput & {
+  readExecutorWalletAddress?: () => Promise<`0x${string}`>;
+};
+
+type AgentServiceIdentityRole = 'orchestrator' | 'subagent';
+
 type AgentServiceIdentity = {
   identity_ref: string;
   agent_id: string;
-  role: 'orchestrator';
+  role: AgentServiceIdentityRole;
   wallet_address: `0x${string}`;
   wallet_source: string;
   capability_metadata: Record<string, unknown>;
@@ -20,14 +32,62 @@ type AgentServiceIdentity = {
   registered_at: string;
 };
 
+type EnsureServiceIdentityResult = {
+  revision: number | null;
+  wroteIdentity: boolean;
+  identity: AgentServiceIdentity;
+};
+
+type DeferredHiddenWorkerIdentity = {
+  status: 'deferred';
+  reason: string;
+};
+
+type AgentServiceIdentitySpec = {
+  agentId: string;
+  role: AgentServiceIdentityRole;
+  walletSource: string;
+  capabilityMetadata: Record<string, unknown>;
+  unconfirmedIdentityError: string;
+};
+
+export const HIDDEN_OCA_EXECUTOR_AGENT_ID = 'agent-oca-executor';
+export const HIDDEN_OCA_EXECUTOR_OWNER_AGENT_ID = 'agent-portfolio-manager';
+export const HIDDEN_OCA_EXECUTOR_CONTROL_PATH = 'spot.swap';
+
 const PORTFOLIO_MANAGER_SERVICE_ROLE = 'orchestrator';
 const PORTFOLIO_MANAGER_WALLET_SOURCE = 'ember_local_write';
 const PORTFOLIO_MANAGER_CAPABILITY_METADATA = {
   onboarding: true,
   root_registration: true,
 };
+const HIDDEN_OCA_EXECUTOR_SERVICE_ROLE = 'subagent';
+const HIDDEN_OCA_EXECUTOR_WALLET_SOURCE = 'ember_local_write';
+const HIDDEN_OCA_EXECUTOR_CAPABILITY_METADATA = {
+  visibility: 'internal',
+  owner_agent_id: HIDDEN_OCA_EXECUTOR_OWNER_AGENT_ID,
+  worker_kind: 'execution',
+  execution_surface: 'onchain_actions',
+  control_paths: [HIDDEN_OCA_EXECUTOR_CONTROL_PATH],
+};
 const UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR =
   'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.';
+const UNCONFIRMED_HIDDEN_OCA_EXECUTOR_IDENTITY_ERROR =
+  'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected hidden Onchain Actions executor identity.';
+const PORTFOLIO_MANAGER_IDENTITY_SPEC: AgentServiceIdentitySpec = {
+  agentId: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
+  role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+  walletSource: PORTFOLIO_MANAGER_WALLET_SOURCE,
+  capabilityMetadata: PORTFOLIO_MANAGER_CAPABILITY_METADATA,
+  unconfirmedIdentityError: UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR,
+};
+const HIDDEN_OCA_EXECUTOR_IDENTITY_SPEC: AgentServiceIdentitySpec = {
+  agentId: HIDDEN_OCA_EXECUTOR_AGENT_ID,
+  role: HIDDEN_OCA_EXECUTOR_SERVICE_ROLE,
+  walletSource: HIDDEN_OCA_EXECUTOR_WALLET_SOURCE,
+  capabilityMetadata: HIDDEN_OCA_EXECUTOR_CAPABILITY_METADATA,
+  unconfirmedIdentityError: UNCONFIRMED_HIDDEN_OCA_EXECUTOR_IDENTITY_ERROR,
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -46,7 +106,10 @@ function readInt(value: unknown): number | null {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
-function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
+function readAgentServiceIdentity(
+  value: unknown,
+  spec: Pick<AgentServiceIdentitySpec, 'agentId' | 'role'>,
+): AgentServiceIdentity | null {
   if (!isRecord(value)) {
     return null;
   }
@@ -73,18 +136,18 @@ function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
     return null;
   }
 
-  if (agentId !== PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID) {
+  if (agentId !== spec.agentId) {
     return null;
   }
 
-  if (readString(value['role']) !== PORTFOLIO_MANAGER_SERVICE_ROLE) {
+  if (readString(value['role']) !== spec.role) {
     return null;
   }
 
   return {
     identity_ref: identityRef,
     agent_id: agentId,
-    role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+    role: spec.role,
     wallet_address: walletAddress,
     wallet_source: walletSource,
     capability_metadata: capabilityMetadata,
@@ -95,6 +158,7 @@ function readAgentServiceIdentity(value: unknown): AgentServiceIdentity | null {
 
 async function readCurrentIdentity(input: {
   protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  spec: AgentServiceIdentitySpec;
 }): Promise<{
   revision: number;
   identity: AgentServiceIdentity | null;
@@ -104,15 +168,15 @@ async function readCurrentIdentity(input: {
     id: 'rpc-agent-service-identity-read',
     method: 'orchestrator.readAgentServiceIdentity.v1',
     params: {
-      agent_id: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
-      role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+      agent_id: input.spec.agentId,
+      role: input.spec.role,
     },
   });
   const result = isRecord(response) && isRecord(response['result']) ? response['result'] : null;
 
   return {
     revision: readInt(result?.['revision']) ?? 0,
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null, input.spec),
   };
 }
 
@@ -120,6 +184,7 @@ async function writeIdentity(input: {
   protocolHost: PortfolioManagerSharedEmberProtocolHost;
   expectedRevision: number;
   identity: AgentServiceIdentity;
+  spec: AgentServiceIdentitySpec;
 }): Promise<{
   revision: number | null;
   identity: AgentServiceIdentity | null;
@@ -138,35 +203,36 @@ async function writeIdentity(input: {
 
   return {
     revision: readInt(result?.['revision']),
-    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null),
+    identity: readAgentServiceIdentity(result?.['agent_service_identity'] ?? null, input.spec),
   };
 }
 
 function requireConfirmedIdentity(input: {
   expectedIdentity: Pick<AgentServiceIdentity, 'agent_id' | 'role' | 'wallet_address'>;
   identity: AgentServiceIdentity | null;
+  unconfirmedIdentityError: string;
 }): AgentServiceIdentity {
   if (
     input.identity?.agent_id !== input.expectedIdentity.agent_id ||
     input.identity?.role !== input.expectedIdentity.role ||
     input.identity?.wallet_address !== input.expectedIdentity.wallet_address
   ) {
-    throw new Error(UNCONFIRMED_ORCHESTRATOR_IDENTITY_ERROR);
+    throw new Error(input.unconfirmedIdentityError);
   }
 
   return input.identity;
 }
 
-export async function ensurePortfolioManagerServiceIdentity(
-  input: EnsurePortfolioManagerServiceIdentityInput,
-): Promise<{
-  revision: number | null;
-  wroteIdentity: boolean;
-  identity: AgentServiceIdentity;
-}> {
-  const walletAddress = await input.readControllerWalletAddress();
+async function ensureAgentServiceIdentity(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  readWalletAddress: () => Promise<`0x${string}`>;
+  now?: () => Date;
+  spec: AgentServiceIdentitySpec;
+}): Promise<EnsureServiceIdentityResult> {
+  const walletAddress = await input.readWalletAddress();
   const current = await readCurrentIdentity({
     protocolHost: input.protocolHost,
+    spec: input.spec,
   });
 
   if (current.identity?.wallet_address === walletAddress) {
@@ -179,12 +245,12 @@ export async function ensurePortfolioManagerServiceIdentity(
 
   const registrationVersion = (current.identity?.registration_version ?? 0) + 1;
   const identity: AgentServiceIdentity = {
-    identity_ref: `agent-service-identity-${PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID}-${PORTFOLIO_MANAGER_SERVICE_ROLE}-${registrationVersion}`,
-    agent_id: PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
-    role: PORTFOLIO_MANAGER_SERVICE_ROLE,
+    identity_ref: `agent-service-identity-${input.spec.agentId}-${input.spec.role}-${registrationVersion}`,
+    agent_id: input.spec.agentId,
+    role: input.spec.role,
     wallet_address: walletAddress,
-    wallet_source: PORTFOLIO_MANAGER_WALLET_SOURCE,
-    capability_metadata: PORTFOLIO_MANAGER_CAPABILITY_METADATA,
+    wallet_source: input.spec.walletSource,
+    capability_metadata: input.spec.capabilityMetadata,
     registration_version: registrationVersion,
     registered_at: (input.now ?? (() => new Date()))().toISOString(),
   };
@@ -192,10 +258,12 @@ export async function ensurePortfolioManagerServiceIdentity(
     protocolHost: input.protocolHost,
     expectedRevision: current.revision,
     identity,
+    spec: input.spec,
   });
   const confirmedIdentity = requireConfirmedIdentity({
     expectedIdentity: identity,
     identity: written.identity,
+    unconfirmedIdentityError: input.spec.unconfirmedIdentityError,
   });
 
   return {
@@ -203,4 +271,60 @@ export async function ensurePortfolioManagerServiceIdentity(
     wroteIdentity: true,
     identity: confirmedIdentity,
   };
+}
+
+export async function ensurePortfolioManagerServiceIdentity(
+  input: EnsurePortfolioManagerServiceIdentityInput,
+): Promise<EnsureServiceIdentityResult> {
+  return ensureAgentServiceIdentity({
+    protocolHost: input.protocolHost,
+    readWalletAddress: input.readControllerWalletAddress,
+    now: input.now,
+    spec: PORTFOLIO_MANAGER_IDENTITY_SPEC,
+  });
+}
+
+export async function ensureHiddenOcaExecutorServiceIdentity(
+  input: EnsureHiddenOcaExecutorServiceIdentityInput,
+): Promise<EnsureServiceIdentityResult> {
+  return ensureAgentServiceIdentity({
+    protocolHost: input.protocolHost,
+    readWalletAddress: input.readExecutorWalletAddress,
+    now: input.now,
+    spec: HIDDEN_OCA_EXECUTOR_IDENTITY_SPEC,
+  });
+}
+
+export async function ensurePortfolioManagerServiceIdentities(
+  input: EnsurePortfolioManagerServiceIdentitiesInput,
+): Promise<{
+  orchestrator: EnsureServiceIdentityResult;
+  hiddenOcaExecutor: EnsureServiceIdentityResult | DeferredHiddenWorkerIdentity | null;
+}> {
+  const orchestrator = await ensurePortfolioManagerServiceIdentity(input);
+  if (!input.readExecutorWalletAddress) {
+    return {
+      orchestrator,
+      hiddenOcaExecutor: null,
+    };
+  }
+
+  try {
+    return {
+      orchestrator,
+      hiddenOcaExecutor: await ensureHiddenOcaExecutorServiceIdentity({
+        protocolHost: input.protocolHost,
+        readExecutorWalletAddress: input.readExecutorWalletAddress,
+        now: input.now,
+      }),
+    };
+  } catch (error) {
+    return {
+      orchestrator,
+      hiddenOcaExecutor: {
+        status: 'deferred',
+        reason: error instanceof Error ? error.message : 'Unknown hidden worker identity error.',
+      },
+    };
+  }
 }

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.ts
@@ -1,3 +1,5 @@
+import { isAddress, isAddressEqual } from 'viem';
+
 import {
   PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
   type PortfolioManagerSharedEmberProtocolHost,
@@ -99,11 +101,59 @@ function readString(value: unknown): string | null {
 
 function readHexAddress(value: unknown): `0x${string}` | null {
   const normalized = readString(value);
-  return normalized?.startsWith('0x') ? (normalized as `0x${string}`) : null;
+  return normalized && isAddress(normalized, { strict: false })
+    ? (normalized.toLowerCase() as `0x${string}`)
+    : null;
 }
 
 function readInt(value: unknown): number | null {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function metadataValueMatches(expected: unknown, actual: unknown): boolean {
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(actual) &&
+      expected.length === actual.length &&
+      expected.every((entry, index) => metadataValueMatches(entry, actual[index]))
+    );
+  }
+
+  if (isRecord(expected)) {
+    if (!isRecord(actual)) {
+      return false;
+    }
+
+    return Object.entries(expected).every(([key, value]) =>
+      metadataValueMatches(value, actual[key]),
+    );
+  }
+
+  return actual === expected;
+}
+
+function capabilityMetadataMatches(input: {
+  actual: Record<string, unknown>;
+  expected: Record<string, unknown>;
+}): boolean {
+  return Object.entries(input.expected).every(([key, value]) =>
+    metadataValueMatches(value, input.actual[key]),
+  );
+}
+
+function serviceIdentityMatchesSpec(input: {
+  identity: AgentServiceIdentity;
+  walletAddress: `0x${string}`;
+  spec: AgentServiceIdentitySpec;
+}): boolean {
+  return (
+    isAddressEqual(input.identity.wallet_address, input.walletAddress) &&
+    input.identity.wallet_source === input.spec.walletSource &&
+    capabilityMetadataMatches({
+      actual: input.identity.capability_metadata,
+      expected: input.spec.capabilityMetadata,
+    })
+  );
 }
 
 function readAgentServiceIdentity(
@@ -208,14 +258,19 @@ async function writeIdentity(input: {
 }
 
 function requireConfirmedIdentity(input: {
-  expectedIdentity: Pick<AgentServiceIdentity, 'agent_id' | 'role' | 'wallet_address'>;
+  expectedIdentity: AgentServiceIdentity;
   identity: AgentServiceIdentity | null;
+  spec: AgentServiceIdentitySpec;
   unconfirmedIdentityError: string;
 }): AgentServiceIdentity {
   if (
     input.identity?.agent_id !== input.expectedIdentity.agent_id ||
     input.identity?.role !== input.expectedIdentity.role ||
-    input.identity?.wallet_address !== input.expectedIdentity.wallet_address
+    !serviceIdentityMatchesSpec({
+      identity: input.identity,
+      walletAddress: input.expectedIdentity.wallet_address,
+      spec: input.spec,
+    })
   ) {
     throw new Error(input.unconfirmedIdentityError);
   }
@@ -235,7 +290,14 @@ async function ensureAgentServiceIdentity(input: {
     spec: input.spec,
   });
 
-  if (current.identity?.wallet_address === walletAddress) {
+  if (
+    current.identity &&
+    serviceIdentityMatchesSpec({
+      identity: current.identity,
+      walletAddress,
+      spec: input.spec,
+    })
+  ) {
     return {
       revision: current.revision,
       wroteIdentity: false,
@@ -263,6 +325,7 @@ async function ensureAgentServiceIdentity(input: {
   const confirmedIdentity = requireConfirmedIdentity({
     expectedIdentity: identity,
     identity: written.identity,
+    spec: input.spec,
     unconfirmedIdentityError: input.spec.unconfirmedIdentityError,
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { ensurePortfolioManagerServiceIdentity } from './serviceIdentityPreflight.js';
+import {
+  ensureHiddenOcaExecutorServiceIdentity,
+  ensurePortfolioManagerServiceIdentities,
+  ensurePortfolioManagerServiceIdentity,
+} from './serviceIdentityPreflight.js';
 
 describe('ensurePortfolioManagerServiceIdentity', () => {
   it('reuses the durable orchestrator identity when the OWS controller wallet already matches', async () => {
@@ -418,5 +422,217 @@ describe('ensurePortfolioManagerServiceIdentity', () => {
     ).rejects.toThrow(
       'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected orchestrator identity.',
     );
+  });
+});
+
+describe('ensureHiddenOcaExecutorServiceIdentity', () => {
+  it('registers the hidden Onchain Actions executor identity with internal worker metadata', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params).toMatchObject({
+          agent_id: 'agent-oca-executor',
+          role: 'subagent',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.['expected_revision']).toBe(9);
+        expect(jsonRpcRequest.params?.['agent_service_identity']).toMatchObject({
+          identity_ref: 'agent-service-identity-agent-oca-executor-subagent-1',
+          agent_id: 'agent-oca-executor',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000e1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            visibility: 'internal',
+            owner_agent_id: 'agent-portfolio-manager',
+            worker_kind: 'execution',
+            execution_surface: 'onchain_actions',
+            control_paths: ['spot.swap'],
+          },
+          registration_version: 1,
+          registered_at: '2026-04-10T12:00:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            committed_event_ids: ['evt-agent-service-identity-hidden-1'],
+            agent_service_identity: jsonRpcRequest.params?.['agent_service_identity'],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureHiddenOcaExecutorServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readExecutorWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000e1' as const,
+        ),
+        now: () => new Date('2026-04-10T12:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      revision: 10,
+      wroteIdentity: true,
+      identity: {
+        agent_id: 'agent-oca-executor',
+        role: 'subagent',
+        wallet_address: '0x00000000000000000000000000000000000000e1',
+      },
+    });
+  });
+
+  it('fails when Shared Ember does not confirm the written hidden executor identity', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 9,
+            agent_service_identity: null,
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 10,
+            agent_service_identity: {
+              ...(jsonRpcRequest.params?.['agent_service_identity'] as Record<string, unknown>),
+              agent_id: 'portfolio-manager',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureHiddenOcaExecutorServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readExecutorWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000e1' as const,
+        ),
+        now: () => new Date('2026-04-10T12:00:00.000Z'),
+      }),
+    ).rejects.toThrow(
+      'Portfolio-manager startup identity preflight failed because Shared Ember did not confirm the expected hidden Onchain Actions executor identity.',
+    );
+  });
+});
+
+describe('ensurePortfolioManagerServiceIdentities', () => {
+  it('keeps portfolio-manager activation non-blocking when hidden executor readiness fails', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (
+        jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1' &&
+        jsonRpcRequest.params?.['agent_id'] === 'portfolio-manager'
+      ) {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 2,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-portfolio-manager-orchestrator-1',
+              agent_id: 'portfolio-manager',
+              role: 'orchestrator',
+              wallet_address: '0x00000000000000000000000000000000000000c1',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                onboarding: true,
+                root_registration: true,
+              },
+              registration_version: 1,
+              registered_at: '2026-04-02T09:30:00.000Z',
+            },
+          },
+        };
+      }
+
+      if (
+        jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1' &&
+        jsonRpcRequest.params?.['agent_id'] === 'agent-oca-executor'
+      ) {
+        throw new Error('Shared Ember is temporarily unavailable for hidden worker identity');
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensurePortfolioManagerServiceIdentities({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readControllerWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000c1' as const,
+        ),
+        readExecutorWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000e1' as const,
+        ),
+      }),
+    ).resolves.toMatchObject({
+      orchestrator: {
+        wroteIdentity: false,
+        identity: {
+          agent_id: 'portfolio-manager',
+          role: 'orchestrator',
+        },
+      },
+      hiddenOcaExecutor: {
+        status: 'deferred',
+        reason: 'Shared Ember is temporarily unavailable for hidden worker identity',
+      },
+    });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/serviceIdentityPreflight.unit.test.ts
@@ -507,6 +507,99 @@ describe('ensureHiddenOcaExecutorServiceIdentity', () => {
     });
   });
 
+  it('repairs an existing hidden executor identity when internal worker metadata is stale', async () => {
+    const handleJsonRpc = vi.fn(async (request: unknown) => {
+      const jsonRpcRequest =
+        typeof request === 'object' && request !== null
+          ? (request as { method?: string; params?: Record<string, unknown> })
+          : {};
+
+      if (jsonRpcRequest.method === 'orchestrator.readAgentServiceIdentity.v1') {
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-read',
+          result: {
+            protocol_version: 'v1',
+            revision: 12,
+            agent_service_identity: {
+              identity_ref: 'agent-service-identity-agent-oca-executor-subagent-2',
+              agent_id: 'agent-oca-executor',
+              role: 'subagent',
+              wallet_address: '0x00000000000000000000000000000000000000e1',
+              wallet_source: 'ember_local_write',
+              capability_metadata: {
+                visibility: 'public',
+                control_paths: [],
+              },
+              registration_version: 2,
+              registered_at: '2026-04-09T12:00:00.000Z',
+            },
+          },
+        };
+      }
+
+      if (jsonRpcRequest.method === 'orchestrator.writeAgentServiceIdentity.v1') {
+        expect(jsonRpcRequest.params?.['expected_revision']).toBe(12);
+        expect(jsonRpcRequest.params?.['agent_service_identity']).toMatchObject({
+          identity_ref: 'agent-service-identity-agent-oca-executor-subagent-3',
+          agent_id: 'agent-oca-executor',
+          role: 'subagent',
+          wallet_address: '0x00000000000000000000000000000000000000e1',
+          wallet_source: 'ember_local_write',
+          capability_metadata: {
+            visibility: 'internal',
+            owner_agent_id: 'agent-portfolio-manager',
+            worker_kind: 'execution',
+            execution_surface: 'onchain_actions',
+            control_paths: ['spot.swap'],
+          },
+          registration_version: 3,
+          registered_at: '2026-04-10T13:00:00.000Z',
+        });
+
+        return {
+          jsonrpc: '2.0',
+          id: 'rpc-agent-service-identity-write',
+          result: {
+            protocol_version: 'v1',
+            revision: 13,
+            committed_event_ids: ['evt-agent-service-identity-hidden-3'],
+            agent_service_identity: jsonRpcRequest.params?.['agent_service_identity'],
+          },
+        };
+      }
+
+      throw new Error(`Unexpected Shared Ember JSON-RPC method: ${String(jsonRpcRequest.method)}`);
+    });
+
+    await expect(
+      ensureHiddenOcaExecutorServiceIdentity({
+        protocolHost: {
+          handleJsonRpc,
+          readCommittedEventOutbox: vi.fn(),
+          acknowledgeCommittedEventOutbox: vi.fn(),
+        },
+        readExecutorWalletAddress: vi.fn(
+          async () => '0x00000000000000000000000000000000000000e1' as const,
+        ),
+        now: () => new Date('2026-04-10T13:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      revision: 13,
+      wroteIdentity: true,
+      identity: {
+        registration_version: 3,
+        capability_metadata: {
+          visibility: 'internal',
+          owner_agent_id: 'agent-portfolio-manager',
+          worker_kind: 'execution',
+          execution_surface: 'onchain_actions',
+          control_paths: ['spot.swap'],
+        },
+      },
+    });
+  });
+
   it('fails when Shared Ember does not confirm the written hidden executor identity', async () => {
     const handleJsonRpc = vi.fn(async (request: unknown) => {
       const jsonRpcRequest =

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -818,6 +818,7 @@ const PORTFOLIO_MANAGER_SIGNING_INTERRUPT_TYPE = 'portfolio-manager-delegation-s
 const PORTFOLIO_MANAGER_SIGNING_MESSAGE =
   'Review and sign the delegation needed to activate your portfolio manager.';
 const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND = 'dispatch_spot_swap';
+const PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND = 'confirm_spot_swap_reserved_capital';
 const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION = [
   'Dispatch a structured spot swap through the portfolio-manager owned hidden Onchain Actions executor.',
   'When using this command, put a JSON object string in inputJson with required fields walletAddress, amount, amountType, fromChain, toChain, fromToken, and toToken.',
@@ -829,15 +830,26 @@ const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION = [
   'Do not set reservationConflictHandling in inputJson; it is supplied only by the portfolio-manager conflict confirmation retry.',
   'Example inputJson: {"walletAddress":"0x...","amount":"894102247158860","amountType":"exactIn","fromChain":"arbitrum","toChain":"arbitrum","fromToken":"WETH","toToken":"USDC","capitalPool":"reserved_or_assigned"}.',
 ].join(' ');
+const PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND_DESCRIPTION = [
+  'Resolve the exact pending reserved-capital spot swap confirmation through the tool-callable command path.',
+  'Use this command when pending_spot_swap_conflict is present and the user replies yes, confirm, proceed, use reserved funds, use unassigned only, or cancel.',
+  'Required inputJson field: outcome.',
+  'For yes, confirm, proceed, or use reserved funds, set outcome to "allow_reserved_for_other_agent".',
+  'For unassigned/free capital only, set outcome to "unassigned_only".',
+  'For cancel/stop, set outcome to "cancel".',
+  'Do not call dispatch_spot_swap again for the same pending reserved-capital confirmation.',
+  'Example inputJson: {"outcome":"allow_reserved_for_other_agent"}.',
+].join(' ');
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE =
   'portfolio-manager-swap-reservation-conflict-request';
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_MESSAGE =
   'This swap would touch capital reserved for another agent. Confirm whether to proceed or retry with unassigned capital only.';
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_DESCRIPTION = [
   'Ask whether a spot swap may touch capital reserved for another agent or should retry with unassigned capital only.',
-  'When this interrupt is pending and the user says yes, confirm, proceed, or equivalent, answer this interrupt with inputJson {"outcome":"allow_reserved_for_other_agent"}.',
-  'When the user asks for unassigned/free capital only, answer this interrupt with inputJson {"outcome":"unassigned_only"}.',
-  'When the user cancels, answer this interrupt with inputJson {"outcome":"cancel"}.',
+  `In normal chat, use the ${PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND} command because lifecycle interrupts are not model tool-callable.`,
+  'When a client forwards an interrupt resume directly and the user says yes, confirm, proceed, or equivalent, resume with inputJson {"outcome":"allow_reserved_for_other_agent"}.',
+  'When the user asks for unassigned/free capital only, resume with inputJson {"outcome":"unassigned_only"}.',
+  'When the user cancels, resume with inputJson {"outcome":"cancel"}.',
   'Do not repeat dispatch_spot_swap for a pending reserved-capital confirmation.',
 ].join(' ');
 const PORTFOLIO_MANAGER_ROOT_AUTHORITY = ROOT_AUTHORITY;
@@ -2823,6 +2835,10 @@ export function createPortfolioManagerDomain(
           description: PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION,
         },
         {
+          name: PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND,
+          description: PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND_DESCRIPTION,
+        },
+        {
           name: 'complete_rooted_bootstrap_from_user_signing',
           description:
             'Complete the rooted bootstrap in one Shared Ember command using onboarding data and the signing handoff.',
@@ -2917,6 +2933,9 @@ export function createPortfolioManagerDomain(
           `    <confirmation_operation>${PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE}</confirmation_operation>`,
         );
         context.push(
+          `    <tool_command>${PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND}</tool_command>`,
+        );
+        context.push(
           '    <affirmative_user_reply_outcome>allow_reserved_for_other_agent</affirmative_user_reply_outcome>',
         );
         context.push(
@@ -2924,7 +2943,7 @@ export function createPortfolioManagerDomain(
         );
         context.push('    <cancel_user_reply_outcome>cancel</cancel_user_reply_outcome>');
         context.push(
-          '    <instruction>Do not call dispatch_spot_swap again for yes/confirm/proceed replies. Answer this pending interrupt with outcome allow_reserved_for_other_agent.</instruction>',
+          `    <instruction>Do not call dispatch_spot_swap again for yes/confirm/proceed replies. Use ${PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND} with outcome allow_reserved_for_other_agent.</instruction>`,
         );
         appendStructuredXmlNode({
           lines: context,
@@ -3842,6 +3861,7 @@ export function createPortfolioManagerDomain(
             result,
           });
         }
+        case PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND:
         case PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE: {
           const outcome = readSpotSwapConflictOutcome(operation.input);
           const pendingConflict = currentState.pendingSpotSwapConflict ?? null;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -828,6 +828,7 @@ const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION = [
   'amountType must be "exactIn" or "exactOut"; for requests like "half my WETH" or "$3 of WETH", infer the token amount from current portfolio state when possible before dispatching.',
   'capitalPool may be "unassigned_only", "reserved_or_assigned", or "all"; use reserved_or_assigned when the user explicitly asks to use reserved or assigned units, and use all when the selected asset pool should include both free and reserved units.',
   'Never suggest releasing or adjusting a reservation for spot swaps; dispatch with capitalPool instead and let the reserved-capital confirmation interrupt ask the user to proceed or retry with unassigned capital only.',
+  `If ${PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND} returns a reserved-capital confirmation, stop the current assistant turn and wait for the user's next reply before calling ${PORTFOLIO_MANAGER_CONFIRM_SPOT_SWAP_COMMAND}.`,
   'Do not set reservationConflictHandling in inputJson; it is supplied only by the portfolio-manager conflict confirmation retry.',
   'Example inputJson: {"walletAddress":"0x...","amount":"894102247158860","amountType":"exactIn","fromChain":"arbitrum","toChain":"arbitrum","fromToken":"WETH","toToken":"USDC","capitalPool":"reserved_or_assigned"}.',
 ].join(' ');
@@ -2083,6 +2084,23 @@ function readSpotSwapConflictOutcome(
   }
 
   return null;
+}
+
+function buildConfirmedSpotSwapDispatch(input: {
+  dispatch: HiddenOcaSpotSwapInput;
+  outcome: HiddenOcaReservationConflictHandling['kind'];
+}): HiddenOcaSpotSwapInput {
+  return {
+    ...input.dispatch,
+    ...(input.dispatch.idempotencyKey
+      ? {
+          idempotencyKey: `${input.dispatch.idempotencyKey}:reserved-capital-confirmation:${input.outcome}`,
+        }
+      : {}),
+    reservationConflictHandling: {
+      kind: input.outcome,
+    },
+  };
 }
 
 function readApprovedSetupFromOnboardingBootstrap(
@@ -3881,12 +3899,10 @@ export function createPortfolioManagerDomain(
             };
           }
 
-          const dispatch: HiddenOcaSpotSwapInput = {
-            ...pendingConflict.dispatch,
-            reservationConflictHandling: {
-              kind: outcome,
-            },
-          };
+          const dispatch = buildConfirmedSpotSwapDispatch({
+            dispatch: pendingConflict.dispatch,
+            outcome,
+          });
           const result = await options.hiddenOcaSpotSwapExecutor.executeSpotSwap({
             threadId,
             currentRevision: currentState.lastSharedEmberRevision,

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -818,6 +818,14 @@ const PORTFOLIO_MANAGER_SIGNING_INTERRUPT_TYPE = 'portfolio-manager-delegation-s
 const PORTFOLIO_MANAGER_SIGNING_MESSAGE =
   'Review and sign the delegation needed to activate your portfolio manager.';
 const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND = 'dispatch_spot_swap';
+const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION = [
+  'Dispatch a structured spot swap through the portfolio-manager owned hidden Onchain Actions executor.',
+  'When using this command, put a JSON object string in inputJson with required fields walletAddress, amount, amountType, fromChain, toChain, fromToken, and toToken.',
+  'Optional fields are slippageTolerance, expiration, idempotencyKey, and rootedWalletContextId.',
+  'amount should be a base-unit integer string; decimal token-unit strings are accepted only when token decimals are known.',
+  'amountType must be "exactIn" or "exactOut"; for requests like "half my WETH" or "$3 of WETH", infer the token amount from current portfolio state when possible before dispatching.',
+  'Example inputJson: {"walletAddress":"0x...","amount":"894102247158860","amountType":"exactIn","fromChain":"arbitrum","toChain":"arbitrum","fromToken":"WETH","toToken":"USDC"}.',
+].join(' ');
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE =
   'portfolio-manager-swap-reservation-conflict-request';
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_MESSAGE =
@@ -2748,8 +2756,7 @@ export function createPortfolioManagerDomain(
         },
         {
           name: PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND,
-          description:
-            'Dispatch a structured spot swap through the portfolio-manager owned hidden Onchain Actions executor.',
+          description: PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION,
         },
         {
           name: 'complete_rooted_bootstrap_from_user_signing',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -366,6 +366,10 @@ function readCommittedEvent(value: unknown): SharedEmberCommittedEvent | null {
 function readNextReadyForRedelegationWork(
   events: unknown[],
   acknowledgedThroughSequence: number,
+  expected?: {
+    requestId?: string;
+    transactionPlanId?: string;
+  },
 ): SharedEmberRedelegationWork | null {
   let latestWork: SharedEmberRedelegationWork | null = null;
 
@@ -391,7 +395,9 @@ function readNextReadyForRedelegationWork(
       requestId === null ||
       transactionPlanId === null ||
       phase !== 'ready_for_redelegation' ||
-      redelegationSigningPackage === null
+      redelegationSigningPackage === null ||
+      (expected?.requestId !== undefined && requestId !== expected.requestId) ||
+      (expected?.transactionPlanId !== undefined && transactionPlanId !== expected.transactionPlanId)
     ) {
       continue;
     }
@@ -536,6 +542,190 @@ async function runSharedEmberCommandWithResolvedRevision<T>(input: {
     expectedRevision = refreshedRevision;
     return (await input.protocolHost.handleJsonRpc(input.buildRequest(expectedRevision))) as T;
   }
+}
+
+export async function refreshPortfolioManagerRedelegationWork(input: {
+  protocolHost: PortfolioManagerSharedEmberProtocolHost;
+  threadId: string;
+  agentId?: string;
+  currentRevision?: number | null;
+  runtimeSigning?: AgentRuntimeSigningService;
+  runtimeSignerRef?: string;
+  controllerWalletAddress?: `0x${string}`;
+  controllerSignerAddress?: `0x${string}`;
+  expectedRequestId?: string;
+  expectedTransactionPlanId?: string;
+}): Promise<{
+  status: 'completed' | 'empty' | 'failed';
+  revision: number | null;
+  statusMessage: string;
+  artifact?: Record<string, unknown>;
+}> {
+  const outboxPage = await input.protocolHost.readCommittedEventOutbox({
+    protocol_version: 'v1',
+    consumer_id: PORTFOLIO_MANAGER_REDELEGATION_OUTBOX_CONSUMER_ID,
+    after_sequence: 0,
+    limit: 100,
+  });
+  const outboxRecord = isRecord(outboxPage) ? outboxPage : {};
+  const revision = readInt(outboxRecord['revision']) ?? input.currentRevision ?? null;
+  const redelegationWork = readNextReadyForRedelegationWork(
+    Array.isArray(outboxRecord['events']) ? outboxRecord['events'] : [],
+    readInt(outboxRecord['acknowledged_through_sequence']) ?? 0,
+    {
+      ...(input.expectedRequestId ? { requestId: input.expectedRequestId } : {}),
+      ...(input.expectedTransactionPlanId
+        ? { transactionPlanId: input.expectedTransactionPlanId }
+        : {}),
+    },
+  );
+
+  if (redelegationWork === null) {
+    return {
+      status: 'empty',
+      revision,
+      statusMessage: 'No redelegation work is currently pending in the Shared Ember outbox.',
+    };
+  }
+
+  if (!input.runtimeSigning) {
+    return {
+      status: 'failed',
+      revision,
+      statusMessage:
+        'Runtime-owned signing service is not configured for portfolio-manager redelegation signing.',
+    };
+  }
+
+  if (!input.controllerWalletAddress) {
+    return {
+      status: 'failed',
+      revision,
+      statusMessage:
+        'Portfolio-manager redelegation signing is blocked because the controller smart-account address is not configured.',
+    };
+  }
+
+  if (!input.controllerSignerAddress) {
+    return {
+      status: 'failed',
+      revision,
+      statusMessage:
+        'Portfolio-manager redelegation signing is blocked because the controller signer address is not configured.',
+    };
+  }
+
+  let unsignedRedelegation: PortfolioManagerUnsignedDelegation;
+  try {
+    unsignedRedelegation = buildRuntimeRedelegationUnsignedDelegation({
+      redelegationSigningPackage: redelegationWork.redelegationSigningPackage,
+      delegatorAddress: input.controllerWalletAddress,
+    });
+  } catch {
+    return {
+      status: 'failed',
+      revision,
+      statusMessage:
+        'Portfolio-manager redelegation signing could not continue because the canonical signing package was incomplete.',
+    };
+  }
+
+  const redelegationNetwork = readString(redelegationWork.redelegationSigningPackage['network']);
+  if (!redelegationNetwork) {
+    return {
+      status: 'failed',
+      revision,
+      statusMessage:
+        'Portfolio-manager redelegation signing could not continue because the canonical signing package was incomplete.',
+    };
+  }
+
+  const signedRedelegation = await signPreparedDelegation({
+    signing: input.runtimeSigning,
+    signerRef: input.runtimeSignerRef ?? DEFAULT_RUNTIME_SIGNER_REF,
+    expectedAddress: input.controllerSignerAddress,
+    chain: OWS_SIGNING_CHAIN,
+    chainId: resolveRuntimeRedelegationChainId(redelegationNetwork),
+    delegationManager: PORTFOLIO_MANAGER_DELEGATION_MANAGER,
+    delegation: unsignedRedelegation,
+  });
+
+  let signedRedelegationRecord: Record<string, unknown>;
+  try {
+    signedRedelegationRecord = buildRuntimeSignedRedelegationRecord({
+      redelegationSigningPackage: redelegationWork.redelegationSigningPackage,
+      artifactRef: signedRedelegation.artifactRef,
+    });
+  } catch {
+    return {
+      status: 'failed',
+      revision,
+      statusMessage:
+        'Portfolio-manager redelegation signing could not continue because the canonical signing package was incomplete.',
+    };
+  }
+
+  const registrationResponse = await runSharedEmberCommandWithResolvedRevision<{
+    result?: {
+      revision?: number;
+      committed_event_ids?: string[];
+      execution_result?: unknown;
+    };
+  }>({
+    protocolHost: input.protocolHost,
+    threadId: input.threadId,
+    agentId: input.agentId ?? PORTFOLIO_MANAGER_SHARED_EMBER_AGENT_ID,
+    currentRevision: revision,
+    buildRequest: (expectedRevision) => ({
+      jsonrpc: '2.0',
+      id: `shared-ember-${input.threadId}-register-signed-redelegation`,
+      method: 'orchestrator.registerSignedRedelegation.v1',
+      params: {
+        idempotency_key: `idem-refresh-redelegation-work-${input.threadId}:register-redelegation:${redelegationWork.requestId}`,
+        expected_revision: expectedRevision,
+        transaction_plan_id: redelegationWork.transactionPlanId,
+        signed_redelegation: signedRedelegationRecord,
+      },
+    }),
+  });
+
+  const acknowledgeResponse = await input.protocolHost.acknowledgeCommittedEventOutbox({
+    protocol_version: 'v1',
+    consumer_id: PORTFOLIO_MANAGER_REDELEGATION_OUTBOX_CONSUMER_ID,
+    delivered_through_sequence: redelegationWork.sequence,
+  });
+  const acknowledgeErrorMessage = readOutboxErrorMessage(acknowledgeResponse);
+  if (acknowledgeErrorMessage !== null) {
+    throw new Error(
+      `Shared Ember committed outbox acknowledgement failed: ${acknowledgeErrorMessage}`,
+    );
+  }
+
+  const registeredRevision = readInt(registrationResponse.result?.revision) ?? revision;
+  const acknowledgedRevision =
+    readInt(isRecord(acknowledgeResponse) ? acknowledgeResponse['revision'] : null) ??
+    registeredRevision;
+  const acknowledgedThroughSequence =
+    readInt(
+      isRecord(acknowledgeResponse) ? acknowledgeResponse['acknowledged_through_sequence'] : null,
+    ) ?? redelegationWork.sequence;
+
+  return {
+    status: 'completed',
+    revision: acknowledgedRevision,
+    statusMessage: 'Redelegation signed, registered, and acknowledged through Shared Ember.',
+    artifact: {
+      type: 'shared-ember-redelegation-registration',
+      revision: acknowledgedRevision,
+      consumerId: PORTFOLIO_MANAGER_REDELEGATION_OUTBOX_CONSUMER_ID,
+      eventId: redelegationWork.eventId,
+      sequence: redelegationWork.sequence,
+      requestId: redelegationWork.requestId,
+      transactionPlanId: redelegationWork.transactionPlanId,
+      committedEventIds: registrationResponse.result?.committed_event_ids ?? [],
+      acknowledgedThroughSequence,
+    },
+  };
 }
 
 async function readSharedEmberAgentServiceIdentity(input: {
@@ -1708,6 +1898,7 @@ function buildSpotSwapArtifact(result: HiddenOcaSpotSwapResult): Record<string, 
   return {
     type: 'hidden-oca-spot-swap',
     status: result.status,
+    ...(result.idempotencyKey ? { idempotencyKey: result.idempotencyKey } : {}),
     swapSummary: result.swapSummary,
     transactionPlanId: result.transactionPlanId,
     requestId: result.requestId,
@@ -1740,7 +1931,10 @@ function buildSpotSwapOperationResult(input: {
     const nextState: PortfolioManagerLifecycleState = {
       ...input.currentState,
       pendingSpotSwapConflict: {
-        dispatch: input.dispatch,
+        dispatch: {
+          ...input.dispatch,
+          ...(input.result.idempotencyKey ? { idempotencyKey: input.result.idempotencyKey } : {}),
+        },
         conflict: input.result.conflict,
       },
     };
@@ -1761,6 +1955,24 @@ function buildSpotSwapOperationResult(input: {
             conflict: input.result.conflict,
             retryOptions: input.result.conflict.retryOptions,
           },
+        },
+        artifacts: [
+          {
+            data: buildSpotSwapArtifact(input.result),
+          },
+        ],
+      },
+    };
+  }
+
+  if (input.result.status === 'awaiting_redelegation') {
+    return {
+      state: input.currentState,
+      outputs: {
+        status: {
+          executionStatus: 'failed' as const,
+          statusMessage:
+            'Spot swap execution is waiting for Shared Ember redelegation readiness and was not completed.',
         },
         artifacts: [
           {
@@ -3480,6 +3692,19 @@ export function createPortfolioManagerDomain(
                   executionStatus: 'failed',
                   statusMessage:
                     'Spot swap dispatch requires walletAddress, amount, amountType, fromChain, toChain, fromToken, and toToken.',
+                },
+              },
+            };
+          }
+
+          if (dispatch.reservationConflictHandling) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Spot swap reserved-capital conflict handling can only be supplied by the portfolio-manager conflict confirmation retry.',
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -1,11 +1,16 @@
 import { createHash } from 'node:crypto';
 
+import { getDeleGatorEnvironment, ROOT_AUTHORITY } from '@metamask/delegation-toolkit';
+import { getDelegationHashOffchain } from '@metamask/delegation-toolkit/utils';
 import type { AgentRuntimeDomainConfig } from 'agent-runtime';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedDelegation } from 'agent-runtime/internal';
-import { getDeleGatorEnvironment, ROOT_AUTHORITY } from '@metamask/delegation-toolkit';
-import { getDelegationHashOffchain } from '@metamask/delegation-toolkit/utils';
 import { formatUnits, keccak256, toHex } from 'viem';
+import type {
+  HiddenOcaReservationConflictHandling,
+  HiddenOcaSpotSwapInput,
+  HiddenOcaSpotSwapResult,
+} from './hiddenOcaSwapExecutor.js';
 import {
   buildPortfolioManagerWalletAccountingDetails,
   buildSharedEmberAccountingContextXml,
@@ -33,6 +38,12 @@ export type PortfolioManagerLifecycleState = {
   activeWalletAddress: `0x${string}` | null;
   pendingOnboardingWalletAddress: `0x${string}` | null;
   pendingApprovedSetup?: PortfolioManagerApprovedSetup | null;
+  pendingSpotSwapConflict?: PortfolioManagerPendingSpotSwapConflict | null;
+};
+
+type PortfolioManagerPendingSpotSwapConflict = {
+  dispatch: HiddenOcaSpotSwapInput;
+  conflict: NonNullable<HiddenOcaSpotSwapResult['conflict']>;
 };
 
 type CreatePortfolioManagerDomainOptions = {
@@ -42,6 +53,13 @@ type CreatePortfolioManagerDomainOptions = {
   controllerSignerAddress?: `0x${string}`;
   runtimeSigning?: AgentRuntimeSigningService;
   runtimeSignerRef?: string;
+  hiddenOcaSpotSwapExecutor?: {
+    executeSpotSwap(input: {
+      threadId: string;
+      currentRevision?: number | null;
+      input: HiddenOcaSpotSwapInput;
+    }): Promise<HiddenOcaSpotSwapResult>;
+  };
 };
 
 type SharedEmberRevisionResponse = {
@@ -108,6 +126,7 @@ function buildDefaultLifecycleState(): PortfolioManagerLifecycleState {
     activeWalletAddress: null,
     pendingOnboardingWalletAddress: null,
     pendingApprovedSetup: null,
+    pendingSpotSwapConflict: null,
   };
 }
 
@@ -608,6 +627,11 @@ const PORTFOLIO_MANAGER_SETUP_MESSAGE =
 const PORTFOLIO_MANAGER_SIGNING_INTERRUPT_TYPE = 'portfolio-manager-delegation-signing-request';
 const PORTFOLIO_MANAGER_SIGNING_MESSAGE =
   'Review and sign the delegation needed to activate your portfolio manager.';
+const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND = 'dispatch_spot_swap';
+const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE =
+  'portfolio-manager-swap-reservation-conflict-request';
+const PORTFOLIO_MANAGER_SWAP_CONFLICT_MESSAGE =
+  'This swap would touch capital reserved for another agent. Confirm whether to proceed or retry with unassigned capital only.';
 const PORTFOLIO_MANAGER_ROOT_AUTHORITY = ROOT_AUTHORITY;
 const PORTFOLIO_MANAGER_DELEGATION_SALT =
   '0x1111111111111111111111111111111111111111111111111111111111111111';
@@ -1591,6 +1615,219 @@ function parseManagedMandateUpdateInput(input: unknown): ManagedMandateUpdateInp
   };
 }
 
+function readSpotSwapAmountType(value: unknown): HiddenOcaSpotSwapInput['amountType'] | null {
+  return value === 'exactIn' || value === 'exactOut' ? value : null;
+}
+
+function readSpotSwapReservationConflictHandling(
+  value: unknown,
+): HiddenOcaSpotSwapInput['reservationConflictHandling'] | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const kind = readString(value['kind']);
+  if (kind !== 'allow_reserved_for_other_agent' && kind !== 'unassigned_only') {
+    return null;
+  }
+
+  return { kind };
+}
+
+function parseSpotSwapDispatchInput(input: unknown): HiddenOcaSpotSwapInput | null {
+  if (!isRecord(input)) {
+    return null;
+  }
+
+  const walletAddress = readHexAddress(input['walletAddress']);
+  const amount = readString(input['amount']);
+  const amountType = readSpotSwapAmountType(input['amountType']);
+  const fromChain = readString(input['fromChain']);
+  const toChain = readString(input['toChain']);
+  const fromToken = readString(input['fromToken']);
+  const toToken = readString(input['toToken']);
+
+  if (
+    walletAddress === null ||
+    amount === null ||
+    amountType === null ||
+    fromChain === null ||
+    toChain === null ||
+    fromToken === null ||
+    toToken === null
+  ) {
+    return null;
+  }
+
+  const reservationConflictHandling = readSpotSwapReservationConflictHandling(
+    input['reservationConflictHandling'],
+  );
+
+  return {
+    walletAddress,
+    amount,
+    amountType,
+    fromChain,
+    toChain,
+    fromToken,
+    toToken,
+    ...(readString(input['slippageTolerance'])
+      ? { slippageTolerance: readString(input['slippageTolerance'])! }
+      : {}),
+    ...(readString(input['expiration']) ? { expiration: readString(input['expiration'])! } : {}),
+    ...(readString(input['idempotencyKey'])
+      ? { idempotencyKey: readString(input['idempotencyKey'])! }
+      : {}),
+    ...(readString(input['rootedWalletContextId'])
+      ? { rootedWalletContextId: readString(input['rootedWalletContextId'])! }
+      : {}),
+    ...(reservationConflictHandling ? { reservationConflictHandling } : {}),
+  };
+}
+
+function buildSpotSwapDispatchInput(input: {
+  operationInput: unknown;
+  currentState: PortfolioManagerLifecycleState;
+}): HiddenOcaSpotSwapInput | null {
+  const dispatch = parseSpotSwapDispatchInput(input.operationInput);
+  if (!dispatch) {
+    return null;
+  }
+
+  return {
+    ...dispatch,
+    ...(dispatch.rootedWalletContextId
+      ? {}
+      : input.currentState.lastRootedWalletContextId
+        ? { rootedWalletContextId: input.currentState.lastRootedWalletContextId }
+        : {}),
+  };
+}
+
+function buildSpotSwapArtifact(result: HiddenOcaSpotSwapResult): Record<string, unknown> {
+  return {
+    type: 'hidden-oca-spot-swap',
+    status: result.status,
+    swapSummary: result.swapSummary,
+    transactionPlanId: result.transactionPlanId,
+    requestId: result.requestId,
+    committedEventIds: result.committedEventIds,
+    ...(result.transactionHash ? { transactionHash: result.transactionHash } : {}),
+    ...(result.conflict ? { conflict: result.conflict } : {}),
+    ...(result.failureReason ? { failureReason: result.failureReason } : {}),
+  };
+}
+
+function buildSpotSwapCompletionMessage(status: HiddenOcaSpotSwapResult['status']): string {
+  switch (status) {
+    case 'completed':
+      return 'Spot swap completed through the portfolio manager.';
+    case 'submitted':
+      return 'Spot swap submitted through the portfolio manager.';
+    case 'awaiting_redelegation':
+      return 'Spot swap execution is waiting for Shared Ember redelegation readiness.';
+    default:
+      return 'Spot swap execution finished through the portfolio manager.';
+  }
+}
+
+function buildSpotSwapOperationResult(input: {
+  currentState: PortfolioManagerLifecycleState;
+  dispatch: HiddenOcaSpotSwapInput;
+  result: HiddenOcaSpotSwapResult;
+}) {
+  if (input.result.status === 'conflict' && input.result.conflict) {
+    const nextState: PortfolioManagerLifecycleState = {
+      ...input.currentState,
+      pendingSpotSwapConflict: {
+        dispatch: input.dispatch,
+        conflict: input.result.conflict,
+      },
+    };
+
+    return {
+      state: nextState,
+      outputs: {
+        status: {
+          executionStatus: 'interrupted' as const,
+          statusMessage: PORTFOLIO_MANAGER_SWAP_CONFLICT_MESSAGE,
+        },
+        interrupt: {
+          type: PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE,
+          mirroredToActivity: false,
+          message: PORTFOLIO_MANAGER_SWAP_CONFLICT_MESSAGE,
+          payload: {
+            swap: input.result.swapSummary,
+            conflict: input.result.conflict,
+            retryOptions: input.result.conflict.retryOptions,
+          },
+        },
+        artifacts: [
+          {
+            data: buildSpotSwapArtifact(input.result),
+          },
+        ],
+      },
+    };
+  }
+
+  if (input.result.status === 'failed' || input.result.status === 'blocked') {
+    return {
+      state: input.currentState,
+      outputs: {
+        status: {
+          executionStatus: 'failed' as const,
+          statusMessage:
+            input.result.failureReason ??
+            'Spot swap could not be prepared or executed through the portfolio manager.',
+        },
+        artifacts: [
+          {
+            data: buildSpotSwapArtifact(input.result),
+          },
+        ],
+      },
+    };
+  }
+
+  return {
+    state: {
+      ...input.currentState,
+      pendingSpotSwapConflict: null,
+    },
+    outputs: {
+      status: {
+        executionStatus: 'completed' as const,
+        statusMessage: buildSpotSwapCompletionMessage(input.result.status),
+      },
+      artifacts: [
+        {
+          data: buildSpotSwapArtifact(input.result),
+        },
+      ],
+    },
+  };
+}
+
+function readSpotSwapConflictOutcome(
+  value: unknown,
+): HiddenOcaReservationConflictHandling['kind'] | 'cancel' | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const outcome = readString(value['outcome']);
+  if (
+    outcome === 'allow_reserved_for_other_agent' ||
+    outcome === 'unassigned_only' ||
+    outcome === 'cancel'
+  ) {
+    return outcome;
+  }
+
+  return null;
+}
+
 function readApprovedSetupFromOnboardingBootstrap(
   value: unknown,
 ): PortfolioManagerApprovedSetup | null {
@@ -2298,6 +2535,11 @@ export function createPortfolioManagerDomain(
             'Read committed redelegation work from the Shared Ember outbox for the portfolio-manager orchestrator.',
         },
         {
+          name: PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND,
+          description:
+            'Dispatch a structured spot swap through the portfolio-manager owned hidden Onchain Actions executor.',
+        },
+        {
           name: 'complete_rooted_bootstrap_from_user_signing',
           description:
             'Complete the rooted bootstrap in one Shared Ember command using onboarding data and the signing handoff.',
@@ -2314,6 +2556,12 @@ export function createPortfolioManagerDomain(
           type: 'portfolio-manager-delegation-signing-request',
           description:
             'Request delegation signatures needed to complete portfolio-manager onboarding.',
+          mirroredToActivity: false,
+        },
+        {
+          type: PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE,
+          description:
+            'Ask whether a spot swap may touch capital reserved for another agent or should retry with unassigned capital only.',
           mirroredToActivity: false,
         },
       ],
@@ -2514,6 +2762,7 @@ export function createPortfolioManagerDomain(
             activeWalletAddress: null,
             pendingOnboardingWalletAddress: null,
             pendingApprovedSetup: null,
+            pendingSpotSwapConflict: null,
           };
 
           return {
@@ -3204,6 +3453,141 @@ export function createPortfolioManagerDomain(
               ],
             },
           };
+        }
+        case PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND: {
+          if (!options.hiddenOcaSpotSwapExecutor) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Hidden Onchain Actions spot swap executor is not configured for this portfolio-manager runtime.',
+                },
+              },
+            };
+          }
+
+          const dispatch = buildSpotSwapDispatchInput({
+            operationInput: operation.input,
+            currentState,
+          });
+          if (!dispatch) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Spot swap dispatch requires walletAddress, amount, amountType, fromChain, toChain, fromToken, and toToken.',
+                },
+              },
+            };
+          }
+
+          if (!dispatch.rootedWalletContextId) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Spot swap dispatch requires an active rooted wallet context before hidden execution can start.',
+                },
+              },
+            };
+          }
+
+          const result = await options.hiddenOcaSpotSwapExecutor.executeSpotSwap({
+            threadId,
+            currentRevision: currentState.lastSharedEmberRevision,
+            input: dispatch,
+          });
+
+          return buildSpotSwapOperationResult({
+            currentState,
+            dispatch,
+            result,
+          });
+        }
+        case PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE: {
+          const outcome = readSpotSwapConflictOutcome(operation.input);
+          const pendingConflict = currentState.pendingSpotSwapConflict ?? null;
+
+          if (!pendingConflict) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'There is no exact pending spot swap conflict to confirm or retry.',
+                },
+              },
+            };
+          }
+
+          if (outcome === 'cancel') {
+            return {
+              state: {
+                ...currentState,
+                pendingSpotSwapConflict: null,
+              },
+              outputs: {
+                status: {
+                  executionStatus: 'canceled',
+                  statusMessage: 'Spot swap canceled before reserved-capital retry.',
+                },
+              },
+            };
+          }
+
+          if (outcome === null) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Spot swap conflict confirmation requires allow_reserved_for_other_agent, unassigned_only, or cancel.',
+                },
+              },
+            };
+          }
+
+          if (!options.hiddenOcaSpotSwapExecutor) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage:
+                    'Hidden Onchain Actions spot swap executor is not configured for this portfolio-manager runtime.',
+                },
+              },
+            };
+          }
+
+          const dispatch: HiddenOcaSpotSwapInput = {
+            ...pendingConflict.dispatch,
+            reservationConflictHandling: {
+              kind: outcome,
+            },
+          };
+          const result = await options.hiddenOcaSpotSwapExecutor.executeSpotSwap({
+            threadId,
+            currentRevision: currentState.lastSharedEmberRevision,
+            input: dispatch,
+          });
+
+          return buildSpotSwapOperationResult({
+            currentState: {
+              ...currentState,
+              pendingSpotSwapConflict: null,
+            },
+            dispatch,
+            result,
+          });
         }
         case 'refresh_redelegation_work': {
           if (!options.protocolHost) {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -5,7 +5,7 @@ import { getDelegationHashOffchain } from '@metamask/delegation-toolkit/utils';
 import type { AgentRuntimeDomainConfig } from 'agent-runtime';
 import type { AgentRuntimeSigningService } from 'agent-runtime/internal';
 import { signPreparedDelegation } from 'agent-runtime/internal';
-import { formatUnits, keccak256, toHex } from 'viem';
+import { keccak256, toHex } from 'viem';
 import type {
   HiddenOcaReservationConflictHandling,
   HiddenOcaSpotSwapInput,
@@ -18,6 +18,7 @@ import {
   readManagedAgentAccountingState,
   type OnboardingState as SharedEmberOnboardingState,
 } from './sharedEmberOnboardingState.js';
+import { buildTokenDisplayQuantity } from './tokenQuantityDisplay.js';
 
 export type PortfolioManagerSharedEmberProtocolHost = {
   handleJsonRpc: (input: unknown) => Promise<unknown>;
@@ -1215,46 +1216,6 @@ function readNumberLike(value: unknown): number | null {
 
   const parsed = Number(value.trim());
   return Number.isFinite(parsed) ? parsed : null;
-}
-
-const TOKEN_DECIMALS_BY_ASSET = new Map<string, number>([
-  ['ETH', 18],
-  ['WETH', 18],
-  ['USDC', 6],
-  ['USDCN', 6],
-  ['USDT', 6],
-  ['WBTC', 8],
-]);
-
-function normalizeAssetForDisplayDecimals(asset: string): string {
-  const upperAsset = asset.toUpperCase();
-  if (upperAsset.startsWith('AARB')) {
-    return upperAsset.slice('AARB'.length);
-  }
-  if (upperAsset.startsWith('VARIABLEDEBT')) {
-    return upperAsset.slice('VARIABLEDEBT'.length);
-  }
-  if (upperAsset.startsWith('STABLEDEBT')) {
-    return upperAsset.slice('STABLEDEBT'.length);
-  }
-  return upperAsset;
-}
-
-function buildTokenDisplayQuantity(input: {
-  asset: string;
-  quantity: string;
-  explicitDisplayQuantity?: string | null;
-}): string | undefined {
-  if (input.explicitDisplayQuantity) {
-    return input.explicitDisplayQuantity;
-  }
-
-  if (!/^\d+$/.test(input.quantity)) {
-    return input.quantity;
-  }
-
-  const decimals = TOKEN_DECIMALS_BY_ASSET.get(normalizeAssetForDisplayDecimals(input.asset));
-  return decimals === undefined ? undefined : formatUnits(BigInt(input.quantity), decimals);
 }
 
 function readEconomicExposureInputs(value: unknown): PortfolioProjectionEconomicExposureInput[] {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -821,10 +821,13 @@ const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND = 'dispatch_spot_swap';
 const PORTFOLIO_MANAGER_SPOT_SWAP_COMMAND_DESCRIPTION = [
   'Dispatch a structured spot swap through the portfolio-manager owned hidden Onchain Actions executor.',
   'When using this command, put a JSON object string in inputJson with required fields walletAddress, amount, amountType, fromChain, toChain, fromToken, and toToken.',
-  'Optional fields are slippageTolerance, expiration, idempotencyKey, and rootedWalletContextId.',
+  'Optional fields are slippageTolerance, expiration, idempotencyKey, rootedWalletContextId, and capitalPool.',
   'amount should be a base-unit integer string; decimal token-unit strings are accepted only when token decimals are known.',
   'amountType must be "exactIn" or "exactOut"; for requests like "half my WETH" or "$3 of WETH", infer the token amount from current portfolio state when possible before dispatching.',
-  'Example inputJson: {"walletAddress":"0x...","amount":"894102247158860","amountType":"exactIn","fromChain":"arbitrum","toChain":"arbitrum","fromToken":"WETH","toToken":"USDC"}.',
+  'capitalPool may be "unassigned_only", "reserved_or_assigned", or "all"; use reserved_or_assigned when the user explicitly asks to use reserved or assigned units, and use all when the selected asset pool should include both free and reserved units.',
+  'Never suggest releasing or adjusting a reservation for spot swaps; dispatch with capitalPool instead and let the reserved-capital confirmation interrupt ask the user to proceed or retry with unassigned capital only.',
+  'Do not set reservationConflictHandling in inputJson; it is supplied only by the portfolio-manager conflict confirmation retry.',
+  'Example inputJson: {"walletAddress":"0x...","amount":"894102247158860","amountType":"exactIn","fromChain":"arbitrum","toChain":"arbitrum","fromToken":"WETH","toToken":"USDC","capitalPool":"reserved_or_assigned"}.',
 ].join(' ');
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE =
   'portfolio-manager-swap-reservation-conflict-request';
@@ -1832,6 +1835,12 @@ function readSpotSwapReservationConflictHandling(
   return { kind };
 }
 
+function readSpotSwapCapitalPool(value: unknown): HiddenOcaSpotSwapInput['capitalPool'] | null {
+  return value === 'unassigned_only' || value === 'reserved_or_assigned' || value === 'all'
+    ? value
+    : null;
+}
+
 function parseSpotSwapDispatchInput(input: unknown): HiddenOcaSpotSwapInput | null {
   if (!isRecord(input)) {
     return null;
@@ -1860,6 +1869,7 @@ function parseSpotSwapDispatchInput(input: unknown): HiddenOcaSpotSwapInput | nu
   const reservationConflictHandling = readSpotSwapReservationConflictHandling(
     input['reservationConflictHandling'],
   );
+  const capitalPool = readSpotSwapCapitalPool(input['capitalPool']);
 
   return {
     walletAddress,
@@ -1879,6 +1889,7 @@ function parseSpotSwapDispatchInput(input: unknown): HiddenOcaSpotSwapInput | nu
     ...(readString(input['rootedWalletContextId'])
       ? { rootedWalletContextId: readString(input['rootedWalletContextId'])! }
       : {}),
+    ...(capitalPool ? { capitalPool } : {}),
     ...(reservationConflictHandling ? { reservationConflictHandling } : {}),
   };
 }
@@ -1928,6 +1939,52 @@ function buildSpotSwapCompletionMessage(status: HiddenOcaSpotSwapResult['status'
     default:
       return 'Spot swap execution finished through the portfolio manager.';
   }
+}
+
+function shouldConfirmSpotSwapReservedCapital(dispatch: HiddenOcaSpotSwapInput): boolean {
+  return dispatch.capitalPool === 'reserved_or_assigned' || dispatch.capitalPool === 'all';
+}
+
+function buildSpotSwapDispatchSummary(
+  dispatch: HiddenOcaSpotSwapInput,
+): HiddenOcaSpotSwapResult['swapSummary'] {
+  return {
+    fromToken: dispatch.fromToken,
+    toToken: dispatch.toToken,
+    amount: dispatch.amount,
+    amountType: dispatch.amountType,
+    displayFromAmount: '',
+    displayToAmount: '',
+  };
+}
+
+function buildSpotSwapReservedCapitalConfirmationResult(input: {
+  currentState: PortfolioManagerLifecycleState;
+  dispatch: HiddenOcaSpotSwapInput;
+}) {
+  const conflict: NonNullable<HiddenOcaSpotSwapResult['conflict']> = {
+    kind: 'reserved_for_other_agent',
+    blockingReasonCode: 'reserved_for_other_agent',
+    reservationId: null,
+    message:
+      input.dispatch.capitalPool === 'all'
+        ? 'The selected swap pool includes capital reserved for another agent.'
+        : 'The requested swap capital is reserved for another agent.',
+    retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+  };
+
+  return buildSpotSwapOperationResult({
+    currentState: input.currentState,
+    dispatch: input.dispatch,
+    result: {
+      status: 'conflict',
+      swapSummary: buildSpotSwapDispatchSummary(input.dispatch),
+      transactionPlanId: null,
+      requestId: null,
+      committedEventIds: [],
+      conflict,
+    },
+  });
 }
 
 function buildSpotSwapOperationResult(input: {
@@ -3728,6 +3785,13 @@ export function createPortfolioManagerDomain(
                 },
               },
             };
+          }
+
+          if (shouldConfirmSpotSwapReservedCapital(dispatch)) {
+            return buildSpotSwapReservedCapitalConfirmationResult({
+              currentState,
+              dispatch,
+            });
           }
 
           const result = await options.hiddenOcaSpotSwapExecutor.executeSpotSwap({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -833,6 +833,13 @@ const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE =
   'portfolio-manager-swap-reservation-conflict-request';
 const PORTFOLIO_MANAGER_SWAP_CONFLICT_MESSAGE =
   'This swap would touch capital reserved for another agent. Confirm whether to proceed or retry with unassigned capital only.';
+const PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_DESCRIPTION = [
+  'Ask whether a spot swap may touch capital reserved for another agent or should retry with unassigned capital only.',
+  'When this interrupt is pending and the user says yes, confirm, proceed, or equivalent, answer this interrupt with inputJson {"outcome":"allow_reserved_for_other_agent"}.',
+  'When the user asks for unassigned/free capital only, answer this interrupt with inputJson {"outcome":"unassigned_only"}.',
+  'When the user cancels, answer this interrupt with inputJson {"outcome":"cancel"}.',
+  'Do not repeat dispatch_spot_swap for a pending reserved-capital confirmation.',
+].join(' ');
 const PORTFOLIO_MANAGER_ROOT_AUTHORITY = ROOT_AUTHORITY;
 const PORTFOLIO_MANAGER_DELEGATION_SALT =
   '0x1111111111111111111111111111111111111111111111111111111111111111';
@@ -2836,8 +2843,7 @@ export function createPortfolioManagerDomain(
         },
         {
           type: PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE,
-          description:
-            'Ask whether a spot swap may touch capital reserved for another agent or should retry with unassigned capital only.',
+          description: PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_DESCRIPTION,
           mirroredToActivity: false,
         },
       ],
@@ -2903,6 +2909,36 @@ export function createPortfolioManagerDomain(
         context.push(
           `  <pending_onboarding_wallet_address source="onboarding_setup">${currentState.pendingOnboardingWalletAddress}</pending_onboarding_wallet_address>`,
         );
+      }
+
+      if (currentState.pendingSpotSwapConflict) {
+        context.push('  <pending_spot_swap_conflict>');
+        context.push(
+          `    <confirmation_operation>${PORTFOLIO_MANAGER_SWAP_CONFLICT_INTERRUPT_TYPE}</confirmation_operation>`,
+        );
+        context.push(
+          '    <affirmative_user_reply_outcome>allow_reserved_for_other_agent</affirmative_user_reply_outcome>',
+        );
+        context.push(
+          '    <unassigned_only_user_reply_outcome>unassigned_only</unassigned_only_user_reply_outcome>',
+        );
+        context.push('    <cancel_user_reply_outcome>cancel</cancel_user_reply_outcome>');
+        context.push(
+          '    <instruction>Do not call dispatch_spot_swap again for yes/confirm/proceed replies. Answer this pending interrupt with outcome allow_reserved_for_other_agent.</instruction>',
+        );
+        appendStructuredXmlNode({
+          lines: context,
+          indent: '    ',
+          tag: 'dispatch',
+          value: currentState.pendingSpotSwapConflict.dispatch,
+        });
+        appendStructuredXmlNode({
+          lines: context,
+          indent: '    ',
+          tag: 'conflict',
+          value: currentState.pendingSpotSwapConflict.conflict,
+        });
+        context.push('  </pending_spot_swap_conflict>');
       }
 
       const approvedSetup = readApprovedSetupFromOnboardingBootstrap(

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -3577,6 +3577,282 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
+  it('dispatches structured spot swaps through the hidden OCA executor with the selected rooted wallet context', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'submitted' as const,
+        swapSummary: {
+          fromToken: 'USDC',
+          toToken: 'WETH',
+          amount: '1000000',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '1',
+          displayToAmount: '0.0003',
+        },
+        transactionPlanId: 'txplan-hidden-swap-001',
+        requestId: 'req-hidden-swap-001',
+        transactionHash: '0xsubmittedswap',
+        committedEventIds: ['evt-hidden-swap-1'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+        },
+        operation: {
+          source: 'command',
+          name: 'dispatch_spot_swap',
+          input: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '1000000',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'USDC',
+            toToken: 'WETH',
+            slippageTolerance: '0.5',
+            idempotencyKey: 'idem-hidden-swap-001',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 8,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Spot swap submitted through the portfolio manager.',
+        },
+        artifacts: [
+          {
+            data: {
+              type: 'hidden-oca-spot-swap',
+              status: 'submitted',
+              transactionPlanId: 'txplan-hidden-swap-001',
+              requestId: 'req-hidden-swap-001',
+              transactionHash: '0xsubmittedswap',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      currentRevision: 8,
+      input: {
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '1000000',
+        amountType: 'exactIn',
+        fromChain: 'arbitrum',
+        toChain: 'arbitrum',
+        fromToken: 'USDC',
+        toToken: 'WETH',
+        slippageTolerance: '0.5',
+        idempotencyKey: 'idem-hidden-swap-001',
+        rootedWalletContextId: 'rwc-user-protocol-001',
+      },
+    });
+  });
+
+  it('interrupts for PM-routed reserved-capital confirmation and stores the exact swap retry', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'conflict' as const,
+        swapSummary: {
+          fromToken: 'USDC',
+          toToken: 'WETH',
+          amount: '1000000',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '1',
+          displayToAmount: '0.0003',
+        },
+        transactionPlanId: 'txplan-hidden-swap-001',
+        requestId: 'req-hidden-swap-001',
+        committedEventIds: ['evt-hidden-swap-conflict-1'],
+        conflict: {
+          kind: 'reserved_for_other_agent' as const,
+          blockingReasonCode: 'reserved_for_other_agent',
+          reservationId: 'res-ember-lending-001',
+          message: 'USDC is reserved for another agent.',
+          retryOptions: ['allow_reserved_for_other_agent' as const, 'unassigned_only' as const],
+        },
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+        },
+        operation: {
+          source: 'command',
+          name: 'dispatch_spot_swap',
+          input: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '1000000',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'USDC',
+            toToken: 'WETH',
+            idempotencyKey: 'idem-hidden-swap-001',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        pendingSpotSwapConflict: {
+          dispatch: {
+            idempotencyKey: 'idem-hidden-swap-001',
+            rootedWalletContextId: 'rwc-user-protocol-001',
+          },
+          conflict: {
+            reservationId: 'res-ember-lending-001',
+          },
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'interrupted',
+          statusMessage:
+            'This swap would touch capital reserved for another agent. Confirm whether to proceed or retry with unassigned capital only.',
+        },
+        interrupt: {
+          type: 'portfolio-manager-swap-reservation-conflict-request',
+          mirroredToActivity: false,
+          payload: {
+            retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+          },
+        },
+      },
+    });
+  });
+
+  it('re-dispatches the exact pending swap after conflict-only user confirmation', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'completed' as const,
+        swapSummary: {
+          fromToken: 'USDC',
+          toToken: 'WETH',
+          amount: '1000000',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '1',
+          displayToAmount: '0.0003',
+        },
+        transactionPlanId: 'txplan-hidden-swap-001',
+        requestId: 'req-hidden-swap-001',
+        transactionHash: '0xconfirmed',
+        committedEventIds: ['evt-hidden-swap-2'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          pendingSpotSwapConflict: {
+            dispatch: {
+              walletAddress: '0x00000000000000000000000000000000000000a1',
+              amount: '1000000',
+              amountType: 'exactIn',
+              fromChain: 'arbitrum',
+              toChain: 'arbitrum',
+              fromToken: 'USDC',
+              toToken: 'WETH',
+              idempotencyKey: 'idem-hidden-swap-001',
+              rootedWalletContextId: 'rwc-user-protocol-001',
+            },
+            conflict: {
+              kind: 'reserved_for_other_agent',
+              blockingReasonCode: 'reserved_for_other_agent',
+              reservationId: 'res-ember-lending-001',
+              message: 'USDC is reserved for another agent.',
+              retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+            },
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-swap-reservation-conflict-request',
+          input: {
+            outcome: 'unassigned_only',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        pendingSpotSwapConflict: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Spot swap completed through the portfolio manager.',
+        },
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      currentRevision: 8,
+      input: {
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '1000000',
+        amountType: 'exactIn',
+        fromChain: 'arbitrum',
+        toChain: 'arbitrum',
+        fromToken: 'USDC',
+        toToken: 'WETH',
+        idempotencyKey: 'idem-hidden-swap-001',
+        rootedWalletContextId: 'rwc-user-protocol-001',
+        reservationConflictHandling: {
+          kind: 'unassigned_only',
+        },
+      },
+    });
+  });
+
   it('signs, registers, and acknowledges redelegation work from the committed outbox', async () => {
     const rootSignedDelegation = createSignedRootDelegation(
       '0x00000000000000000000000000000000000000c1',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -3723,6 +3723,108 @@ describe('createPortfolioManagerDomain', () => {
     expect(hiddenExecutor.executeSpotSwap).not.toHaveBeenCalled();
   });
 
+  it('interrupts before execution when the selected swap pool includes reserved capital', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'submitted' as const,
+        swapSummary: {
+          fromToken: 'WETH',
+          toToken: 'USDC',
+          amount: '680295188055654',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '0.000680295188055654',
+          displayToAmount: '2.1',
+        },
+        transactionPlanId: 'txplan-hidden-swap-should-not-run',
+        requestId: 'req-hidden-swap-should-not-run',
+        committedEventIds: ['evt-hidden-swap-should-not-run'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 9,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+        },
+        operation: {
+          source: 'command',
+          name: 'dispatch_spot_swap',
+          input: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '680295188055654',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'WETH',
+            toToken: 'USDC',
+            capitalPool: 'reserved_or_assigned',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        pendingSpotSwapConflict: {
+          dispatch: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '680295188055654',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'WETH',
+            toToken: 'USDC',
+            rootedWalletContextId: 'rwc-user-protocol-001',
+            capitalPool: 'reserved_or_assigned',
+          },
+          conflict: {
+            kind: 'reserved_for_other_agent',
+            blockingReasonCode: 'reserved_for_other_agent',
+            reservationId: null,
+            retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+          },
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'interrupted',
+          statusMessage:
+            'This swap would touch capital reserved for another agent. Confirm whether to proceed or retry with unassigned capital only.',
+        },
+        interrupt: {
+          type: 'portfolio-manager-swap-reservation-conflict-request',
+          mirroredToActivity: false,
+          payload: {
+            swap: {
+              fromToken: 'WETH',
+              toToken: 'USDC',
+              amount: '680295188055654',
+              amountType: 'exactIn',
+            },
+            conflict: {
+              kind: 'reserved_for_other_agent',
+              blockingReasonCode: 'reserved_for_other_agent',
+              reservationId: null,
+            },
+            retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+          },
+        },
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).not.toHaveBeenCalled();
+  });
+
   it('interrupts for PM-routed reserved-capital confirmation and stores the exact swap retry', async () => {
     const hiddenExecutor = {
       executeSpotSwap: vi.fn(async () => ({

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -4164,6 +4164,102 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
+  it('re-dispatches reserved-capital confirmations through the tool-callable confirmation command', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'completed' as const,
+        swapSummary: {
+          fromToken: 'WETH',
+          toToken: 'WBTC',
+          amount: '680295188055654',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '0.000680295188055654',
+          displayToAmount: '0.000005',
+        },
+        transactionPlanId: 'txplan-hidden-swap-reserved-002',
+        requestId: 'req-hidden-swap-reserved-002',
+        transactionHash: '0xconfirmedreservedcommand',
+        committedEventIds: ['evt-hidden-swap-reserved-command-2'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 9,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          pendingSpotSwapConflict: {
+            dispatch: {
+              walletAddress: '0x00000000000000000000000000000000000000a1',
+              amount: '680295188055654',
+              amountType: 'exactIn',
+              fromChain: 'arbitrum',
+              toChain: 'arbitrum',
+              fromToken: 'WETH',
+              toToken: 'WBTC',
+              capitalPool: 'reserved_or_assigned',
+              rootedWalletContextId: 'rwc-user-protocol-001',
+            },
+            conflict: {
+              kind: 'reserved_for_other_agent',
+              blockingReasonCode: 'reserved_for_other_agent',
+              reservationId: 'res-ember-lending-weth-001',
+              message: 'WETH is reserved for another agent.',
+              retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+            },
+          },
+        },
+        operation: {
+          source: 'tool',
+          name: 'confirm_spot_swap_reserved_capital',
+          input: {
+            outcome: 'allow_reserved_for_other_agent',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        pendingSpotSwapConflict: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Spot swap completed through the portfolio manager.',
+        },
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      currentRevision: 9,
+      input: {
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '680295188055654',
+        amountType: 'exactIn',
+        fromChain: 'arbitrum',
+        toChain: 'arbitrum',
+        fromToken: 'WETH',
+        toToken: 'WBTC',
+        capitalPool: 'reserved_or_assigned',
+        rootedWalletContextId: 'rwc-user-protocol-001',
+        reservationConflictHandling: {
+          kind: 'allow_reserved_for_other_agent',
+        },
+      },
+    });
+  });
+
   it('signs, registers, and acknowledges redelegation work from the committed outbox', async () => {
     const rootSignedDelegation = createSignedRootDelegation(
       '0x00000000000000000000000000000000000000c1',
@@ -5019,10 +5115,11 @@ describe('createPortfolioManagerDomain', () => {
       expect.arrayContaining([
         '  <pending_spot_swap_conflict>',
         '    <confirmation_operation>portfolio-manager-swap-reservation-conflict-request</confirmation_operation>',
+        '    <tool_command>confirm_spot_swap_reserved_capital</tool_command>',
         '    <affirmative_user_reply_outcome>allow_reserved_for_other_agent</affirmative_user_reply_outcome>',
         '    <unassigned_only_user_reply_outcome>unassigned_only</unassigned_only_user_reply_outcome>',
         '    <cancel_user_reply_outcome>cancel</cancel_user_reply_outcome>',
-        '    <instruction>Do not call dispatch_spot_swap again for yes/confirm/proceed replies. Answer this pending interrupt with outcome allow_reserved_for_other_agent.</instruction>',
+        '    <instruction>Do not call dispatch_spot_swap again for yes/confirm/proceed replies. Use confirm_spot_swap_reserved_capital with outcome allow_reserved_for_other_agent.</instruction>',
         '    <dispatch>',
         '      <fromToken>WETH</fromToken>',
         '      <toToken>WBTC</toToken>',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -3671,10 +3671,63 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
+  it('rejects initial spot swap dispatches that try to pre-authorize reserved-capital conflict handling', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+        },
+        operation: {
+          source: 'command',
+          name: 'dispatch_spot_swap',
+          input: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '1000000',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'USDC',
+            toToken: 'WETH',
+            reservationConflictHandling: {
+              kind: 'allow_reserved_for_other_agent',
+            },
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Spot swap reserved-capital conflict handling can only be supplied by the portfolio-manager conflict confirmation retry.',
+        },
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).not.toHaveBeenCalled();
+  });
+
   it('interrupts for PM-routed reserved-capital confirmation and stores the exact swap retry', async () => {
     const hiddenExecutor = {
       executeSpotSwap: vi.fn(async () => ({
         status: 'conflict' as const,
+        idempotencyKey: 'idem-generated-hidden-swap-001',
         swapSummary: {
           fromToken: 'USDC',
           toToken: 'WETH',
@@ -3724,7 +3777,6 @@ describe('createPortfolioManagerDomain', () => {
             toChain: 'arbitrum',
             fromToken: 'USDC',
             toToken: 'WETH',
-            idempotencyKey: 'idem-hidden-swap-001',
           },
         },
       }),
@@ -3732,7 +3784,7 @@ describe('createPortfolioManagerDomain', () => {
       state: {
         pendingSpotSwapConflict: {
           dispatch: {
-            idempotencyKey: 'idem-hidden-swap-001',
+            idempotencyKey: 'idem-generated-hidden-swap-001',
             rootedWalletContextId: 'rwc-user-protocol-001',
           },
           conflict: {
@@ -3752,6 +3804,67 @@ describe('createPortfolioManagerDomain', () => {
           payload: {
             retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
           },
+        },
+      },
+    });
+  });
+
+  it('does not report hidden spot swaps as completed while executor redelegation remains pending', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'awaiting_redelegation' as const,
+        swapSummary: {
+          fromToken: 'USDC',
+          toToken: 'WETH',
+          amount: '1000000',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '1',
+          displayToAmount: '0.0003',
+        },
+        transactionPlanId: 'txplan-hidden-swap-001',
+        requestId: 'req-hidden-swap-001',
+        committedEventIds: ['evt-hidden-swap-redelegation-1'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 8,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+        },
+        operation: {
+          source: 'command',
+          name: 'dispatch_spot_swap',
+          input: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '1000000',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'USDC',
+            toToken: 'WETH',
+            idempotencyKey: 'idem-hidden-swap-001',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      outputs: {
+        status: {
+          executionStatus: 'failed',
+          statusMessage:
+            'Spot swap execution is waiting for Shared Ember redelegation readiness and was not completed.',
         },
       },
     });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -4059,7 +4059,7 @@ describe('createPortfolioManagerDomain', () => {
         toChain: 'arbitrum',
         fromToken: 'USDC',
         toToken: 'WETH',
-        idempotencyKey: 'idem-hidden-swap-001',
+        idempotencyKey: 'idem-hidden-swap-001:reserved-capital-confirmation:unassigned_only',
         rootedWalletContextId: 'rwc-user-protocol-001',
         reservationConflictHandling: {
           kind: 'unassigned_only',
@@ -4257,6 +4257,84 @@ describe('createPortfolioManagerDomain', () => {
           kind: 'allow_reserved_for_other_agent',
         },
       },
+    });
+  });
+
+  it('uses a distinct idempotency key for confirmed reserved-capital retries', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'completed' as const,
+        swapSummary: {
+          fromToken: 'WETH',
+          toToken: 'USDC',
+          amount: '100000',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '0.0001',
+          displayToAmount: '0.22',
+        },
+        transactionPlanId: 'txplan-hidden-swap-confirmed-idem-001',
+        requestId: 'req-hidden-swap-confirmed-idem-001',
+        transactionHash: '0xconfirmedreservedidem',
+        committedEventIds: ['evt-hidden-swap-confirmed-idem-2'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await domain.handleOperation?.({
+      threadId: 'thread-1',
+      state: {
+        phase: 'active',
+        lastPortfolioState: null,
+        lastSharedEmberRevision: 9,
+        lastRootDelegation: null,
+        lastOnboardingBootstrap: createOnboardingBootstrap(),
+        lastRootedWalletContextId: 'rwc-user-protocol-001',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: null,
+        pendingSpotSwapConflict: {
+          dispatch: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '100000',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'WETH',
+            toToken: 'USDC',
+            capitalPool: 'all',
+            idempotencyKey: 'idem-hidden-oca-swap-user-selected-001',
+            rootedWalletContextId: 'rwc-user-protocol-001',
+          },
+          conflict: {
+            kind: 'reserved_for_other_agent',
+            blockingReasonCode: 'reserved_for_other_agent',
+            reservationId: 'res-ember-lending-weth-001',
+            message: 'WETH is reserved for another agent.',
+            retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+          },
+        },
+      },
+      operation: {
+        source: 'tool',
+        name: 'confirm_spot_swap_reserved_capital',
+        input: {
+          outcome: 'allow_reserved_for_other_agent',
+        },
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      currentRevision: 9,
+      input: expect.objectContaining({
+        idempotencyKey:
+          'idem-hidden-oca-swap-user-selected-001:reserved-capital-confirmation:allow_reserved_for_other_agent',
+        reservationConflictHandling: {
+          kind: 'allow_reserved_for_other_agent',
+        },
+      }),
     });
   });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -4068,6 +4068,102 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
+  it('re-dispatches reserved-capital confirmations with the privileged executor allowance', async () => {
+    const hiddenExecutor = {
+      executeSpotSwap: vi.fn(async () => ({
+        status: 'completed' as const,
+        swapSummary: {
+          fromToken: 'WETH',
+          toToken: 'USDC',
+          amount: '680295188055654',
+          amountType: 'exactIn' as const,
+          displayFromAmount: '0.000680295188055654',
+          displayToAmount: '2.1',
+        },
+        transactionPlanId: 'txplan-hidden-swap-reserved-001',
+        requestId: 'req-hidden-swap-reserved-001',
+        transactionHash: '0xconfirmedreserved',
+        committedEventIds: ['evt-hidden-swap-reserved-2'],
+      })),
+    };
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+      hiddenOcaSpotSwapExecutor: hiddenExecutor,
+    });
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 9,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          pendingSpotSwapConflict: {
+            dispatch: {
+              walletAddress: '0x00000000000000000000000000000000000000a1',
+              amount: '680295188055654',
+              amountType: 'exactIn',
+              fromChain: 'arbitrum',
+              toChain: 'arbitrum',
+              fromToken: 'WETH',
+              toToken: 'USDC',
+              capitalPool: 'reserved_or_assigned',
+              rootedWalletContextId: 'rwc-user-protocol-001',
+            },
+            conflict: {
+              kind: 'reserved_for_other_agent',
+              blockingReasonCode: 'reserved_for_other_agent',
+              reservationId: 'res-ember-lending-weth-001',
+              message: 'WETH is reserved for another agent.',
+              retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+            },
+          },
+        },
+        operation: {
+          source: 'interrupt',
+          name: 'portfolio-manager-swap-reservation-conflict-request',
+          input: {
+            outcome: 'allow_reserved_for_other_agent',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        pendingSpotSwapConflict: null,
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage: 'Spot swap completed through the portfolio manager.',
+        },
+      },
+    });
+
+    expect(hiddenExecutor.executeSpotSwap).toHaveBeenCalledWith({
+      threadId: 'thread-1',
+      currentRevision: 9,
+      input: {
+        walletAddress: '0x00000000000000000000000000000000000000a1',
+        amount: '680295188055654',
+        amountType: 'exactIn',
+        fromChain: 'arbitrum',
+        toChain: 'arbitrum',
+        fromToken: 'WETH',
+        toToken: 'USDC',
+        capitalPool: 'reserved_or_assigned',
+        rootedWalletContextId: 'rwc-user-protocol-001',
+        reservationConflictHandling: {
+          kind: 'allow_reserved_for_other_agent',
+        },
+      },
+    });
+  });
+
   it('signs, registers, and acknowledges redelegation work from the committed outbox', async () => {
     const rootSignedDelegation = createSignedRootDelegation(
       '0x00000000000000000000000000000000000000c1',

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -4974,6 +4974,66 @@ describe('createPortfolioManagerDomain', () => {
     );
   });
 
+  it('surfaces pending reserved-capital swap confirmation instructions in system context', async () => {
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+    });
+
+    const context = await domain.systemContext?.({
+      threadId: 'thread-1',
+      state: {
+        phase: 'active',
+        lastPortfolioState: null,
+        lastSharedEmberRevision: 9,
+        lastRootDelegation: {
+          root_delegation_id: 'root-a1',
+        },
+        lastOnboardingBootstrap: createOnboardingBootstrap(),
+        lastRootedWalletContextId: 'rwc-user-protocol-001',
+        activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+        pendingOnboardingWalletAddress: null,
+        pendingSpotSwapConflict: {
+          dispatch: {
+            walletAddress: '0x00000000000000000000000000000000000000a1',
+            amount: '680295188055654',
+            amountType: 'exactIn',
+            fromChain: 'arbitrum',
+            toChain: 'arbitrum',
+            fromToken: 'WETH',
+            toToken: 'WBTC',
+            capitalPool: 'reserved_or_assigned',
+            rootedWalletContextId: 'rwc-user-protocol-001',
+          },
+          conflict: {
+            kind: 'reserved_for_other_agent',
+            blockingReasonCode: 'reserved_for_other_agent',
+            reservationId: 'res-ember-lending-weth-001',
+            message: 'WETH is reserved for another agent.',
+            retryOptions: ['allow_reserved_for_other_agent', 'unassigned_only'],
+          },
+        },
+      },
+    });
+
+    expect(context).toEqual(
+      expect.arrayContaining([
+        '  <pending_spot_swap_conflict>',
+        '    <confirmation_operation>portfolio-manager-swap-reservation-conflict-request</confirmation_operation>',
+        '    <affirmative_user_reply_outcome>allow_reserved_for_other_agent</affirmative_user_reply_outcome>',
+        '    <unassigned_only_user_reply_outcome>unassigned_only</unassigned_only_user_reply_outcome>',
+        '    <cancel_user_reply_outcome>cancel</cancel_user_reply_outcome>',
+        '    <instruction>Do not call dispatch_spot_swap again for yes/confirm/proceed replies. Answer this pending interrupt with outcome allow_reserved_for_other_agent.</instruction>',
+        '    <dispatch>',
+        '      <fromToken>WETH</fromToken>',
+        '      <toToken>WBTC</toToken>',
+        '      <capitalPool>reserved_or_assigned</capitalPool>',
+        '    <conflict>',
+        '      <reservationId>res-ember-lending-weth-001</reservationId>',
+        '  </pending_spot_swap_conflict>',
+      ]),
+    );
+  });
+
   it('appends aggregated live Shared Ember accounting context to the system prompt context when a wallet is active', async () => {
     const onboardingBootstrap = {
       ...createOnboardingBootstrap(),

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.ts
@@ -1,4 +1,5 @@
 import type { PortfolioManagerSharedEmberProtocolHost } from './sharedEmberAdapter.js';
+import { buildTokenDisplayQuantity } from './tokenQuantityDisplay.js';
 
 export const PORTFOLIO_MANAGER_SHARED_EMBER_NETWORK = 'arbitrum';
 export const PORTFOLIO_MANAGER_DEFAULT_ACCOUNTING_AGENT_ID = 'ember-lending';
@@ -89,6 +90,7 @@ export type PortfolioManagerWalletAccountingDetails = {
     unitId: string;
     asset: string;
     quantity: string;
+    displayQuantity?: string;
     status: string;
     controlPath: string;
     reservationId: string | null;
@@ -103,6 +105,7 @@ export type PortfolioManagerWalletAccountingDetails = {
       unitId: string;
       asset: string;
       quantity: string;
+      displayQuantity?: string;
     }>;
   }>;
 };
@@ -190,25 +193,42 @@ export function buildPortfolioManagerWalletAccountingDetails(input: {
   const unitsById = new Map(
     (input.onboardingState.owned_units ?? []).map((ownedUnit) => [ownedUnit.unit_id, ownedUnit] as const),
   );
-  const assets = (input.onboardingState.owned_units ?? []).map((ownedUnit) => ({
-    unitId: ownedUnit.unit_id,
-    asset: ownedUnit.root_asset,
-    quantity: ownedUnit.quantity,
-    status: ownedUnit.status,
-    controlPath: ownedUnit.control_path,
-    reservationId: ownedUnit.reservation_id,
-  }));
+  const assets = (input.onboardingState.owned_units ?? []).map((ownedUnit) => {
+    const displayQuantity = buildTokenDisplayQuantity({
+      asset: ownedUnit.root_asset,
+      quantity: ownedUnit.quantity,
+    });
+
+    return {
+      unitId: ownedUnit.unit_id,
+      asset: ownedUnit.root_asset,
+      quantity: ownedUnit.quantity,
+      ...(displayQuantity !== undefined ? { displayQuantity } : {}),
+      status: ownedUnit.status,
+      controlPath: ownedUnit.control_path,
+      reservationId: ownedUnit.reservation_id,
+    };
+  });
   const reservations = (input.onboardingState.reservations ?? []).map((reservation) => ({
     reservationId: reservation.reservation_id,
     agentId: reservation.agent_id,
     purpose: reservation.purpose,
     status: reservation.status,
     controlPath: reservation.control_path,
-    allocations: reservation.unit_allocations.map((allocation) => ({
-      unitId: allocation.unit_id,
-      asset: unitsById.get(allocation.unit_id)?.root_asset ?? 'unknown',
-      quantity: allocation.quantity,
-    })),
+    allocations: reservation.unit_allocations.map((allocation) => {
+      const asset = unitsById.get(allocation.unit_id)?.root_asset ?? 'unknown';
+      const displayQuantity = buildTokenDisplayQuantity({
+        asset,
+        quantity: allocation.quantity,
+      });
+
+      return {
+        unitId: allocation.unit_id,
+        asset,
+        quantity: allocation.quantity,
+        ...(displayQuantity !== undefined ? { displayQuantity } : {}),
+      };
+    }),
   }));
 
   return {
@@ -274,6 +294,9 @@ export function buildSharedEmberAccountingContextXml(input:
     );
     lines.push(`      <root_asset>${escapeXml(asset.asset)}</root_asset>`);
     lines.push(`      <quantity>${escapeXml(asset.quantity)}</quantity>`);
+    if (asset.displayQuantity) {
+      lines.push(`      <display_quantity>${escapeXml(asset.displayQuantity)}</display_quantity>`);
+    }
     lines.push(`      <status>${escapeXml(asset.status)}</status>`);
     lines.push(`      <control_path>${escapeXml(asset.controlPath)}</control_path>`);
     lines.push('    </asset>');
@@ -292,6 +315,11 @@ export function buildSharedEmberAccountingContextXml(input:
       lines.push(`        <allocation unit_id="${escapeXml(allocation.unitId)}">`);
       lines.push(`          <asset>${escapeXml(allocation.asset)}</asset>`);
       lines.push(`          <quantity>${escapeXml(allocation.quantity)}</quantity>`);
+      if (allocation.displayQuantity) {
+        lines.push(
+          `          <display_quantity>${escapeXml(allocation.displayQuantity)}</display_quantity>`,
+        );
+      }
       lines.push('        </allocation>');
     }
     lines.push('      </allocations>');

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberOnboardingState.unit.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolvePortfolioManagerAccountingAgentId } from './sharedEmberOnboardingState.js';
+import {
+  buildPortfolioManagerWalletAccountingDetails,
+  buildSharedEmberAccountingContextXml,
+  resolvePortfolioManagerAccountingAgentId,
+} from './sharedEmberOnboardingState.js';
 
 describe('resolvePortfolioManagerAccountingAgentId', () => {
   it('uses the activated durable managed mandate when onboarding names a mandate ref', () => {
@@ -41,5 +45,53 @@ describe('resolvePortfolioManagerAccountingAgentId', () => {
         },
       }),
     ).toBe('ember-lending');
+  });
+
+  it('includes display quantities in the Shared Ember accounting context', () => {
+    const details = buildPortfolioManagerWalletAccountingDetails({
+      revision: 10,
+      onboardingState: {
+        wallet_address: '0x00000000000000000000000000000000000000a1',
+        network: 'arbitrum',
+        phase: 'active',
+        proofs: {
+          rooted_wallet_context_registered: true,
+          root_delegation_registered: true,
+          root_authority_active: true,
+          wallet_baseline_observed: true,
+          accounting_units_seeded: true,
+          mandate_inputs_configured: true,
+          reserve_policy_configured: true,
+          capital_reserved_for_agent: true,
+          policy_snapshot_recorded: true,
+          agent_active: true,
+        },
+        owned_units: [
+          {
+            unit_id: 'unit-wbtc-ingress-a1',
+            root_asset: 'WBTC',
+            quantity: '2792',
+            status: 'free',
+            control_path: 'unassigned',
+            reservation_id: null,
+          },
+        ],
+        reservations: [],
+      },
+    });
+
+    expect(details.assets).toMatchObject([
+      {
+        asset: 'WBTC',
+        quantity: '2792',
+        displayQuantity: '0.00002792',
+      },
+    ]);
+    expect(
+      buildSharedEmberAccountingContextXml({
+        status: 'live',
+        details,
+      }).join('\n'),
+    ).toContain('<display_quantity>0.00002792</display_quantity>');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/tokenQuantityDisplay.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/tokenQuantityDisplay.ts
@@ -1,0 +1,58 @@
+import { formatUnits } from 'viem';
+
+const TOKEN_DECIMALS_BY_ASSET = new Map<string, number>([
+  ['ETH', 18],
+  ['WETH', 18],
+  ['USDC', 6],
+  ['USDCN', 6],
+  ['USDT', 6],
+  ['WBTC', 8],
+]);
+
+function normalizeAssetForDisplayDecimals(asset: string): string {
+  const upperAsset = asset.toUpperCase();
+  if (upperAsset.startsWith('AARB')) {
+    return upperAsset.slice('AARB'.length);
+  }
+  if (upperAsset.startsWith('VARIABLEDEBT')) {
+    return upperAsset.slice('VARIABLEDEBT'.length);
+  }
+  if (upperAsset.startsWith('STABLEDEBT')) {
+    return upperAsset.slice('STABLEDEBT'.length);
+  }
+  return upperAsset;
+}
+
+export function buildTokenDisplayQuantity(input: {
+  asset: string;
+  quantity: string;
+  explicitDisplayQuantity?: string | null;
+}): string | undefined {
+  if (input.explicitDisplayQuantity) {
+    return input.explicitDisplayQuantity;
+  }
+
+  if (!/^\d+$/.test(input.quantity)) {
+    return input.quantity;
+  }
+
+  const decimals = TOKEN_DECIMALS_BY_ASSET.get(normalizeAssetForDisplayDecimals(input.asset));
+  return decimals === undefined ? undefined : formatUnits(BigInt(input.quantity), decimals);
+}
+
+export function formatTokenQuantityForAgentSummary(input: {
+  asset: string;
+  quantity: string;
+}): string {
+  const displayQuantity = buildTokenDisplayQuantity(input);
+
+  if (displayQuantity === undefined) {
+    return `${input.quantity} ${input.asset}`;
+  }
+
+  if (/^\d+$/.test(input.quantity) && displayQuantity !== input.quantity) {
+    return `${displayQuantity} ${input.asset} (${input.quantity} base units)`;
+  }
+
+  return `${displayQuantity} ${input.asset}`;
+}

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.int.test.ts
@@ -147,7 +147,7 @@ describeSharedEmberIntegration('wallet accounting tool Shared Ember integration'
       content: [
         {
           type: 'text',
-          text: expect.stringContaining('10 USDC'),
+          text: expect.stringContaining('0.00001 USDC (10 base units)'),
         },
       ],
       details: {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.ts
@@ -8,6 +8,7 @@ import {
   readManagedAgentAccountingState,
   type PortfolioManagerWalletAccountingDetails,
 } from './sharedEmberOnboardingState.js';
+import { formatTokenQuantityForAgentSummary } from './tokenQuantityDisplay.js';
 
 type PortfolioManagerAgentTool = NonNullable<CreateAgentRuntimeOptions['tools']>[number];
 
@@ -44,12 +45,15 @@ function buildWalletAccountingSummary(
   }
 
   const assetSummary = details.assets
-    .map((asset) => `${asset.quantity} ${asset.asset} (${asset.status}, ${asset.controlPath})`)
+    .map(
+      (asset) =>
+        `${formatTokenQuantityForAgentSummary(asset)} (${asset.status}, ${asset.controlPath})`,
+    )
     .join(', ');
   const reservationSummary = details.reservations
     .map((reservation) => {
       const allocationSummary = reservation.allocations
-        .map((allocation) => `${allocation.quantity} ${allocation.asset}`)
+        .map((allocation) => formatTokenQuantityForAgentSummary(allocation))
         .join(', ');
       return `${allocationSummary} reserved for ${reservation.agentId} (${reservation.status}, ${reservation.controlPath})`;
     })

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletAccountingTool.unit.test.ts
@@ -96,7 +96,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
       content: [
         {
           type: 'text',
-          text: expect.stringContaining('10 USDC'),
+          text: expect.stringContaining('0.00001 USDC (10 base units)'),
         },
       ],
       details: {
@@ -113,6 +113,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
           {
             asset: 'USDC',
             quantity: '10',
+            displayQuantity: '0.00001',
             status: 'reserved',
             controlPath: 'lending.supply',
           },
@@ -127,6 +128,7 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
                 unitId: 'unit-usdc-a1',
                 asset: 'USDC',
                 quantity: '10',
+                displayQuantity: '0.00001',
               },
             ],
           },
@@ -198,6 +200,102 @@ describe('createPortfolioManagerWalletAccountingTool', () => {
         },
         assets: [],
         reservations: [],
+      },
+    });
+  });
+
+  it('formats known integer token quantities as token units with base units in the agent summary', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'rpc-wallet-accounting-wbtc',
+        result: {
+          protocol_version: 'v1',
+          revision: 10,
+          onboarding_state: {
+            agent_id: 'ember-lending',
+            wallet_address: '0x00000000000000000000000000000000000000a1',
+            network: 'arbitrum',
+            phase: 'active',
+            proofs: {
+              rooted_wallet_context_registered: true,
+              root_delegation_registered: true,
+              root_authority_active: true,
+              wallet_baseline_observed: true,
+              accounting_units_seeded: true,
+              mandate_inputs_configured: true,
+              reserve_policy_configured: true,
+              capital_reserved_for_agent: true,
+              policy_snapshot_recorded: true,
+              agent_active: true,
+            },
+            rooted_wallet_context: {
+              rooted_wallet_context_id: 'rwc-portfolio-manager-a1',
+            },
+            root_delegation: {
+              root_delegation_id: 'root-delegation-portfolio-manager-a1',
+              status: 'active',
+            },
+            owned_units: [
+              {
+                unit_id: 'unit-wbtc-dust-a1',
+                root_asset: 'WBTC',
+                quantity: '3',
+                status: 'free',
+                control_path: 'unassigned',
+                reservation_id: null,
+              },
+              {
+                unit_id: 'unit-wbtc-ingress-a1',
+                root_asset: 'WBTC',
+                quantity: '2792',
+                status: 'free',
+                control_path: 'unassigned',
+                reservation_id: null,
+              },
+            ],
+            reservations: [],
+            policy_snapshots: [],
+          },
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(),
+      acknowledgeCommittedEventOutbox: vi.fn(),
+    };
+
+    const tool = createPortfolioManagerWalletAccountingTool({
+      protocolHost,
+      agentId: 'ember-lending',
+    });
+
+    const result = await tool.execute?.('tool-wallet-accounting-wbtc', {
+      walletAddress: '0x00000000000000000000000000000000000000a1',
+    });
+
+    expect(result).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: expect.stringContaining('0.00000003 WBTC (3 base units)'),
+        },
+      ],
+    });
+    expect(result?.content[0]?.text).toContain('0.00002792 WBTC (2792 base units)');
+    expect(result?.content[0]?.text).not.toContain('2792 WBTC (free, unassigned)');
+    expect(result).toMatchObject({
+      details: {
+        assets: [
+          {
+            asset: 'WBTC',
+            quantity: '3',
+            displayQuantity: '0.00000003',
+          },
+          {
+            asset: 'WBTC',
+            quantity: '2792',
+            displayQuantity: '0.00002792',
+          },
+        ],
       },
     });
   });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletQaStack.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletQaStack.unit.test.ts
@@ -231,6 +231,11 @@ describe('buildWalletQaEnvironmentOverrides', () => {
       PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH:
         '/tmp/runtime/ows/portfolio-manager',
     });
+    expect(overrides.sharedEmberEnv).toMatchObject({
+      PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME: 'oca-executor-wallet-id',
+      PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH:
+        '/tmp/runtime/ows/portfolio-manager',
+    });
   });
 });
 

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletQaStack.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletQaStack.unit.test.ts
@@ -207,6 +207,31 @@ describe('buildWalletQaEnvironmentOverrides', () => {
         },
       });
   });
+
+  it('wires the hidden OCA executor wallet and vault into PM env when present', () => {
+    const overrides = buildWalletQaEnvironmentOverrides({
+      specRoot: '/tmp/ember-orchestration-v1-spec',
+      sharedEmberDatabaseUrl: 'postgresql://ember:ember@127.0.0.1:55433/ember',
+      portfolioManagerOwsVaultPath: '/tmp/runtime/ows/portfolio-manager',
+      emberLendingOwsVaultPath: '/tmp/runtime/ows/ember-lending',
+      sharedEmberBaseUrl: 'http://127.0.0.1:4011',
+      portfolioManagerBaseUrl: 'http://127.0.0.1:3421/ag-ui',
+      emberLendingBaseUrl: 'http://127.0.0.1:3431/ag-ui',
+      onchainActionsApiUrl: 'http://127.0.0.1:50051',
+      webBaseEnv: {},
+      portfolioManagerBaseEnv: {
+        PORTFOLIO_MANAGER_OWS_WALLET_NAME: 'portfolio-manager-controller-wallet',
+        PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME: 'oca-executor-wallet-id',
+      },
+      emberLendingBaseEnv: {},
+    });
+
+    expect(overrides.portfolioManagerEnv).toMatchObject({
+      PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME: 'oca-executor-wallet-id',
+      PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH:
+        '/tmp/runtime/ows/portfolio-manager',
+    });
+  });
 });
 
 describe('resolveManagedWalletIds', () => {
@@ -247,7 +272,36 @@ describe('resolveManagedWalletIds', () => {
 
     expect(resolved).toEqual({
       portfolioManagerWalletId: 'older-controller',
+      portfolioManagerOcaExecutorWalletId: 'newer-controller',
       emberLendingWalletId: 'older-lending',
+    });
+  });
+
+  it('infers the hidden OCA executor wallet from the spare portfolio-manager wallet', () => {
+    const resolved = resolveManagedWalletIds({
+      portfolioManagerWalletName: 'portfolio-manager-controller-wallet',
+      emberLendingWalletName: null,
+      controllerSignerAddress: '0x1111111111111111111111111111111111111111',
+      portfolioManagerWallets: [
+        {
+          id: 'controller-wallet-id',
+          name: 'portfolio-manager-controller-wallet',
+          address: '0x1111111111111111111111111111111111111111',
+          createdAt: '2026-04-25T00:00:00.000Z',
+        },
+        {
+          id: 'oca-executor-wallet-id',
+          name: 'portfolio-manager-controller-wallet',
+          address: '0x2222222222222222222222222222222222222222',
+          createdAt: '2026-04-25T00:00:01.000Z',
+        },
+      ],
+      emberLendingWallets: [],
+    });
+
+    expect(resolved).toMatchObject({
+      portfolioManagerWalletId: 'controller-wallet-id',
+      portfolioManagerOcaExecutorWalletId: 'oca-executor-wallet-id',
     });
   });
 });

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletQaStack.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/walletQaStack.unit.test.ts
@@ -277,14 +277,43 @@ describe('resolveManagedWalletIds', () => {
 
     expect(resolved).toEqual({
       portfolioManagerWalletId: 'older-controller',
-      portfolioManagerOcaExecutorWalletId: 'newer-controller',
+      portfolioManagerOcaExecutorWalletId: 'older-controller',
       emberLendingWalletId: 'older-lending',
     });
   });
 
-  it('infers the hidden OCA executor wallet from the spare portfolio-manager wallet', () => {
+  it('falls back to the selected portfolio-manager wallet for hidden OCA executor QA funding', () => {
     const resolved = resolveManagedWalletIds({
       portfolioManagerWalletName: 'portfolio-manager-controller-wallet',
+      emberLendingWalletName: null,
+      controllerSignerAddress: '0x1111111111111111111111111111111111111111',
+      portfolioManagerWallets: [
+        {
+          id: 'controller-wallet-id',
+          name: 'portfolio-manager-controller-wallet',
+          address: '0x1111111111111111111111111111111111111111',
+          createdAt: '2026-04-25T00:00:00.000Z',
+        },
+        {
+          id: 'oca-executor-wallet-id',
+          name: 'portfolio-manager-controller-wallet',
+          address: '0x2222222222222222222222222222222222222222',
+          createdAt: '2026-04-25T00:00:01.000Z',
+        },
+      ],
+      emberLendingWallets: [],
+    });
+
+    expect(resolved).toMatchObject({
+      portfolioManagerWalletId: 'controller-wallet-id',
+      portfolioManagerOcaExecutorWalletId: 'controller-wallet-id',
+    });
+  });
+
+  it('uses an explicit hidden OCA executor wallet when configured', () => {
+    const resolved = resolveManagedWalletIds({
+      portfolioManagerWalletName: 'portfolio-manager-controller-wallet',
+      portfolioManagerOcaExecutorWalletName: 'oca-executor-wallet-id',
       emberLendingWalletName: null,
       controllerSignerAddress: '0x1111111111111111111111111111111111111111',
       portfolioManagerWallets: [

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
@@ -65,6 +65,24 @@ describe('POST /api/agent-command', () => {
     });
   });
 
+  it('rejects direct commands for the hidden OCA executor', async () => {
+    const response = await POST(
+      buildRequest({
+        agentId: 'agent-oca-executor',
+        threadId: 'thread-1',
+        command: {
+          name: 'dispatch_spot_swap',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Invalid agent command payload.',
+    });
+  });
+
   it('returns the latest thread domain projection after a successful one-off command run', async () => {
     runMock.mockReturnValue(
       from([

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts
@@ -122,6 +122,7 @@ describe('buildCopilotRuntimeAgents', () => {
     });
 
     expect(Object.keys(agents)).toEqual(['agent-portfolio-manager', 'agent-ember-lending']);
+    expect(Object.keys(agents)).not.toContain('agent-oca-executor');
     expect(langGraphInterruptSnapshotAgentConfigs).toEqual([]);
     expect(agentRuntimeHttpAgentConfigs).toEqual([
       {
@@ -141,5 +142,8 @@ describe('buildCopilotRuntimeAgents', () => {
     expect(() =>
       resolveAgentRuntimeUrl({ LANGSMITH_API_KEY: 'test-langsmith-key' }, 'agent-pi-example'),
     ).toThrow('Unsupported AG-UI runtime agent "agent-pi-example".');
+    expect(() =>
+      resolveAgentRuntimeUrl({ LANGSMITH_API_KEY: 'test-langsmith-key' }, 'agent-oca-executor'),
+    ).toThrow('Unsupported AG-UI runtime agent "agent-oca-executor".');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/copilotkit/piRuntimeHttpAgent.int.test.ts
@@ -158,6 +158,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function encodeJsonPointerToken(token: string): string {
+  return token.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function collectSnapshotReplaceOperations(value: unknown, path = ''): JsonPatchOperation[] {
+  const currentOperation = { op: 'replace', path, value } satisfies JsonPatchOperation;
+  if (!isRecord(value)) {
+    return [currentOperation];
+  }
+
+  const entries = Array.isArray(value) ? [...value.entries()] : Object.entries(value);
+  return [
+    currentOperation,
+    ...entries.flatMap(([key, nestedValue]) =>
+      collectSnapshotReplaceOperations(
+        nestedValue,
+        `${path}/${encodeJsonPointerToken(String(key))}`,
+      ),
+    ),
+  ];
+}
+
 function matchesArtifactData(
   value: unknown,
   expected: {
@@ -221,11 +243,18 @@ function expectStateDeltaOperation(
   events: BaseEvent[],
   predicate: (operation: JsonPatchOperation) => boolean,
 ): void {
-  const stateDeltas = findStateDeltas(events);
-  expect(stateDeltas).not.toHaveLength(0);
-  expect(
-    stateDeltas.some((event) => event.delta.some((operation) => predicate(operation as JsonPatchOperation))),
-  ).toBe(true);
+  const operations = [
+    ...findStateDeltas(events).flatMap((event) =>
+      event.delta.map((operation) => operation as JsonPatchOperation),
+    ),
+    ...events.flatMap((event) =>
+      event.type === EventType.STATE_SNAPSHOT && isRecord(event.snapshot)
+        ? collectSnapshotReplaceOperations(event.snapshot)
+        : [],
+    ),
+  ];
+  expect(operations).not.toHaveLength(0);
+  expect(operations.some(predicate)).toBe(true);
 }
 
 function createInternalPostgresHooks() {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.prehire.unit.test.ts
@@ -288,6 +288,47 @@ describe('AgentDetailPage (pre-hire + onboarding affordances)', () => {
     );
   });
 
+  it('renders simple markdown emphasis in chat transcript messages', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(AgentDetailPage, {
+        agentId: 'agent-portfolio-manager',
+        agentName: 'Ember Portfolio Agent',
+        agentDescription: 'desc',
+        creatorName: 'Ember AI Team',
+        creatorVerified: true,
+        profile: {
+          chains: [],
+          protocols: [],
+          tokens: [],
+        },
+        metrics: {},
+        initialTab: 'chat',
+        isHired: false,
+        isHiring: false,
+        hasLoadedView: true,
+        messages: [
+          {
+            id: 'assistant-markdown-1',
+            role: 'assistant',
+            content: 'Use **reserved WETH** only after *confirmation*.',
+          },
+        ],
+        onHire: () => {},
+        onFire: () => {},
+        onSync: () => {},
+        onBack: () => {},
+        allowedPools: [],
+      }),
+    );
+
+    expect(html).toContain('<strong');
+    expect(html).toContain('reserved WETH');
+    expect(html).toContain('<em');
+    expect(html).toContain('confirmation');
+    expect(html).not.toContain('**reserved WETH**');
+    expect(html).not.toContain('*confirmation*');
+  });
+
   it('renders automation status artifacts and A2UI cards in the Ember Portfolio Agent chat transcript', () => {
     const html = renderToStaticMarkup(
       React.createElement(AgentDetailPage, {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -71,6 +71,7 @@ import { AgentSurfaceTag } from './ui/AgentSurfaceTag';
 import { CreatorIdentity } from './ui/CreatorIdentity';
 import { CursorListTooltip } from './ui/CursorListTooltip';
 import { CTA_SIZE_MD, CTA_SIZE_MD_FULL } from './ui/cta';
+import { SimpleMarkdownText } from './ui/SimpleMarkdownText';
 import {
   formatDelegationSigningError,
   signDelegationWithFallback,
@@ -2136,7 +2137,9 @@ function AgentChatTab(props: {
               <div className="text-[11px] uppercase tracking-[0.14em] text-[#907764]">
                 {message.label}
               </div>
-              <div className="mt-2 whitespace-pre-wrap text-sm leading-relaxed">{message.text}</div>
+              <div className="mt-2 whitespace-pre-wrap text-sm leading-relaxed">
+                <SimpleMarkdownText text={message.text} />
+              </div>
             </div>
           ))
         )}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.activityRail.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.activityRail.unit.test.tsx
@@ -294,4 +294,57 @@ describe('AppSidebar activity rail', () => {
       root.unmount();
     });
   });
+
+  it('derives the portfolio card holdings tooltip from the cached portfolio projection', () => {
+    getAuthoritativeSnapshotMock.mockReturnValue({
+      thread: {
+        domainProjection: {
+          portfolioProjectionInput: {
+            benchmarkAsset: 'USD',
+            walletContents: [
+              { asset: 'USDC', network: 'arbitrum', quantity: '1000', valueUsd: 500 },
+              { asset: 'WETH', network: 'arbitrum', quantity: '0.05', valueUsd: 200 },
+              { asset: 'WBTC', network: 'arbitrum', quantity: '0.0012', valueUsd: 150 },
+              { asset: 'ARB', network: 'arbitrum', quantity: '80', valueUsd: 100 },
+              { asset: 'GMX', network: 'arbitrum', quantity: '4', valueUsd: 40 },
+              { asset: 'DAI', network: 'arbitrum', quantity: '10', valueUsd: 10 },
+            ],
+            ownedUnits: [],
+            reservations: [],
+            activePositionScopes: [],
+          },
+        },
+      },
+    });
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(React.createElement(AppSidebar));
+    });
+
+    const portfolioCard = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Ember Portfolio Agent'),
+    );
+
+    expect(portfolioCard).not.toBeUndefined();
+
+    act(() => {
+      portfolioCard?.dispatchEvent(
+        new MouseEvent('mouseover', { bubbles: true, clientX: 24, clientY: 24 }),
+      );
+    });
+
+    const pageText = document.body.textContent ?? '';
+    expect(pageText).toContain('Top holdings');
+    expect(pageText).toContain('USDC');
+    expect(pageText).toContain('1,000');
+    expect(pageText).toContain('50%');
+    expect(pageText).toContain('$500');
+    expect(pageText).toContain('GMX');
+    expect(pageText).not.toContain('DAI');
+
+    act(() => {
+      root.unmount();
+    });
+  });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AppSidebar.tsx
@@ -36,6 +36,7 @@ import {
   SidebarActivityCard,
   SidebarAgentAvatar,
   type SidebarActivityCardControlSlice,
+  type SidebarActivityCardTokenHolding,
   type SidebarActivityCardTokenSlice,
   type SidebarActivityCardView,
 } from '@/components/ui/SidebarActivityCard';
@@ -62,6 +63,7 @@ type SidebarProjectionCardData = {
   liabilitiesUsd: number;
   allocationShare: number;
   tokenBreakdown: SidebarActivityCardTokenSlice[];
+  tokenHoldings?: SidebarActivityCardTokenHolding[];
   controlBreakdown?: SidebarActivityCardControlSlice[];
   thirtyDayPnlPct?: number;
 };
@@ -391,6 +393,9 @@ export function AppSidebar() {
       card.tokenBreakdown.forEach((slice) => {
         addToken(slice.asset);
       });
+      card.tokenHoldings?.forEach((holding) => {
+        addToken(holding.asset);
+      });
     });
     allActivityAgents.forEach((activity) => {
       const protocols = activity.entry?.profile?.protocols ?? activity.config.protocols ?? [];
@@ -455,6 +460,14 @@ export function AppSidebar() {
                 sidebarTokenIconBySymbol[normalizeSymbolKey(slice.asset)] ??
                 null,
               fallbackIconSymbol: slice.fallbackIconSymbol ?? slice.asset,
+            })),
+            tokenHoldings: card.tokenHoldings?.map((holding) => ({
+              ...holding,
+              iconUri:
+                holding.iconUri ??
+                sidebarTokenIconBySymbol[normalizeSymbolKey(holding.asset)] ??
+                null,
+              fallbackIconSymbol: holding.fallbackIconSymbol ?? holding.asset,
             })),
           },
         ]),
@@ -849,6 +862,7 @@ function buildSidebarActivityCardView(params: {
         entry: params.activity.entry,
         config: params.activity.config,
       }),
+    tokenHoldings: params.projectionCardData?.tokenHoldings,
     controlBreakdown:
       params.projectionCardData?.controlBreakdown ??
       (params.activity.id === PORTFOLIO_AGENT_ID && params.portfolioControlBreakdown.length > 0
@@ -1111,6 +1125,10 @@ function buildSidebarProjectionCardDataByAgentId(params: {
     liabilitiesUsd: portfolio.agents.portfolio.liabilitiesUsd,
     allocationShare: 1,
     tokenBreakdown: buildProjectionTokenBreakdown(portfolio.agents.portfolio.tokenExposures),
+    tokenHoldings: buildProjectionTokenHoldings({
+      assetFamilies: portfolio.assetFamilies,
+      totalPortfolioUsd: portfolio.summary.positiveAssetsUsd,
+    }),
     controlBreakdown: [
       ...specialistSlices,
       {
@@ -1149,6 +1167,37 @@ function buildProjectionTokenBreakdown(
     asset: tokenExposure.asset,
     share: tokenExposure.share,
   }));
+}
+
+function buildProjectionTokenHoldings(params: {
+  assetFamilies: PortfolioProjectionPacket['assetFamilies'];
+  totalPortfolioUsd: number;
+}): SidebarActivityCardTokenHolding[] {
+  return params.assetFamilies
+    .filter((family) => family.positiveUsd > 0)
+    .map((family) => ({
+      asset: family.asset,
+      amount: family.observedAssets
+        .filter((observedAsset) => observedAsset.sourceKind !== 'debt')
+        .reduce((sum, observedAsset) => sum + resolveObservedAssetDisplayQuantity(observedAsset), 0),
+      share: params.totalPortfolioUsd > 0 ? family.positiveUsd / params.totalPortfolioUsd : 0,
+      valueUsd: family.positiveUsd,
+    }))
+    .filter((holding) => holding.amount > 0 && holding.valueUsd > 0)
+    .sort((left, right) => right.valueUsd - left.valueUsd)
+    .slice(0, 5);
+}
+
+function resolveObservedAssetDisplayQuantity(
+  observedAsset: PortfolioProjectionPacket['assetFamilies'][number]['observedAssets'][number],
+): number {
+  const displayQuantity =
+    observedAsset.displayQuantity === undefined ? null : Number(observedAsset.displayQuantity);
+  if (displayQuantity !== null && Number.isFinite(displayQuantity) && displayQuantity > 0) {
+    return displayQuantity;
+  }
+
+  return observedAsset.quantity;
 }
 
 function formatAgentIdLabel(agentId: string): string {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/ui/SidebarActivityCard.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/ui/SidebarActivityCard.tsx
@@ -18,6 +18,15 @@ export type SidebarActivityCardTokenSlice = {
   fallbackIconSymbol?: string;
 };
 
+export type SidebarActivityCardTokenHolding = {
+  asset: string;
+  amount: number;
+  share: number;
+  valueUsd: number;
+  iconUri?: string | null;
+  fallbackIconSymbol?: string;
+};
+
 export type SidebarActivityCardControlSlice = {
   id: string;
   label: string;
@@ -41,6 +50,7 @@ export type SidebarActivityCardView = {
   metricBadge?: string;
   thirtyDayPnlPct?: number;
   tokenBreakdown: SidebarActivityCardTokenSlice[];
+  tokenHoldings?: SidebarActivityCardTokenHolding[];
   controlBreakdown?: SidebarActivityCardControlSlice[];
 };
 
@@ -313,6 +323,133 @@ function CursorTokenTooltip(props: {
   );
 }
 
+function PortfolioHoldingsTooltip(props: {
+  holdings: SidebarActivityCardTokenHolding[];
+  children: React.ReactNode;
+}) {
+  const tooltipId = useId();
+  const [isOpen, setIsOpen] = useState(false);
+  const [pos, setPos] = useState<CursorPos>({ x: 0, y: 0 });
+  const visibleHoldings = useMemo(
+    () =>
+      [...props.holdings]
+        .filter(
+          (holding) =>
+            holding.asset.trim().length > 0 &&
+            Number.isFinite(holding.amount) &&
+            holding.amount > 0 &&
+            Number.isFinite(holding.valueUsd) &&
+            holding.valueUsd > 0,
+        )
+        .sort((left, right) => right.valueUsd - left.valueUsd)
+        .slice(0, 5),
+    [props.holdings],
+  );
+
+  const updatePointerPosition = useCallback((event: React.MouseEvent) => {
+    const padding = 12;
+    const maxWidth = 312;
+    const maxHeight = 260;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const nextX = clamp(event.clientX + padding, padding, Math.max(padding, vw - maxWidth - padding));
+    const nextY = clamp(event.clientY + padding, padding, Math.max(padding, vh - maxHeight - padding));
+
+    setPos({ x: nextX, y: nextY });
+  }, []);
+
+  const updateFocusPosition = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const padding = 12;
+    const maxWidth = 312;
+    const maxHeight = 260;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const nextX = clamp(rect.right + padding, padding, Math.max(padding, vw - maxWidth - padding));
+    const nextY = clamp(rect.top, padding, Math.max(padding, vh - maxHeight - padding));
+
+    setPos({ x: nextX, y: nextY });
+  }, []);
+
+  if (visibleHoldings.length === 0) {
+    return <>{props.children}</>;
+  }
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={(event) => {
+        setIsOpen(true);
+        updatePointerPosition(event);
+      }}
+      onMouseMove={updatePointerPosition}
+      onMouseLeave={() => setIsOpen(false)}
+      onFocus={(event) => {
+        setIsOpen(true);
+        updateFocusPosition(event);
+      }}
+      onBlur={() => setIsOpen(false)}
+      aria-describedby={isOpen ? tooltipId : undefined}
+    >
+      {props.children}
+      {isOpen ? (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="pointer-events-none fixed z-[100] w-[min(312px,calc(100vw-24px))] rounded-xl border border-[#E7DBD0] bg-[#FFFDF9]/96 shadow-[0_18px_60px_rgba(28,18,10,0.2)] backdrop-blur-md"
+          style={{ left: pos.x, top: pos.y }}
+        >
+          <div className="p-2.5">
+            <div className="mb-1.5 font-mono text-[9px] uppercase tracking-[0.16em] text-[#8C7F72]">
+              Top holdings
+            </div>
+            <div className="space-y-1">
+              {visibleHoldings.map((holding) => (
+                <div
+                  key={holding.asset}
+                  className="grid grid-cols-[18px_minmax(0,1fr)_42px_54px] items-center gap-2 rounded-lg bg-[#F7F1EA] px-2 py-1.5 text-[#221A13] ring-1 ring-[#E7DBD0]"
+                >
+                  {holding.iconUri ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={proxyIconUri(holding.iconUri)}
+                      alt=""
+                      loading="lazy"
+                      decoding="async"
+                      className="h-[18px] w-[18px] rounded-full bg-[#FCF8F3] object-contain ring-1 ring-[#E7DBD0]"
+                    />
+                  ) : (
+                    <span
+                      className="inline-flex h-[18px] w-[18px] items-center justify-center rounded-full bg-[#FCF8F3] font-mono text-[7px] font-semibold text-[#8C7F72] ring-1 ring-[#E7DBD0]"
+                      aria-hidden="true"
+                    >
+                      {iconMonogram(holding.fallbackIconSymbol ?? holding.asset)}
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    <div className="truncate font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-[#221A13]">
+                      {holding.asset}
+                    </div>
+                    <div className="truncate font-mono text-[10px] leading-none text-[#8C7F72]">
+                      {formatHoldingAmount(holding.amount)}
+                    </div>
+                  </div>
+                  <div className="font-mono text-[10px] text-[#6D5B4C]">
+                    {formatPrecisePercent(holding.share)}
+                  </div>
+                  <div className="text-right font-mono text-[10px] font-semibold text-[#221A13]">
+                    {formatCompactUsd(holding.valueUsd)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function TokenCluster(props: {
   slices: SidebarActivityCardTokenSlice[];
   active?: boolean;
@@ -412,9 +549,25 @@ function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
 }
 
+function formatPrecisePercent(value: number): string {
+  return `${formatNumber(value * 100)}%`;
+}
+
 function formatSignedPercent(value: number): string {
   const sign = value >= 0 ? '+' : '-';
   return `${sign}${formatNumber(Math.abs(value) * 100)}%`;
+}
+
+function formatHoldingAmount(value: number): string {
+  const maximumFractionDigits = value >= 100
+    ? 0
+    : value >= 1
+      ? 2
+      : 6;
+
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits,
+  }).format(value);
 }
 
 function statusToneClassName(statusTone: SidebarActivityCardView['statusTone']): string {
@@ -467,7 +620,7 @@ export function SidebarActivityCard(props: {
         : 'text-[#B23A32]'
       : statusToneClassName(props.card.statusTone);
 
-  return (
+  const button = (
     <button
       type="button"
       onClick={props.onClick}
@@ -548,4 +701,14 @@ export function SidebarActivityCard(props: {
       </div>
     </button>
   );
+
+  if (props.card.id === 'agent-portfolio-manager' && props.card.tokenHoldings?.length) {
+    return (
+      <PortfolioHoldingsTooltip holdings={props.card.tokenHoldings}>
+        {button}
+      </PortfolioHoldingsTooltip>
+    );
+  }
+
+  return button;
 }

--- a/typescript/clients/web-ag-ui/apps/web/src/components/ui/SidebarActivityCard.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/ui/SidebarActivityCard.unit.test.tsx
@@ -1,8 +1,15 @@
+// @vitest-environment jsdom
+
 import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import { SidebarActivityCard } from './SidebarActivityCard';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
 
 describe('SidebarActivityCard', () => {
   it('matches the reference card structure for exposure, active styling, and token overflow', () => {
@@ -47,5 +54,65 @@ describe('SidebarActivityCard', () => {
     expect(html).not.toContain('>ARB<');
     expect(html).not.toContain('>GMX<');
     expect(html).toContain('…');
+  });
+
+  it('shows a compact top-holdings tooltip for the portfolio agent card on hover', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        React.createElement(SidebarActivityCard, {
+          card: {
+            id: 'agent-portfolio-manager',
+            label: 'Ember Portfolio Agent',
+            statusTone: 'active',
+            valueUsd: 1000,
+            allocationShare: 1,
+            allocationShareLabel: 'portfolio',
+            tokenBreakdown: [],
+            tokenHoldings: [
+              {
+                asset: 'USDC',
+                amount: 1000,
+                share: 0.5,
+                valueUsd: 500,
+                iconUri: '/icons/usdc.svg',
+              },
+              { asset: 'WETH', amount: 0.05, share: 0.2, valueUsd: 200 },
+              { asset: 'WBTC', amount: 0.0012, share: 0.15, valueUsd: 150 },
+              { asset: 'ARB', amount: 80, share: 0.1, valueUsd: 100 },
+              { asset: 'GMX', amount: 4, share: 0.04, valueUsd: 40 },
+              { asset: 'DAI', amount: 10, share: 0.01, valueUsd: 10 },
+            ],
+          },
+        }),
+      );
+    });
+
+    const card = container.querySelector('button');
+    expect(card).not.toBeNull();
+    expect(document.body.textContent).not.toContain('Top holdings');
+
+    act(() => {
+      card?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, clientX: 24, clientY: 24 }));
+    });
+
+    const pageText = document.body.textContent ?? '';
+    expect(pageText).toContain('Top holdings');
+    expect(pageText).toContain('USDC');
+    expect(pageText).toContain('1,000');
+    expect(pageText).toContain('50%');
+    expect(pageText).toContain('$500');
+    expect(pageText).toContain('WETH');
+    expect(pageText).toContain('0.05');
+    expect(pageText).not.toContain('DAI');
+    expect(document.body.querySelector('img[src="/icons/usdc.svg"]')).not.toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/ui/SimpleMarkdownText.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/ui/SimpleMarkdownText.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+
+export type SimpleMarkdownInlineNode =
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'code';
+      text: string;
+    }
+  | {
+      type: 'strong' | 'em';
+      children: SimpleMarkdownInlineNode[];
+    };
+
+type ParseResult = {
+  nodes: SimpleMarkdownInlineNode[];
+  index: number;
+  closed: boolean;
+};
+
+function parseDelimited(
+  source: string,
+  startIndex: number,
+  delimiter: string,
+  type: 'strong' | 'em',
+): { node: SimpleMarkdownInlineNode; nextIndex: number } | null {
+  const parsed = parseSegments(source, startIndex + delimiter.length, delimiter);
+  if (!parsed.closed) {
+    return null;
+  }
+
+  return {
+    node: {
+      type,
+      children: parsed.nodes,
+    },
+    nextIndex: parsed.index + delimiter.length,
+  };
+}
+
+function parseSegments(source: string, startIndex: number, closingDelimiter?: string): ParseResult {
+  const nodes: SimpleMarkdownInlineNode[] = [];
+  let index = startIndex;
+
+  while (index < source.length) {
+    if (closingDelimiter && source.startsWith(closingDelimiter, index)) {
+      return { nodes, index, closed: true };
+    }
+
+    if (source.startsWith('`', index)) {
+      const closingIndex = source.indexOf('`', index + 1);
+      if (closingIndex > index) {
+        nodes.push({
+          type: 'code',
+          text: source.slice(index + 1, closingIndex),
+        });
+        index = closingIndex + 1;
+        continue;
+      }
+
+      nodes.push({ type: 'text', text: '`' });
+      index += 1;
+      continue;
+    }
+
+    if (source.startsWith('**', index)) {
+      const parsed = parseDelimited(source, index, '**', 'strong');
+      if (parsed) {
+        nodes.push(parsed.node);
+        index = parsed.nextIndex;
+        continue;
+      }
+
+      nodes.push({ type: 'text', text: '**' });
+      index += 2;
+      continue;
+    }
+
+    if (source.startsWith('*', index)) {
+      const parsed = parseDelimited(source, index, '*', 'em');
+      if (parsed) {
+        nodes.push(parsed.node);
+        index = parsed.nextIndex;
+        continue;
+      }
+
+      nodes.push({ type: 'text', text: '*' });
+      index += 1;
+      continue;
+    }
+
+    const textStartIndex = index;
+    while (
+      index < source.length &&
+      !source.startsWith('`', index) &&
+      !source.startsWith('*', index) &&
+      !(closingDelimiter && source.startsWith(closingDelimiter, index))
+    ) {
+      index += 1;
+    }
+
+    if (index > textStartIndex) {
+      nodes.push({ type: 'text', text: source.slice(textStartIndex, index) });
+    }
+  }
+
+  return { nodes, index, closed: false };
+}
+
+export function parseSimpleMarkdownInline(text: string): SimpleMarkdownInlineNode[] {
+  return parseSegments(text, 0).nodes;
+}
+
+function renderNodes(nodes: SimpleMarkdownInlineNode[], keyPrefix: string): React.ReactNode[] {
+  return nodes.map((node, index) => {
+    const key = `${keyPrefix}:${index}`;
+
+    if (node.type === 'text') {
+      return <React.Fragment key={key}>{node.text}</React.Fragment>;
+    }
+
+    if (node.type === 'code') {
+      return (
+        <code
+          key={key}
+          className="rounded-[5px] bg-[#241813]/10 px-1 py-0.5 font-mono text-[0.92em] text-current"
+        >
+          {node.text}
+        </code>
+      );
+    }
+
+    if (node.type === 'strong') {
+      return (
+        <strong key={key} className="font-semibold text-current">
+          {renderNodes(node.children, key)}
+        </strong>
+      );
+    }
+
+    return (
+      <em key={key} className="italic text-current">
+        {renderNodes(node.children, key)}
+      </em>
+    );
+  });
+}
+
+export function SimpleMarkdownText(props: { text: string }): React.JSX.Element {
+  return <>{renderNodes(parseSimpleMarkdownInline(props.text), 'md')}</>;
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/ui/SimpleMarkdownText.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/ui/SimpleMarkdownText.unit.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { SimpleMarkdownText, parseSimpleMarkdownInline } from './SimpleMarkdownText';
+
+describe('SimpleMarkdownText', () => {
+  it('renders basic inline markdown without using raw HTML', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SimpleMarkdownText, {
+        text: 'Use **reserved WETH**, keep *unassigned* funds, and pass `amount`.',
+      }),
+    );
+
+    expect(html).toContain('<strong');
+    expect(html).toContain('reserved WETH');
+    expect(html).toContain('<em');
+    expect(html).toContain('unassigned');
+    expect(html).toContain('<code');
+    expect(html).toContain('amount');
+    expect(html).not.toContain('**reserved WETH**');
+    expect(html).not.toContain('*unassigned*');
+  });
+
+  it('leaves unmatched delimiters readable as plain text', () => {
+    expect(parseSimpleMarkdownInline('keep **literal')).toEqual([
+      { type: 'text', text: 'keep ' },
+      { type: 'text', text: '**' },
+      { type: 'text', text: 'literal' },
+    ]);
+  });
+
+  it('escapes html-like user content while still applying markdown spans', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SimpleMarkdownText, {
+        text: '<script>alert(1)</script> **safe**',
+      }),
+    );
+
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('<strong');
+    expect(html).toContain('safe');
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/config/agents.unit.test.ts
@@ -72,7 +72,10 @@ describe('agents config', () => {
     const visibleAgentIds = getVisibleAgents().map((agent) => agent.id);
 
     expect(allAgentIds).not.toContain('agent-pi-example');
+    expect(allAgentIds).not.toContain('agent-oca-executor');
     expect(visibleAgentIds).not.toContain('agent-pi-example');
+    expect(visibleAgentIds).not.toContain('agent-oca-executor');
+    expect(isRegisteredAgentId('agent-oca-executor')).toBe(false);
     expect(visibleAgentIds).toContain('agent-portfolio-manager');
     expect(visibleAgentIds).toContain('agent-ember-lending');
     expect(visibleAgentIds).toEqual(allAgentIds);

--- a/typescript/clients/web-ag-ui/docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md
@@ -1,6 +1,6 @@
 # ADR 0014: fail-closed-service-identity-preflight-for-managed-shared-ember-agents
 
-Status: Accepted
+Status: Superseded by ADR 0017 for hidden internal worker readiness. The visible managed-service fail-closed rule remains retained by ADR 0017.
 Date: 2026-04-02
 
 ## Context

--- a/typescript/clients/web-ag-ui/docs/adr/0017-hidden-internal-worker-readiness.md
+++ b/typescript/clients/web-ag-ui/docs/adr/0017-hidden-internal-worker-readiness.md
@@ -1,0 +1,128 @@
+# ADR 0017: hidden-internal-worker-readiness
+
+Status: Accepted
+Date: 2026-04-25
+
+Supersedes: ADR 0014 for hidden internal worker readiness only.
+
+## Context
+
+ADR 0014 established a fail-closed service-identity preflight rule for the first
+managed Shared Ember downstream pair:
+
+- `portfolio-manager` / `orchestrator`
+- `ember-lending` / `subagent`
+
+That decision was correct for visible managed lanes whose readiness determines
+whether managed onboarding can honestly be marked active.
+
+Issue `#582` introduces a different runtime shape:
+
+- PM remains the only user-facing control plane
+- a hidden internal worker executes PM-owned Onchain Actions work
+- the first hidden worker identity is `agent-oca-executor`
+- the MVP capability is `spot.swap`
+- the worker is not a visible managed lane
+- the worker is not exposed in public registry, routes, CopilotKit, or public
+  direct-command surfaces
+- the worker relies on request-time readiness and authority preparation
+
+Applying ADR 0014 literally to hidden internal workers would make PM activation
+fail closed on a non-visible helper that is not required to render PM as hired
+or active. That is the wrong product and runtime boundary.
+
+## Decision
+
+Split service-identity readiness into two classes.
+
+### Visible Managed Services
+
+Visible managed Shared Ember services keep the ADR 0014 fail-closed rule.
+
+- Each visible managed service owns its own startup identity preflight.
+- PM must fail closed when a required visible managed-lane service identity is
+  missing, stale, or unverified.
+- PM must not mark managed onboarding complete when required visible managed-lane
+  execution context is absent.
+
+### Hidden Internal Workers
+
+Hidden internal workers use best-effort activation readiness and fail-closed
+dispatch readiness.
+
+For hidden internal workers such as `agent-oca-executor`:
+
+- PM activation must not fail closed solely because the hidden worker identity is
+  missing, stale, or temporarily unverifiable.
+- PM activation may attempt best-effort eager registration or verification of
+  hidden worker identity.
+- First-use repair is allowed.
+- The dispatch path must fail closed before executing if the hidden worker
+  identity cannot be made valid for the exact worker and wallet context.
+- The dispatch path must not bypass Shared Ember for domain truth, admission,
+  reservation, delegation, accounting, or execution readiness.
+- The hidden worker must carry durable metadata that distinguishes it from
+  visible managed lanes.
+
+Metadata for the first hidden worker:
+
+```text
+agent_id=agent-oca-executor
+visibility=internal
+owner_agent_id=agent-portfolio-manager
+worker_kind=execution
+execution_surface=onchain_actions
+control_paths=["spot.swap"]
+```
+
+PM dispatch authorization uses owner and capability metadata plus server-side
+runtime wiring, not public registry visibility.
+
+## Rationale
+
+- PM can be truthfully active without every hidden future helper being ready.
+- Hidden internal workers are implementation/runtime helpers, not user-facing
+  managed lanes.
+- First-use repair preserves robustness without weakening execution safety,
+  because execution still fails closed before signing/submission if identity or
+  Shared Ember readiness cannot be established.
+- The split keeps ADR 0014's original safety property for visible managed lanes
+  while removing its overreach into hidden worker readiness.
+- Capability metadata gives Shared Ember and Vibekit a durable way to recognize
+  internal workers without exposing them in public UI or command surfaces.
+
+## Alternatives Considered
+
+- Keep ADR 0014 unchanged for all service identities:
+  - rejected because it would block PM activation on hidden helpers that are not
+    required for PM to be user-facing active.
+- Make hidden worker identity optional at execution time:
+  - rejected because execution/signing must still fail closed before any side
+    effect when identity cannot be verified.
+- Use a swap-specific durable identity such as `agent-swap-executor`:
+  - rejected because the planned worker should expand from `spot.swap` to other
+    Onchain Actions action-style endpoints without renaming identity, wallet, or
+    provenance records.
+- Expose the hidden worker as a visible managed lane to reuse existing readiness
+  semantics:
+  - rejected because the product requires PM to remain the only user-facing
+    control plane for this path.
+
+## Consequences
+
+- Positive:
+  - PM activation is no longer coupled to hidden worker readiness.
+  - Hidden worker execution still remains fail-closed at the point where safety
+    matters: dispatch and execution readiness.
+  - Future Onchain Actions action-style endpoints can be added by capability
+    metadata rather than by replacing the hidden worker identity.
+- Tradeoffs:
+  - Runtime startup and PM activation can appear healthy while a hidden worker
+    still needs first-use repair.
+  - The dispatch path must surface clear operator/user-facing failure when
+    first-use repair cannot establish a valid hidden worker identity.
+- Follow-on work:
+  - ensure Shared Ember issue EmberAGI/ember-orchestration-v1-spec#275 gates
+    internal-worker behavior by durable capability metadata
+  - keep tests proving visible managed services remain fail-closed while hidden
+    workers are best-effort during PM activation and fail-closed during dispatch

--- a/typescript/clients/web-ag-ui/docs/adr/README.md
+++ b/typescript/clients/web-ag-ui/docs/adr/README.md
@@ -15,6 +15,7 @@
 | [0011](./0011-blessed-agent-runtime-factory-and-runtime-owned-projection-assembly.md) | Blessed agent-runtime factory and runtime-owned projection assembly | Accepted | 2026-03-28 |
 | [0012](./0012-runtime-family-neutral-web-thread-contract.md) | Runtime-family-neutral web thread contract | Accepted | 2026-03-30 |
 | [0013](./0013-direct-forwarded-command-lane-precedes-inference.md) | Direct forwarded command lane precedes inference | Accepted | 2026-03-30 |
-| [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Accepted | 2026-04-02 |
+| [0014](./0014-fail-closed-service-identity-preflight-for-managed-shared-ember-agents.md) | Fail-closed service identity preflight for managed Shared Ember agents | Superseded | 2026-04-02 |
 | [0015](./0015-service-owned-onchain-actions-transaction-resolution-for-managed-lending.md) | Service-owned Onchain Actions transaction resolution for managed lending | Accepted | 2026-04-03 |
 | [0016](./0016-ag-ui-state-message-and-control-plane-boundaries.md) | AG-UI state, message, and control-plane boundaries | Accepted | 2026-04-12 |
+| [0017](./0017-hidden-internal-worker-readiness.md) | Hidden internal worker readiness | Accepted | 2026-04-25 |

--- a/typescript/clients/web-ag-ui/package.json
+++ b/typescript/clients/web-ag-ui/package.json
@@ -23,6 +23,7 @@
     "smoke:managed-identities": "pnpm --dir ./apps/agent-portfolio-manager exec tsx ./src/managedOnboardingIdentitySmoke.ts",
     "smoke:redelegation-browser-signing": "node ./apps/agent-portfolio-manager/node_modules/tsx/dist/cli.mjs ./scripts/smoke/redelegation-browser-signing.ts",
     "smoke:managed-idle-reconciliation": "node ./apps/agent-portfolio-manager/node_modules/tsx/dist/cli.mjs ./scripts/smoke/managed-idle-reconciliation.ts",
+    "smoke:portfolio-swap-ag-ui": "node ./apps/agent-portfolio-manager/node_modules/tsx/dist/cli.mjs ./scripts/smoke/portfolio-swap-ag-ui.ts",
     "stack:wallet-qa": "bash scripts/smoke/boot-wallet-qa-stack.sh",
     "reset:dev-stack": "bash scripts/reset-dev-stack.sh"
   },

--- a/typescript/clients/web-ag-ui/scripts/smoke/README.md
+++ b/typescript/clients/web-ag-ui/scripts/smoke/README.md
@@ -93,6 +93,38 @@ restart.
     wallet and verifies ordinary portfolio reads ingest the resulting
     ingress/egress changes without repeated phantom deltas on follow-up reads.
 
+- `pnpm smoke:portfolio-swap-ag-ui`
+  - Speaks only to the portfolio-manager AG-UI surface; it does not call Shared
+    Ember JSON-RPC directly and does not drive browser/UI components.
+  - First completes portfolio-manager onboarding through the same AG-UI
+    hire/setup/delegation-signing interrupt flow used by the app smoke. Then it
+    uses ordinary user messages on that active thread to exercise one
+    unreserved WETH -> USDC swap, one mixed unreserved-plus-reserved WETH ->
+    USDC swap with a follow-up confirmation message, then one reserved-capital
+    WETH -> USDC swap with a follow-up confirmation message.
+  - Keeps assertions intentionally thin: the smoke fails on surfaced AG-UI
+    errors/reverts, requires an AG-UI-surfaced execution transaction hash,
+    waits for a successful receipt, and checks the root wallet actually moved
+    WETH down and USDC up. It does not reimplement candidate-unit or
+    reservation selection logic.
+  - Reads an already-running wallet QA stack from
+    `PM_SWAP_SMOKE_PORTFOLIO_MANAGER_BASE_URL`,
+    `PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL`, or the latest
+    `runtime/wallet-qa-stack/launcher*.log` READY line.
+  - Optional live setup: set `PM_SWAP_SMOKE_ENABLE_FUNDING=1` to top up the
+    rooted wallet with ETH/WETH using the bundle's `FUNDING_WALLET_PRIVATE_KEY`.
+    The reserved-capital lane still must exist in the real app/accounting
+    state; the smoke does not seed fake reservations.
+  - Useful overrides:
+    `PM_SWAP_SMOKE_IDENTITIES_PATH`,
+    `PM_SWAP_SMOKE_ROOT_WALLET_ADDRESS`,
+    `ARBITRUM_RPC_URL`,
+    `PM_SWAP_SMOKE_NON_RESERVED_PROMPT`,
+    `PM_SWAP_SMOKE_MIXED_PROMPT`,
+    `PM_SWAP_SMOKE_RESERVED_PROMPT`,
+    `PM_SWAP_SMOKE_CONFIRM_PROMPT`,
+    `PM_SWAP_SMOKE_MIN_ROOT_ETH`, and `PM_SWAP_SMOKE_MIN_ROOT_WETH`.
+
 - `pnpm stack:wallet-qa`
   - Boots the local wallet QA stack for issue-driven debugging:
     `onchain-actions`, repo-local Shared Ember, `agent-portfolio-manager`,
@@ -154,4 +186,7 @@ pnpm smoke:redelegation-browser-signing
 
 # managed idle-capital reconciliation proof without the web app
 pnpm smoke:managed-idle-reconciliation
+
+# portfolio-manager reserved and unreserved spot-swap proof without the web app
+pnpm smoke:portfolio-swap-ag-ui
 ```

--- a/typescript/clients/web-ag-ui/scripts/smoke/portfolio-swap-ag-ui.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/portfolio-swap-ag-ui.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { signDelegationWithFallback } from '../../apps/web/src/utils/delegationSigning.js';
+import { buildPortfolioManagerSetupInput } from '../../apps/web/src/utils/portfolioManagerSetup.js';
 
 const WEB_PACKAGE_JSON_PATH = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -109,6 +110,7 @@ type DelegationSigningInterruptPayload = {
 
 const PORTFOLIO_MANAGER_AGENT_ID = 'agent-portfolio-manager';
 const DEFAULT_PORTFOLIO_MANAGER_BASE_URL = 'http://127.0.0.1:3420/ag-ui';
+const DEFAULT_WEB_BASE_URL = 'http://127.0.0.1:3000';
 const DEFAULT_ARBITRUM_RPC_URL = 'https://arb1.arbitrum.io/rpc';
 const CHAIN_ID = 42161;
 const WETH = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' as const;
@@ -411,6 +413,14 @@ function resolvePortfolioManagerBaseUrl(): string {
 
   const ready = resolveLatestWalletQaReady();
   return readString(ready?.['portfolioManagerBaseUrl']) ?? DEFAULT_PORTFOLIO_MANAGER_BASE_URL;
+}
+
+function resolveWebBaseUrl(): string {
+  return (
+    readString(process.env['PM_SWAP_SMOKE_WEB_BASE_URL']) ??
+    readString(resolveLatestWalletQaReady()?.['webBaseUrl']) ??
+    DEFAULT_WEB_BASE_URL
+  );
 }
 
 function resolveChainConfig(rootWalletAddressOverride?: `0x${string}`): SmokeChainConfig {
@@ -1071,43 +1081,6 @@ function hasStateReplace(input: {
   );
 }
 
-function buildPortfolioManagerSetupInput(walletAddress: `0x${string}`) {
-  return {
-    walletAddress,
-    portfolioMandate: {
-      approved: true,
-      riskLevel: 'medium',
-    },
-    firstManagedMandate: {
-      targetAgentId: 'ember-lending',
-      targetAgentKey: 'ember-lending-primary',
-      managedMandate: {
-        lending_policy: {
-          collateral_policy: {
-            assets: [
-              {
-                asset: 'USDC',
-                max_allocation_pct: 35,
-              },
-              {
-                asset: 'WETH',
-                max_allocation_pct: 35,
-              },
-            ],
-          },
-          borrow_policy: {
-            allowed_assets: ['USDC'],
-          },
-          risk_policy: {
-            max_ltv_bps: 7000,
-            min_health_factor: '1.25',
-          },
-        },
-      },
-    },
-  };
-}
-
 async function signRootDelegation(input: {
   walletClient: ReturnType<typeof createWalletClient>;
   delegation: UnsignedDelegation;
@@ -1126,10 +1099,52 @@ async function signRootDelegation(input: {
 
 async function runAgentCommand(input: {
   baseUrl: string;
+  webBaseUrl?: string;
   threadId: string;
   runId: string;
   command: Record<string, unknown>;
 }): Promise<{ events: unknown[]; snapshot: AgUiSnapshot | null }> {
+  if (input.webBaseUrl) {
+    const commandName = readString(input.command['name']);
+    const commandInput = input.command['input'];
+    const resumeInput = input.command['resume'];
+    const payload = Object.prototype.hasOwnProperty.call(input.command, 'resume')
+      ? {
+          agentId: PORTFOLIO_MANAGER_AGENT_ID,
+          threadId: input.threadId,
+          resume: resumeInput,
+        }
+      : {
+          agentId: PORTFOLIO_MANAGER_AGENT_ID,
+          threadId: input.threadId,
+          command: {
+            name: commandName,
+            ...(Object.prototype.hasOwnProperty.call(input.command, 'input')
+              ? { input: commandInput }
+              : {}),
+          },
+        };
+    const response = await fetch(`${input.webBaseUrl}/api/agent-command`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `${PORTFOLIO_MANAGER_AGENT_ID} web command failed with HTTP ${response.status}: ${await response.text()}`,
+      );
+    }
+
+    await response.json();
+    return connectAgent({
+      baseUrl: input.baseUrl,
+      threadId: input.threadId,
+      runId: `${input.runId}-snapshot`,
+    });
+  }
+
   const response = await fetch(`${input.baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
     method: 'POST',
     headers: {
@@ -1309,14 +1324,26 @@ function assertReservedConfirmationGate(stage: string, result: AgentRunResult): 
   }
 }
 
+function buildReservedWethManagedMandate(rootWalletAddress: `0x${string}`) {
+  return buildPortfolioManagerSetupInput(rootWalletAddress, {
+    collateralPoliciesInput:
+      readString(process.env['PM_SWAP_SMOKE_RESERVED_COLLATERAL_POLICIES_INPUT']) ??
+      'WETH:35, USDC:35',
+    allowedBorrowAssetsInput:
+      readString(process.env['PM_SWAP_SMOKE_RESERVED_ALLOWED_BORROW_ASSETS_INPUT']) ?? 'USDC',
+  }).firstManagedMandate.managedMandate;
+}
+
 async function onboardPortfolioManagerThread(input: {
   baseUrl: string;
+  webBaseUrl: string;
   threadId: string;
   rootWalletAddress: `0x${string}`;
   browserSigningWalletClient: ReturnType<typeof createWalletClient>;
 }): Promise<void> {
   await runAgentCommand({
     baseUrl: input.baseUrl,
+    webBaseUrl: input.webBaseUrl,
     threadId: input.threadId,
     runId: `${input.threadId}-hire`,
     command: {
@@ -1326,10 +1353,11 @@ async function onboardPortfolioManagerThread(input: {
 
   const setupResult = await runAgentCommand({
     baseUrl: input.baseUrl,
+    webBaseUrl: input.webBaseUrl,
     threadId: input.threadId,
     runId: `${input.threadId}-setup`,
     command: {
-      resume: JSON.stringify(buildPortfolioManagerSetupInput(input.rootWalletAddress)),
+      resume: buildPortfolioManagerSetupInput(input.rootWalletAddress),
     },
   });
   let signingInterrupt = readPortfolioManagerSigningInterrupt(
@@ -1440,8 +1468,47 @@ async function onboardPortfolioManagerThread(input: {
   );
 }
 
+async function updateManagedMandateForReservedSwap(input: {
+  baseUrl: string;
+  webBaseUrl: string;
+  threadId: string;
+  rootWalletAddress: `0x${string}`;
+}): Promise<void> {
+  await runAgentCommand({
+    baseUrl: input.baseUrl,
+    webBaseUrl: input.webBaseUrl,
+    threadId: input.threadId,
+    runId: `${input.threadId}-reserve-weth-mandate`,
+    command: {
+      name: 'update_managed_mandate',
+      input: {
+        targetAgentId: 'ember-lending',
+        managedMandate: buildReservedWethManagedMandate(input.rootWalletAddress),
+      },
+    },
+  });
+
+  await runAgentCommand({
+    baseUrl: input.baseUrl,
+    webBaseUrl: input.webBaseUrl,
+    threadId: input.threadId,
+    runId: `${input.threadId}-refresh-after-reserve-weth-mandate`,
+    command: {
+      name: 'refresh_portfolio_state',
+    },
+  });
+
+  console.log(
+    JSON.stringify({
+      phase: 'managed-mandate-updated-for-reserved-swap',
+      rootWalletAddress: input.rootWalletAddress,
+    }),
+  );
+}
+
 async function main() {
   const baseUrl = resolvePortfolioManagerBaseUrl();
+  const webBaseUrl = resolveWebBaseUrl();
   const identities = readIdentities();
   const rootAccount = privateKeyToAccount(identities.root_owner.private_key);
   const executorAccount = privateKeyToAccount(identities.subagent.private_key);
@@ -1507,6 +1574,7 @@ async function main() {
   console.log(
     JSON.stringify({
       phase: 'start',
+      webBaseUrl,
       portfolioManagerBaseUrl: baseUrl,
       rootWalletAddress: chainConfig.rootWalletAddress,
       wethBalance: formatUnits(fundedWethBalance, 18),
@@ -1516,6 +1584,7 @@ async function main() {
 
   await onboardPortfolioManagerThread({
     baseUrl,
+    webBaseUrl,
     threadId: portfolioThreadId,
     rootWalletAddress: chainConfig.rootWalletAddress,
     browserSigningWalletClient,
@@ -1547,6 +1616,13 @@ async function main() {
       assistantText: truncateForLog(nonReservedResult.assistantText ?? ''),
     }),
   );
+
+  await updateManagedMandateForReservedSwap({
+    baseUrl,
+    webBaseUrl,
+    threadId: portfolioThreadId,
+    rootWalletAddress: chainConfig.rootWalletAddress,
+  });
 
   const mixedBefore = await readSwapBalances({
     publicClient,
@@ -1588,6 +1664,13 @@ async function main() {
       assistantText: truncateForLog(mixedConfirmedResult.assistantText ?? ''),
     }),
   );
+
+  await updateManagedMandateForReservedSwap({
+    baseUrl,
+    webBaseUrl,
+    threadId: portfolioThreadId,
+    rootWalletAddress: chainConfig.rootWalletAddress,
+  });
 
   const reservedBefore = await readSwapBalances({
     publicClient,

--- a/typescript/clients/web-ag-ui/scripts/smoke/portfolio-swap-ag-ui.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/portfolio-swap-ag-ui.ts
@@ -1,0 +1,1637 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { signDelegationWithFallback } from '../../apps/web/src/utils/delegationSigning.js';
+
+const WEB_PACKAGE_JSON_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../apps/web/package.json',
+);
+const requireFromWeb = createRequire(WEB_PACKAGE_JSON_PATH);
+const {
+  getDeleGatorEnvironment,
+  Implementation,
+  toMetaMaskSmartAccount,
+} = requireFromWeb('@metamask/delegation-toolkit') as typeof import('@metamask/delegation-toolkit');
+const {
+  custom,
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  formatUnits,
+  http,
+  parseGwei,
+  parseUnits,
+} = requireFromWeb('viem') as typeof import('viem');
+const { privateKeyToAccount } = requireFromWeb('viem/accounts') as typeof import('viem/accounts');
+const { arbitrum } = requireFromWeb('viem/chains') as typeof import('viem/chains');
+const { signAuthorization } = requireFromWeb('viem/experimental') as typeof import('viem/experimental');
+
+type AgUiSnapshot = {
+  snapshot?: {
+    thread?: {
+      lifecycle?: Record<string, unknown> | null;
+      activity?: {
+        events?: unknown[];
+      } | null;
+      artifacts?: {
+        current?: {
+          data?: unknown;
+        } | null;
+      } | null;
+    } | null;
+    tasks?: Array<{
+      interrupts?: Array<{
+        value?: unknown;
+      }>;
+    }> | null;
+  } | null;
+};
+
+type AgentRunResult = {
+  events: unknown[];
+  snapshot: AgUiSnapshot | null;
+  assistantText: string | null;
+};
+
+type WalletFundingConfig = {
+  fundingPrivateKey: `0x${string}`;
+  rootWalletAddress: `0x${string}`;
+  rpcUrl: string;
+  minRootEth: bigint;
+  minRootWeth: bigint;
+};
+
+type SmokeChainConfig = {
+  rootWalletAddress: `0x${string}`;
+  rpcUrl: string;
+};
+
+type SwapBalances = {
+  weth: bigint;
+  usdc: bigint;
+};
+
+type SwapExecutionProof = {
+  transactionHash: `0x${string}`;
+  balances: SwapBalances;
+};
+
+type PublicClient = ReturnType<typeof createPublicClient>;
+
+type IdentityFile = {
+  root_owner: {
+    private_key: `0x${string}`;
+  };
+  subagent: {
+    private_key: `0x${string}`;
+  };
+};
+
+type UnsignedDelegation = {
+  delegate: `0x${string}`;
+  delegator: `0x${string}`;
+  authority: `0x${string}`;
+  caveats: unknown[];
+  salt: `0x${string}`;
+};
+
+type DelegationSigningInterruptPayload = {
+  type: 'portfolio-manager-delegation-signing-request';
+  chainId: number;
+  delegationManager: `0x${string}`;
+  delegatorAddress: `0x${string}`;
+  delegateeAddress: `0x${string}`;
+  delegationsToSign: UnsignedDelegation[];
+};
+
+const PORTFOLIO_MANAGER_AGENT_ID = 'agent-portfolio-manager';
+const DEFAULT_PORTFOLIO_MANAGER_BASE_URL = 'http://127.0.0.1:3420/ag-ui';
+const DEFAULT_ARBITRUM_RPC_URL = 'https://arb1.arbitrum.io/rpc';
+const CHAIN_ID = 42161;
+const WETH = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' as const;
+const USDC = '0xaf88d065e77c8cc2239327c5edb3a432268e5831' as const;
+const RUN_TIMEOUT_MS = readInteger(process.env['PM_SWAP_SMOKE_RUN_TIMEOUT_MS']) ?? 180_000;
+const BALANCE_DELTA_TIMEOUT_MS =
+  readInteger(process.env['PM_SWAP_SMOKE_BALANCE_DELTA_TIMEOUT_MS']) ?? 30_000;
+const TRANSACTION_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/u;
+const WETH_ABI = [
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: 'balance', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'deposit',
+    stateMutability: 'payable',
+    inputs: [],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'transfer',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ name: 'ok', type: 'bool' }],
+  },
+] as const;
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readInteger(value: unknown): number | null {
+  const normalized = readString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function readBool(value: unknown): boolean {
+  const normalized = readString(value)?.toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseDotEnvFile(filePath: string): Record<string, string> {
+  if (!existsSync(filePath)) {
+    return {};
+  }
+
+  const entries: Record<string, string> = {};
+  for (const line of readFileSync(filePath, 'utf8').split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1).trim();
+    entries[key] = rawValue.replace(/^['"]|['"]$/gu, '');
+  }
+
+  return entries;
+}
+
+function parseJsonMaybe<T>(value: unknown): T | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function findSessionRoot(): string | null {
+  let current = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+  while (true) {
+    if (
+      existsSync(path.join(current, 'worktrees')) &&
+      existsSync(path.join(current, 'runtime'))
+    ) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolveBundleRoot(): string | null {
+  const explicit =
+    readString(process.env['PM_SWAP_SMOKE_BUNDLE_ROOT']) ??
+    readString(process.env['WALLET_QA_BUNDLE_ROOT']);
+  if (explicit && existsSync(explicit)) {
+    return explicit;
+  }
+
+  const sessionRoot = findSessionRoot();
+  if (!sessionRoot) {
+    return null;
+  }
+
+  const runtimeDir = path.join(sessionRoot, 'runtime');
+  const candidates = readdirSync(runtimeDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.includes('local-stack-env'))
+    .map((entry) => path.join(runtimeDir, entry.name));
+
+  return candidates[0] ?? null;
+}
+
+function findWorktreesRoot(): string | null {
+  let current = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+
+  while (true) {
+    const candidate = path.join(current, 'worktrees');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolveSingleWorktree(prefix: string): string | null {
+  const worktreesRoot = findWorktreesRoot();
+  if (!worktreesRoot) {
+    return null;
+  }
+
+  const matches = readdirSync(worktreesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => name === prefix || name.startsWith(`${prefix}-`));
+
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  return path.join(worktreesRoot, matches[0]!);
+}
+
+function resolveIdentitiesFilePath(): string | null {
+  const explicitPath = readString(process.env['PM_SWAP_SMOKE_IDENTITIES_PATH']);
+  if (explicitPath && existsSync(explicitPath)) {
+    return explicitPath;
+  }
+
+  const explicitSpecRoot = readString(process.env['EMBER_ORCHESTRATION_V1_SPEC_ROOT']);
+  if (explicitSpecRoot) {
+    const candidate = path.join(explicitSpecRoot, 'smoke.identities.local.json');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  const inferredSpecRoot = resolveSingleWorktree('ember-orchestration-v1-spec');
+  if (inferredSpecRoot) {
+    const candidate = path.join(inferredSpecRoot, 'smoke.identities.local.json');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function readIdentities(): IdentityFile {
+  const identitiesPath = resolveIdentitiesFilePath();
+  if (identitiesPath) {
+    return JSON.parse(readFileSync(identitiesPath, 'utf8')) as IdentityFile;
+  }
+
+  const bundleRoot = resolveBundleRoot();
+  if (!bundleRoot) {
+    throw new Error(
+      'Unable to resolve smoke identities or local stack bundle. Set PM_SWAP_SMOKE_IDENTITIES_PATH, EMBER_ORCHESTRATION_V1_SPEC_ROOT, or PM_SWAP_SMOKE_BUNDLE_ROOT.',
+    );
+  }
+
+  const webEnv = parseDotEnvFile(path.join(bundleRoot, 'vibekit', 'web.env'));
+  const rootOwnerPrivateKey = readString(webEnv['FUNDING_WALLET_PRIVATE_KEY']);
+  if (!rootOwnerPrivateKey?.startsWith('0x')) {
+    throw new Error('Bundle vibekit/web.env is missing FUNDING_WALLET_PRIVATE_KEY.');
+  }
+
+  const managedOnboardingPath = path.join(
+    bundleRoot,
+    'shared-ember',
+    'shared-ember-managed-onboarding.ember-lending.json',
+  );
+  const managedOnboarding = existsSync(managedOnboardingPath)
+    ? (JSON.parse(readFileSync(managedOnboardingPath, 'utf8')) as Record<string, unknown>)
+    : {};
+  const emberLending =
+    isRecord(managedOnboarding['ember-lending']) ? managedOnboarding['ember-lending'] : {};
+  const controllerPrivateKey = readString(emberLending['controllerPrivateKey']);
+
+  return {
+    root_owner: {
+      private_key: rootOwnerPrivateKey as `0x${string}`,
+    },
+    subagent: {
+      private_key: (controllerPrivateKey?.startsWith('0x')
+        ? controllerPrivateKey
+        : rootOwnerPrivateKey) as `0x${string}`,
+    },
+  };
+}
+
+function parseReadyLine(line: string): Record<string, unknown> | null {
+  const marker = 'READY ';
+  const markerIndex = line.indexOf(marker);
+  if (markerIndex < 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(line.slice(markerIndex + marker.length));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveLatestWalletQaReady(): Record<string, unknown> | null {
+  const sessionRoot = findSessionRoot();
+  if (!sessionRoot) {
+    return null;
+  }
+
+  const stackDir = path.join(sessionRoot, 'runtime', 'wallet-qa-stack');
+  if (!existsSync(stackDir)) {
+    return null;
+  }
+
+  const launcherLogs = readdirSync(stackDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.startsWith('launcher') && entry.name.endsWith('.log'))
+    .map((entry) => {
+      const filePath = path.join(stackDir, entry.name);
+      return {
+        filePath,
+        mtimeMs: statSync(filePath).mtimeMs,
+      };
+    })
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  for (const log of launcherLogs) {
+    const ready = readFileSync(log.filePath, 'utf8')
+      .split(/\r?\n/u)
+      .map(parseReadyLine)
+      .filter((entry): entry is Record<string, unknown> => entry !== null)
+      .at(-1);
+    if (ready) {
+      return ready;
+    }
+  }
+
+  return null;
+}
+
+function resolvePortfolioManagerBaseUrl(): string {
+  const explicit =
+    readString(process.env['PM_SWAP_SMOKE_PORTFOLIO_MANAGER_BASE_URL']) ??
+    readString(process.env['PORTFOLIO_MANAGER_AGENT_DEPLOYMENT_URL']);
+  if (explicit) {
+    return explicit;
+  }
+
+  const ready = resolveLatestWalletQaReady();
+  return readString(ready?.['portfolioManagerBaseUrl']) ?? DEFAULT_PORTFOLIO_MANAGER_BASE_URL;
+}
+
+function resolveChainConfig(rootWalletAddressOverride?: `0x${string}`): SmokeChainConfig {
+  const bundleRoot = resolveBundleRoot();
+  const webEnv = bundleRoot
+    ? parseDotEnvFile(path.join(bundleRoot, 'vibekit', 'web.env'))
+    : {};
+  const typescriptEnv = bundleRoot
+    ? parseDotEnvFile(path.join(bundleRoot, 'vibekit', 'typescript.env'))
+    : {};
+  const rootWalletAddress =
+    rootWalletAddressOverride ??
+    readString(process.env['PM_SWAP_SMOKE_ROOT_WALLET_ADDRESS']) ??
+    readString(webEnv['NEXT_PUBLIC_WALLET_BYPASS_ADDRESS']);
+  if (!rootWalletAddress?.startsWith('0x')) {
+    throw new Error(
+      'PM_SWAP_SMOKE_ROOT_WALLET_ADDRESS or bundle NEXT_PUBLIC_WALLET_BYPASS_ADDRESS is required to prove actual swap balance deltas.',
+    );
+  }
+
+  return {
+    rootWalletAddress: rootWalletAddress as `0x${string}`,
+    rpcUrl:
+      readString(process.env['ARBITRUM_RPC_URL']) ??
+      readString(typescriptEnv['RPC_URL']) ??
+      DEFAULT_ARBITRUM_RPC_URL,
+  };
+}
+
+function resolveFundingConfig(chainConfig: SmokeChainConfig): WalletFundingConfig | null {
+  if (!readBool(process.env['PM_SWAP_SMOKE_ENABLE_FUNDING'])) {
+    return null;
+  }
+
+  const bundleRoot = resolveBundleRoot();
+  const webEnv = bundleRoot
+    ? parseDotEnvFile(path.join(bundleRoot, 'vibekit', 'web.env'))
+    : {};
+  const fundingPrivateKey = readString(process.env['PM_SWAP_SMOKE_FUNDING_WALLET_PRIVATE_KEY']) ??
+    readString(webEnv['FUNDING_WALLET_PRIVATE_KEY']);
+  if (!fundingPrivateKey?.startsWith('0x')) {
+    throw new Error('Funding is enabled, but FUNDING_WALLET_PRIVATE_KEY was not found.');
+  }
+
+  return {
+    fundingPrivateKey: fundingPrivateKey as `0x${string}`,
+    rootWalletAddress: chainConfig.rootWalletAddress,
+    rpcUrl: chainConfig.rpcUrl,
+    minRootEth: parseUnits(process.env['PM_SWAP_SMOKE_MIN_ROOT_ETH'] ?? '0.00015', 18),
+    minRootWeth: parseUnits(process.env['PM_SWAP_SMOKE_MIN_ROOT_WETH'] ?? '0.001', 18),
+  };
+}
+
+async function ensureSmokeFunding(config: WalletFundingConfig): Promise<void> {
+  const account = privateKeyToAccount(config.fundingPrivateKey);
+  const publicClient = createPublicClient({
+    chain: arbitrum,
+    transport: http(config.rpcUrl),
+  });
+  const walletClient = createWalletClient({
+    account,
+    chain: arbitrum,
+    transport: http(config.rpcUrl),
+  });
+
+  const rootEthBalance = await publicClient.getBalance({ address: config.rootWalletAddress });
+  if (rootEthBalance < config.minRootEth) {
+    const hash = await walletClient.sendTransaction({
+      account,
+      to: config.rootWalletAddress,
+      value: config.minRootEth - rootEthBalance,
+      chain: arbitrum,
+      maxFeePerGas: parseGwei('0.1'),
+      maxPriorityFeePerGas: parseGwei('0.01'),
+    });
+    await publicClient.waitForTransactionReceipt({ hash });
+    console.log(JSON.stringify({ phase: 'funding-root-eth', hash }));
+  }
+
+  const rootWethBalance = await publicClient.readContract({
+    address: WETH,
+    abi: WETH_ABI,
+    functionName: 'balanceOf',
+    args: [config.rootWalletAddress],
+  });
+  if (rootWethBalance >= config.minRootWeth) {
+    console.log(
+      JSON.stringify({
+        phase: 'funding-skip-weth',
+        rootWalletAddress: config.rootWalletAddress,
+      }),
+    );
+    return;
+  }
+
+  const deficit = config.minRootWeth - rootWethBalance;
+  const fundingWethBalance = await publicClient.readContract({
+    address: WETH,
+    abi: WETH_ABI,
+    functionName: 'balanceOf',
+    args: [account.address],
+  });
+  if (fundingWethBalance < deficit) {
+    const depositHash = await walletClient.sendTransaction({
+      account,
+      to: WETH,
+      value: deficit - fundingWethBalance,
+      data: encodeFunctionData({
+        abi: WETH_ABI,
+        functionName: 'deposit',
+      }),
+      chain: arbitrum,
+      maxFeePerGas: parseGwei('0.1'),
+      maxPriorityFeePerGas: parseGwei('0.01'),
+    });
+    await publicClient.waitForTransactionReceipt({ hash: depositHash });
+    console.log(JSON.stringify({ phase: 'funding-wrap-weth', hash: depositHash }));
+  }
+
+  const transferHash = await walletClient.sendTransaction({
+    account,
+    to: WETH,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: WETH_ABI,
+      functionName: 'transfer',
+      args: [config.rootWalletAddress, deficit],
+    }),
+    chain: arbitrum,
+    maxFeePerGas: parseGwei('0.1'),
+    maxPriorityFeePerGas: parseGwei('0.01'),
+  });
+  await publicClient.waitForTransactionReceipt({ hash: transferHash });
+  console.log(JSON.stringify({ phase: 'funding-transfer-weth', hash: transferHash }));
+}
+
+async function readTokenBalance(input: {
+  publicClient: PublicClient;
+  tokenAddress: `0x${string}`;
+  walletAddress: `0x${string}`;
+}): Promise<bigint> {
+  return await input.publicClient.readContract({
+    address: input.tokenAddress,
+    abi: WETH_ABI,
+    functionName: 'balanceOf',
+    args: [input.walletAddress],
+  });
+}
+
+async function readSwapBalances(input: {
+  publicClient: PublicClient;
+  walletAddress: `0x${string}`;
+}): Promise<SwapBalances> {
+  const [weth, usdc] = await Promise.all([
+    readTokenBalance({
+      publicClient: input.publicClient,
+      tokenAddress: WETH,
+      walletAddress: input.walletAddress,
+    }),
+    readTokenBalance({
+      publicClient: input.publicClient,
+      tokenAddress: USDC,
+      walletAddress: input.walletAddress,
+    }),
+  ]);
+  return { weth, usdc };
+}
+
+function formatSwapBalances(balances: SwapBalances): Record<string, string> {
+  return {
+    weth: formatUnits(balances.weth, 18),
+    usdc: formatUnits(balances.usdc, 6),
+  };
+}
+
+function createBrowserStyleSigningWalletClient(
+  account: ReturnType<typeof privateKeyToAccount>,
+) {
+  const provider = {
+    async request(input: { method: string; params?: unknown[] }) {
+      const { method, params } = input;
+      if (method === 'eth_chainId') {
+        return `0x${CHAIN_ID.toString(16)}`;
+      }
+
+      if (method === 'eth_accounts' || method === 'eth_requestAccounts') {
+        return [account.address];
+      }
+
+      if (method === 'eth_signTypedData_v4') {
+        const [, typedDataJson] = Array.isArray(params) ? params : [];
+        const typedData =
+          typeof typedDataJson === 'string' ? JSON.parse(typedDataJson) : typedDataJson;
+        const { domain, types, primaryType, message } = typedData as {
+          domain: Record<string, unknown>;
+          types: Record<string, unknown>;
+          primaryType: string;
+          message: Record<string, unknown>;
+        };
+        const { EIP712Domain: _ignoredDomain, ...restTypes } = types ?? {};
+        return account.signTypedData({
+          domain,
+          types: restTypes as Record<string, readonly { name: string; type: string }[]>,
+          primaryType,
+          message,
+        });
+      }
+
+      throw new Error(`Unsupported browser-style signing method: ${method}`);
+    },
+  };
+
+  return createWalletClient({
+    account: account.address,
+    chain: arbitrum,
+    transport: custom(provider),
+  });
+}
+
+async function ensureStateless7702Ready(input: {
+  publicClient: PublicClient;
+  ownerWalletClient: ReturnType<typeof createWalletClient>;
+  executorAccount: ReturnType<typeof privateKeyToAccount>;
+  rootAddress: `0x${string}`;
+  rpcUrl: string;
+}): Promise<void> {
+  const currentCode = await input.publicClient.getCode({ address: input.rootAddress });
+  if (currentCode && currentCode !== '0x') {
+    return;
+  }
+
+  const environment = getDeleGatorEnvironment(CHAIN_ID);
+  const implementationAddress = environment.implementations.EIP7702StatelessDeleGatorImpl;
+  const authorization = await signAuthorization(input.ownerWalletClient, {
+    contractAddress: implementationAddress,
+    executor: input.executorAccount.address,
+  });
+
+  const executorWalletClient = createWalletClient({
+    account: input.executorAccount,
+    chain: arbitrum,
+    transport: http(input.rpcUrl),
+  });
+
+  const upgradeHash = await executorWalletClient.sendTransaction({
+    type: 'eip7702',
+    account: input.executorAccount,
+    chain: arbitrum,
+    to: input.rootAddress,
+    data: '0x',
+    value: 0n,
+    authorizationList: [
+      {
+        chainId: authorization.chainId,
+        address: authorization.address,
+        nonce: authorization.nonce,
+        r: authorization.r,
+        s: authorization.s,
+        v: authorization.v,
+        yParity: authorization.yParity,
+      },
+    ],
+    gas: 120000n,
+    maxFeePerGas: parseGwei('0.1'),
+    maxPriorityFeePerGas: parseGwei('0.01'),
+  });
+
+  await input.publicClient.waitForTransactionReceipt({ hash: upgradeHash });
+
+  const codeAfterUpgrade = await input.publicClient.getCode({ address: input.rootAddress });
+  if (!codeAfterUpgrade || codeAfterUpgrade === '0x') {
+    throw new Error(`7702 upgrade did not install code at ${input.rootAddress}`);
+  }
+
+  console.log(JSON.stringify({ phase: 'root-7702-upgrade', hash: upgradeHash }));
+}
+
+async function ensureRootSmartHasWeth(input: {
+  publicClient: PublicClient;
+  walletClient: ReturnType<typeof createWalletClient>;
+  ownerAccount: ReturnType<typeof privateKeyToAccount>;
+  rootSmartAccount: Awaited<ReturnType<typeof toMetaMaskSmartAccount>>;
+  minimumBalance: bigint;
+}): Promise<bigint> {
+  const currentBalance = await input.publicClient.readContract({
+    address: WETH,
+    abi: WETH_ABI,
+    functionName: 'balanceOf',
+    args: [input.rootSmartAccount.address],
+  });
+
+  if (currentBalance >= input.minimumBalance) {
+    return currentBalance;
+  }
+
+  const depositAmount = input.minimumBalance - currentBalance;
+  const depositHash = await input.walletClient.sendTransaction({
+    account: input.ownerAccount,
+    to: WETH,
+    value: depositAmount,
+    data: encodeFunctionData({
+      abi: WETH_ABI,
+      functionName: 'deposit',
+    }),
+  });
+  await input.publicClient.waitForTransactionReceipt({ hash: depositHash });
+  console.log(JSON.stringify({ phase: 'root-wrap-weth', hash: depositHash }));
+
+  return await input.publicClient.readContract({
+    address: WETH,
+    abi: WETH_ABI,
+    functionName: 'balanceOf',
+    args: [input.rootSmartAccount.address],
+  });
+}
+
+function parseEventStreamBody(body: string): unknown[] {
+  return body
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => JSON.parse(line.slice('data: '.length)));
+}
+
+async function readEventStreamUntilStateSnapshot(response: Response): Promise<unknown[]> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return [];
+  }
+
+  const decoder = new TextDecoder();
+  const events: unknown[] = [];
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary !== -1) {
+      const frame = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      for (const line of frame.split('\n')) {
+        if (!line.startsWith('data: ')) {
+          continue;
+        }
+
+        const event = JSON.parse(line.slice('data: '.length));
+        events.push(event);
+        if (isRecord(event) && event['type'] === 'STATE_SNAPSHOT') {
+          await reader.cancel();
+          return events;
+        }
+      }
+      boundary = buffer.indexOf('\n\n');
+    }
+  }
+
+  return events;
+}
+
+function findStateSnapshot(events: unknown[]): AgUiSnapshot | null {
+  const snapshot = [...events].reverse().find(
+    (event) => isRecord(event) && event['type'] === 'STATE_SNAPSHOT',
+  );
+  return (snapshot as AgUiSnapshot | undefined) ?? null;
+}
+
+function findMessagesSnapshotEvent(events: unknown[]) {
+  const snapshot = [...events].reverse().find(
+    (event) => isRecord(event) && event['type'] === 'MESSAGES_SNAPSHOT' && Array.isArray(event['messages']),
+  );
+  return isRecord(snapshot) ? snapshot : null;
+}
+
+function readMessageContentText(content: unknown): string | null {
+  if (typeof content === 'string' && content.trim().length > 0) {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const text = content
+    .map((part) => (isRecord(part) && part['type'] === 'text' ? readString(part['text']) : null))
+    .filter((part): part is string => part !== null)
+    .join('');
+
+  return text.trim().length > 0 ? text : null;
+}
+
+function readLatestAssistantText(events: unknown[]): string | null {
+  const messages = findMessagesSnapshotEvent(events)?.['messages'];
+  if (!Array.isArray(messages)) {
+    return null;
+  }
+
+  for (const message of [...messages].reverse()) {
+    if (!isRecord(message) || readString(message['role']) !== 'assistant') {
+      continue;
+    }
+
+    const text = readMessageContentText(message['content']);
+    if (text) {
+      return text;
+    }
+  }
+
+  return null;
+}
+
+function compactRunText(result: AgentRunResult): string {
+  return [
+    result.assistantText,
+    JSON.stringify(result.snapshot?.snapshot?.thread?.lifecycle ?? null),
+    JSON.stringify(result.snapshot?.snapshot?.thread?.artifacts?.current?.data ?? null),
+    JSON.stringify(result.events),
+  ]
+    .filter((part): part is string => typeof part === 'string' && part.length > 0)
+    .join('\n')
+    .slice(0, 30_000);
+}
+
+function truncateForLog(text: string, maxLength = 500): string {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)}...`;
+}
+
+function readTransactionHash(value: unknown): `0x${string}` | null {
+  const candidate = readString(value);
+  return candidate && TRANSACTION_HASH_PATTERN.test(candidate)
+    ? (candidate as `0x${string}`)
+    : null;
+}
+
+function findTransactionHash(value: unknown, depth = 0): `0x${string}` | null {
+  if (depth > 8) {
+    return null;
+  }
+
+  const direct = readTransactionHash(value);
+  if (direct) {
+    return direct;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = findTransactionHash(item, depth + 1);
+      if (nested) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  for (const key of ['lastExecutionTxHash', 'transactionHash', 'transaction_hash', 'txHash']) {
+    const nested = readTransactionHash(value[key]);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    const nested = findTransactionHash(nestedValue, depth + 1);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function readExecutionTransactionHash(result: AgentRunResult): `0x${string}` | null {
+  return (
+    findTransactionHash(result.snapshot?.snapshot?.thread?.lifecycle) ??
+    findTransactionHash(result.snapshot?.snapshot?.thread?.artifacts?.current?.data) ??
+    findTransactionHash(result.events)
+  );
+}
+
+function readSnapshotLifecycle(snapshot: AgUiSnapshot | null) {
+  return snapshot?.snapshot?.thread?.lifecycle ?? null;
+}
+
+function readSnapshotArtifact(snapshot: AgUiSnapshot | null) {
+  return snapshot?.snapshot?.thread?.artifacts?.current?.data ?? null;
+}
+
+function readSnapshotActivityEvents(snapshot: AgUiSnapshot | null): unknown[] {
+  const events = snapshot?.snapshot?.thread?.activity?.events;
+  return Array.isArray(events) ? events : [];
+}
+
+function readSnapshotTaskInterrupts(snapshot: AgUiSnapshot | null): unknown[] {
+  const tasks = snapshot?.snapshot?.tasks;
+  if (!Array.isArray(tasks)) {
+    return [];
+  }
+
+  return tasks.flatMap((task) => {
+    const interrupts = task?.interrupts;
+    return Array.isArray(interrupts) ? interrupts.map((interrupt) => interrupt?.value) : [];
+  });
+}
+
+function readInterruptPayloadFromUnknown(value: unknown): DelegationSigningInterruptPayload | null {
+  const candidate =
+    typeof value === 'string' ? parseJsonMaybe<Record<string, unknown>>(value) : value;
+  if (!isRecord(candidate)) {
+    return null;
+  }
+
+  const type = readString(candidate['type']);
+  if (type && type !== 'portfolio-manager-delegation-signing-request') {
+    return null;
+  }
+
+  const chainId = candidate['chainId'];
+  const delegationManager = readString(candidate['delegationManager']) as `0x${string}` | null;
+  const delegatorAddress = readString(candidate['delegatorAddress']) as `0x${string}` | null;
+  const delegateeAddress = readString(candidate['delegateeAddress']) as `0x${string}` | null;
+  const delegationsToSign = candidate['delegationsToSign'];
+
+  if (
+    typeof chainId !== 'number' ||
+    !delegationManager ||
+    !delegatorAddress ||
+    !delegateeAddress ||
+    !Array.isArray(delegationsToSign)
+  ) {
+    return null;
+  }
+
+  return {
+    type: 'portfolio-manager-delegation-signing-request',
+    chainId,
+    delegationManager,
+    delegatorAddress,
+    delegateeAddress,
+    delegationsToSign: delegationsToSign as UnsignedDelegation[],
+  };
+}
+
+function findPortfolioManagerSigningInterrupt(
+  value: unknown,
+  depth = 0,
+): DelegationSigningInterruptPayload | null {
+  if (depth > 8) {
+    return null;
+  }
+
+  const direct = readInterruptPayloadFromUnknown(value);
+  if (direct) {
+    return direct;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = findPortfolioManagerSigningInterrupt(item, depth + 1);
+      if (nested) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    const nested = findPortfolioManagerSigningInterrupt(nestedValue, depth + 1);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function readPortfolioManagerSigningInterrupt(
+  snapshot: AgUiSnapshot | null,
+  events: unknown[] = [],
+): DelegationSigningInterruptPayload | null {
+  const eventInterrupt = findPortfolioManagerSigningInterrupt(events);
+  if (eventInterrupt) {
+    return eventInterrupt;
+  }
+
+  const currentArtifact = readSnapshotArtifact(snapshot);
+  if (isRecord(currentArtifact) && currentArtifact['type'] === 'interrupt-status') {
+    const interruptPayload = readInterruptPayloadFromUnknown(currentArtifact['payload']);
+    if (interruptPayload) {
+      return interruptPayload;
+    }
+  }
+
+  for (const event of readSnapshotActivityEvents(snapshot)) {
+    if (!isRecord(event) || !Array.isArray(event['parts'])) {
+      continue;
+    }
+
+    for (const part of event['parts']) {
+      if (!isRecord(part) || part['kind'] !== 'a2ui' || !isRecord(part['data'])) {
+        continue;
+      }
+
+      const payload = part['data']['payload'];
+      if (!isRecord(payload)) {
+        continue;
+      }
+
+      const maybeInterrupt =
+        readString(payload['kind']) === 'interrupt' ? payload['payload'] : payload;
+      const interruptPayload = readInterruptPayloadFromUnknown(maybeInterrupt);
+      if (interruptPayload) {
+        return interruptPayload;
+      }
+    }
+  }
+
+  for (const interruptValue of readSnapshotTaskInterrupts(snapshot)) {
+    const interruptPayload = readInterruptPayloadFromUnknown(interruptValue);
+    if (interruptPayload) {
+      return interruptPayload;
+    }
+  }
+
+  return null;
+}
+
+function readStateDeltaOperations(events: unknown[]): Array<Record<string, unknown>> {
+  return events.flatMap((event) => {
+    if (!isRecord(event) || event['type'] !== 'STATE_DELTA' || !Array.isArray(event['delta'])) {
+      return [];
+    }
+    return event['delta'].filter((operation): operation is Record<string, unknown> =>
+      isRecord(operation),
+    );
+  });
+}
+
+function hasStateReplace(input: {
+  events: unknown[];
+  path: string;
+  value: unknown;
+}): boolean {
+  return readStateDeltaOperations(input.events).some(
+    (operation) =>
+      operation['op'] === 'replace' &&
+      operation['path'] === input.path &&
+      operation['value'] === input.value,
+  );
+}
+
+function buildPortfolioManagerSetupInput(walletAddress: `0x${string}`) {
+  return {
+    walletAddress,
+    portfolioMandate: {
+      approved: true,
+      riskLevel: 'medium',
+    },
+    firstManagedMandate: {
+      targetAgentId: 'ember-lending',
+      targetAgentKey: 'ember-lending-primary',
+      managedMandate: {
+        lending_policy: {
+          collateral_policy: {
+            assets: [
+              {
+                asset: 'USDC',
+                max_allocation_pct: 35,
+              },
+              {
+                asset: 'WETH',
+                max_allocation_pct: 35,
+              },
+            ],
+          },
+          borrow_policy: {
+            allowed_assets: ['USDC'],
+          },
+          risk_policy: {
+            max_ltv_bps: 7000,
+            min_health_factor: '1.25',
+          },
+        },
+      },
+    },
+  };
+}
+
+async function signRootDelegation(input: {
+  walletClient: ReturnType<typeof createWalletClient>;
+  delegation: UnsignedDelegation;
+  delegationManager: `0x${string}`;
+  chainId: number;
+  account: `0x${string}`;
+}) {
+  return await signDelegationWithFallback({
+    walletClient: input.walletClient,
+    delegation: input.delegation,
+    delegationManager: input.delegationManager,
+    chainId: input.chainId,
+    account: input.account,
+  });
+}
+
+async function runAgentCommand(input: {
+  baseUrl: string;
+  threadId: string;
+  runId: string;
+  command: Record<string, unknown>;
+}): Promise<{ events: unknown[]; snapshot: AgUiSnapshot | null }> {
+  const response = await fetch(`${input.baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      threadId: input.threadId,
+      runId: input.runId,
+      forwardedProps: {
+        command: input.command,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${PORTFOLIO_MANAGER_AGENT_ID} command run failed with HTTP ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  const events = parseEventStreamBody(await response.text());
+  return {
+    events,
+    snapshot: findStateSnapshot(events),
+  };
+}
+
+async function connectAgent(input: {
+  baseUrl: string;
+  threadId: string;
+  runId: string;
+}): Promise<{ events: unknown[]; snapshot: AgUiSnapshot | null }> {
+  const response = await fetch(`${input.baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/connect`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      threadId: input.threadId,
+      runId: input.runId,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${PORTFOLIO_MANAGER_AGENT_ID} connect failed with HTTP ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  const events = await readEventStreamUntilStateSnapshot(response);
+  return {
+    events,
+    snapshot: findStateSnapshot(events),
+  };
+}
+
+async function runAgentMessage(input: {
+  baseUrl: string;
+  threadId: string;
+  runId: string;
+  prompt: string;
+}): Promise<AgentRunResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${input.baseUrl}/agent/${PORTFOLIO_MANAGER_AGENT_ID}/run`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        threadId: input.threadId,
+        runId: input.runId,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: input.prompt,
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `${PORTFOLIO_MANAGER_AGENT_ID} message run failed with HTTP ${response.status}: ${await response.text()}`,
+      );
+    }
+
+    const events = parseEventStreamBody(await response.text());
+    return {
+      events,
+      snapshot: findStateSnapshot(events),
+      assistantText: readLatestAssistantText(events),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function assertNoObviousFailure(stage: string, result: AgentRunResult): void {
+  const text = compactRunText(result);
+  if (
+    /\b(failed|failure|could not|couldn't|can't|cannot|blocked|error|reverted|no transaction was sent|not submitted|invalid_request|internal_error|timed out)\b/iu.test(
+      text,
+    )
+  ) {
+    throw new Error(`${stage} surfaced a failure through AG-UI:\n${truncateForLog(text, 2_000)}`);
+  }
+}
+
+async function assertActualSwapExecution(input: {
+  stage: string;
+  result: AgentRunResult;
+  publicClient: PublicClient;
+  walletAddress: `0x${string}`;
+  before: SwapBalances;
+}): Promise<SwapExecutionProof> {
+  assertNoObviousFailure(input.stage, input.result);
+
+  const transactionHash = readExecutionTransactionHash(input.result);
+  if (!transactionHash) {
+    throw new Error(
+      `${input.stage} completed without an AG-UI-surfaced execution transaction hash:\n${truncateForLog(
+        compactRunText(input.result),
+        2_000,
+      )}`,
+    );
+  }
+
+  const receipt = await input.publicClient.waitForTransactionReceipt({ hash: transactionHash });
+  if (receipt.status !== 'success') {
+    throw new Error(`${input.stage} transaction ${transactionHash} did not succeed.`);
+  }
+
+  const startedAt = Date.now();
+  let latest = await readSwapBalances({
+    publicClient: input.publicClient,
+    walletAddress: input.walletAddress,
+  });
+  while (
+    !(latest.weth < input.before.weth && latest.usdc > input.before.usdc) &&
+    Date.now() - startedAt < BALANCE_DELTA_TIMEOUT_MS
+  ) {
+    await sleep(1_000);
+    latest = await readSwapBalances({
+      publicClient: input.publicClient,
+      walletAddress: input.walletAddress,
+    });
+  }
+
+  if (!(latest.weth < input.before.weth && latest.usdc > input.before.usdc)) {
+    throw new Error(
+      `${input.stage} transaction ${transactionHash} did not produce a WETH -> USDC root-wallet balance delta. ` +
+        `before=${JSON.stringify(formatSwapBalances(input.before))} after=${JSON.stringify(formatSwapBalances(latest))}`,
+    );
+  }
+
+  return {
+    transactionHash,
+    balances: latest,
+  };
+}
+
+function assertReservedConfirmationGate(stage: string, result: AgentRunResult): void {
+  const text = compactRunText(result);
+  if (/\b(completed|swapped|submitted|confirmed transaction)\b/iu.test(text)) {
+    return;
+  }
+  if (!/\breserved\b/iu.test(text) || !/\b(confirm|proceed|confirmation)\b/iu.test(text)) {
+    throw new Error(`${stage} did not surface the reserved-capital confirmation gate:\n${truncateForLog(text, 2_000)}`);
+  }
+}
+
+async function onboardPortfolioManagerThread(input: {
+  baseUrl: string;
+  threadId: string;
+  rootWalletAddress: `0x${string}`;
+  browserSigningWalletClient: ReturnType<typeof createWalletClient>;
+}): Promise<void> {
+  await runAgentCommand({
+    baseUrl: input.baseUrl,
+    threadId: input.threadId,
+    runId: `${input.threadId}-hire`,
+    command: {
+      name: 'hire',
+    },
+  });
+
+  const setupResult = await runAgentCommand({
+    baseUrl: input.baseUrl,
+    threadId: input.threadId,
+    runId: `${input.threadId}-setup`,
+    command: {
+      resume: JSON.stringify(buildPortfolioManagerSetupInput(input.rootWalletAddress)),
+    },
+  });
+  let signingInterrupt = readPortfolioManagerSigningInterrupt(
+    setupResult.snapshot,
+    setupResult.events,
+  );
+  let setupSnapshot = setupResult.snapshot;
+  let setupEvents = setupResult.events;
+  if (!signingInterrupt) {
+    const connectedSetup = await connectAgent({
+      baseUrl: input.baseUrl,
+      threadId: input.threadId,
+      runId: `${input.threadId}-setup-connect`,
+    });
+    setupSnapshot = connectedSetup.snapshot;
+    setupEvents = [...setupEvents, ...connectedSetup.events];
+    signingInterrupt = readPortfolioManagerSigningInterrupt(
+      connectedSetup.snapshot,
+      connectedSetup.events,
+    );
+  }
+  if (!signingInterrupt) {
+    throw new Error(
+      `Portfolio-manager setup did not emit a usable delegation-signing interrupt: ${truncateForLog(
+        JSON.stringify({
+          snapshot: setupSnapshot,
+          events: setupEvents,
+        }),
+        2_000,
+      )}`,
+    );
+  }
+  if (signingInterrupt.delegatorAddress.toLowerCase() !== input.rootWalletAddress.toLowerCase()) {
+    throw new Error(
+      `Portfolio-manager requested signing from ${signingInterrupt.delegatorAddress} but smoke root is ${input.rootWalletAddress}.`,
+    );
+  }
+
+  const signedDelegations: Array<UnsignedDelegation & { signature: `0x${string}` }> = [];
+  for (const delegation of signingInterrupt.delegationsToSign) {
+    const signature = await signRootDelegation({
+      walletClient: input.browserSigningWalletClient,
+      delegation,
+      delegationManager: signingInterrupt.delegationManager,
+      chainId: signingInterrupt.chainId,
+      account: signingInterrupt.delegatorAddress,
+    });
+    signedDelegations.push({ ...delegation, signature });
+  }
+
+  const signingResult = await runAgentCommand({
+    baseUrl: input.baseUrl,
+    threadId: input.threadId,
+    runId: `${input.threadId}-signing`,
+    command: {
+      resume: JSON.stringify({
+        outcome: 'signed',
+        signedDelegations,
+      }),
+    },
+  });
+
+  let signingSnapshot = signingResult.snapshot;
+  let signingEvents = signingResult.events;
+  if (
+    !signingSnapshot &&
+    !hasStateReplace({
+      events: signingEvents,
+      path: '/thread/lifecycle/phase',
+      value: 'active',
+    })
+  ) {
+    const connectedSigning = await connectAgent({
+      baseUrl: input.baseUrl,
+      threadId: input.threadId,
+      runId: `${input.threadId}-signing-connect`,
+    });
+    signingSnapshot = connectedSigning.snapshot;
+    signingEvents = [...signingEvents, ...connectedSigning.events];
+  }
+
+  const lifecycle = readSnapshotLifecycle(signingSnapshot);
+  const reachedActive =
+    (isRecord(lifecycle) && lifecycle['phase'] === 'active') ||
+    hasStateReplace({
+      events: signingEvents,
+      path: '/thread/lifecycle/phase',
+      value: 'active',
+    });
+  if (!reachedActive) {
+    throw new Error(
+      `Portfolio-manager onboarding did not complete: ${truncateForLog(
+        JSON.stringify({
+          snapshot: signingSnapshot,
+          events: signingEvents,
+        }),
+        2_000,
+      )}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify({
+      phase: 'portfolio-manager-onboarded',
+      rootWalletAddress: input.rootWalletAddress,
+      delegationCount: signedDelegations.length,
+    }),
+  );
+}
+
+async function main() {
+  const baseUrl = resolvePortfolioManagerBaseUrl();
+  const identities = readIdentities();
+  const rootAccount = privateKeyToAccount(identities.root_owner.private_key);
+  const executorAccount = privateKeyToAccount(identities.subagent.private_key);
+  const chainConfig = resolveChainConfig(rootAccount.address);
+  const publicClient = createPublicClient({
+    chain: arbitrum,
+    transport: http(chainConfig.rpcUrl),
+  });
+  const walletClient = createWalletClient({
+    account: rootAccount,
+    chain: arbitrum,
+    transport: http(chainConfig.rpcUrl),
+  });
+  const browserSigningWalletClient = createBrowserStyleSigningWalletClient(rootAccount);
+  const fundingConfig = resolveFundingConfig(chainConfig);
+  if (fundingConfig) {
+    await ensureSmokeFunding(fundingConfig);
+  }
+
+  await ensureStateless7702Ready({
+    publicClient,
+    ownerWalletClient: walletClient,
+    executorAccount,
+    rootAddress: rootAccount.address,
+    rpcUrl: chainConfig.rpcUrl,
+  });
+  const rootSmartAccount = await toMetaMaskSmartAccount({
+    client: publicClient,
+    implementation: Implementation.Stateless7702,
+    address: rootAccount.address,
+    signer: {
+      walletClient,
+    },
+  });
+  if (rootSmartAccount.address.toLowerCase() !== chainConfig.rootWalletAddress.toLowerCase()) {
+    throw new Error(
+      `Resolved root smart account ${rootSmartAccount.address} did not match smoke wallet ${chainConfig.rootWalletAddress}.`,
+    );
+  }
+  const fundedWethBalance = await ensureRootSmartHasWeth({
+    publicClient,
+    walletClient,
+    ownerAccount: rootAccount,
+    rootSmartAccount,
+    minimumBalance:
+      fundingConfig?.minRootWeth ??
+      parseUnits(process.env['PM_SWAP_SMOKE_MIN_ROOT_WETH'] ?? '0.001', 18),
+  });
+
+  const timestamp = Date.now();
+  const portfolioThreadId = `pm-swap-smoke-${timestamp}`;
+  const nonReservedPrompt =
+    readString(process.env['PM_SWAP_SMOKE_NON_RESERVED_PROMPT']) ??
+    `For wallet ${chainConfig.rootWalletAddress}, swap exactly 0.00010 WETH that is not reserved for USDC on Arbitrum. Use unassigned or unreserved capital only.`;
+  const mixedPrompt =
+    readString(process.env['PM_SWAP_SMOKE_MIXED_PROMPT']) ??
+    `For wallet ${chainConfig.rootWalletAddress}, swap exactly 0.00010 WETH to USDC on Arbitrum using a mixed source: include some unreserved WETH and some WETH currently reserved for another agent. Do not use only one pool.`;
+  const reservedPrompt =
+    readString(process.env['PM_SWAP_SMOKE_RESERVED_PROMPT']) ??
+    `For wallet ${chainConfig.rootWalletAddress}, swap exactly 0.00005 WETH from the WETH currently reserved for another agent to USDC on Arbitrum.`;
+  const confirmPrompt = readString(process.env['PM_SWAP_SMOKE_CONFIRM_PROMPT']) ?? 'yes';
+
+  console.log(
+    JSON.stringify({
+      phase: 'start',
+      portfolioManagerBaseUrl: baseUrl,
+      rootWalletAddress: chainConfig.rootWalletAddress,
+      wethBalance: formatUnits(fundedWethBalance, 18),
+      fundingEnabled: fundingConfig !== null,
+    }),
+  );
+
+  await onboardPortfolioManagerThread({
+    baseUrl,
+    threadId: portfolioThreadId,
+    rootWalletAddress: chainConfig.rootWalletAddress,
+    browserSigningWalletClient,
+  });
+
+  const nonReservedBefore = await readSwapBalances({
+    publicClient,
+    walletAddress: chainConfig.rootWalletAddress,
+  });
+  const nonReservedResult = await runAgentMessage({
+    baseUrl,
+    threadId: portfolioThreadId,
+    runId: `${portfolioThreadId}-unreserved-swap`,
+    prompt: nonReservedPrompt,
+  });
+  const nonReservedProof = await assertActualSwapExecution({
+    stage: 'non-reserved swap',
+    result: nonReservedResult,
+    publicClient,
+    walletAddress: chainConfig.rootWalletAddress,
+    before: nonReservedBefore,
+  });
+  console.log(
+    JSON.stringify({
+      phase: 'non-reserved-swap-complete',
+      transactionHash: nonReservedProof.transactionHash,
+      before: formatSwapBalances(nonReservedBefore),
+      after: formatSwapBalances(nonReservedProof.balances),
+      assistantText: truncateForLog(nonReservedResult.assistantText ?? ''),
+    }),
+  );
+
+  const mixedBefore = await readSwapBalances({
+    publicClient,
+    walletAddress: chainConfig.rootWalletAddress,
+  });
+  const mixedGateResult = await runAgentMessage({
+    baseUrl,
+    threadId: portfolioThreadId,
+    runId: `${portfolioThreadId}-mixed-gate`,
+    prompt: mixedPrompt,
+  });
+  assertReservedConfirmationGate('mixed swap confirmation gate', mixedGateResult);
+  console.log(
+    JSON.stringify({
+      phase: 'mixed-confirmation-gate',
+      assistantText: truncateForLog(mixedGateResult.assistantText ?? ''),
+    }),
+  );
+
+  const mixedConfirmedResult = await runAgentMessage({
+    baseUrl,
+    threadId: portfolioThreadId,
+    runId: `${portfolioThreadId}-mixed-confirmed`,
+    prompt: confirmPrompt,
+  });
+  const mixedProof = await assertActualSwapExecution({
+    stage: 'mixed swap confirmation',
+    result: mixedConfirmedResult,
+    publicClient,
+    walletAddress: chainConfig.rootWalletAddress,
+    before: mixedBefore,
+  });
+  console.log(
+    JSON.stringify({
+      phase: 'mixed-swap-complete',
+      transactionHash: mixedProof.transactionHash,
+      before: formatSwapBalances(mixedBefore),
+      after: formatSwapBalances(mixedProof.balances),
+      assistantText: truncateForLog(mixedConfirmedResult.assistantText ?? ''),
+    }),
+  );
+
+  const reservedBefore = await readSwapBalances({
+    publicClient,
+    walletAddress: chainConfig.rootWalletAddress,
+  });
+  const reservedGateResult = await runAgentMessage({
+    baseUrl,
+    threadId: portfolioThreadId,
+    runId: `${portfolioThreadId}-reserved-gate`,
+    prompt: reservedPrompt,
+  });
+  assertReservedConfirmationGate('reserved swap confirmation gate', reservedGateResult);
+  console.log(
+    JSON.stringify({
+      phase: 'reserved-confirmation-gate',
+      assistantText: truncateForLog(reservedGateResult.assistantText ?? ''),
+    }),
+  );
+
+  const reservedConfirmedResult = await runAgentMessage({
+    baseUrl,
+    threadId: portfolioThreadId,
+    runId: `${portfolioThreadId}-reserved-confirmed`,
+    prompt: confirmPrompt,
+  });
+  const reservedProof = await assertActualSwapExecution({
+    stage: 'reserved swap confirmation',
+    result: reservedConfirmedResult,
+    publicClient,
+    walletAddress: chainConfig.rootWalletAddress,
+    before: reservedBefore,
+  });
+  console.log(
+    JSON.stringify({
+      phase: 'reserved-swap-complete',
+      transactionHash: reservedProof.transactionHash,
+      before: formatSwapBalances(reservedBefore),
+      after: formatSwapBalances(reservedProof.balances),
+      assistantText: truncateForLog(reservedConfirmedResult.assistantText ?? ''),
+    }),
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/typescript/clients/web-ag-ui/scripts/smoke/start-managed-shared-ember.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/start-managed-shared-ember.ts
@@ -9,6 +9,13 @@ function readString(value: string | undefined): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 }
 
+function readCommaSeparatedStrings(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 async function main() {
   const specRoot = readString(process.env.EMBER_ORCHESTRATION_V1_SPEC_ROOT);
   if (specRoot === null) {
@@ -23,12 +30,17 @@ async function main() {
     throw new Error(`Invalid SHARED_EMBER_PORT: ${process.env.SHARED_EMBER_PORT ?? ''}`);
   }
 
-  const managedAgentId =
-    readString(process.env.SHARED_EMBER_MANAGED_AGENT_ID) ?? DEFAULT_MANAGED_AGENT_ID;
+  const configuredManagedAgentIds = readCommaSeparatedStrings(
+    process.env.SHARED_EMBER_MANAGED_AGENT_IDS,
+  );
+  const managedAgentIds =
+    configuredManagedAgentIds.length > 0
+      ? configuredManagedAgentIds
+      : [readString(process.env.SHARED_EMBER_MANAGED_AGENT_ID) ?? DEFAULT_MANAGED_AGENT_ID];
   const server = await startManagedSharedEmberHarness({
     specRoot,
     vibekitRoot,
-    managedAgentId,
+    managedAgentIds,
     host,
     port,
   });

--- a/typescript/clients/web-ag-ui/scripts/smoke/start-wallet-qa-stack.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/start-wallet-qa-stack.ts
@@ -50,6 +50,7 @@ const DEFAULT_PI_DATABASE_URL = 'postgresql://postgres:postgres@127.0.0.1:55432/
 const DEFAULT_ONCHAIN_ACTIONS_PORT = 50051;
 const DEFAULT_SHARED_EMBER_PORT = 4010;
 const DEFAULT_WEB_PORT = 3000;
+const WALLET_QA_MANAGED_AGENT_IDS = ['ember-lending', 'agent-oca-executor'] as const;
 const HOST = '127.0.0.1';
 const HEALTH_TIMEOUT_MS = 90_000;
 
@@ -877,7 +878,7 @@ async function main() {
     sharedEmberServer = await startManagedSharedEmberHarness({
       specRoot: workspace.specRoot,
       vibekitRoot: workspace.vibekitRoot,
-      managedAgentId: 'ember-lending',
+      managedAgentIds: WALLET_QA_MANAGED_AGENT_IDS,
       host: HOST,
       port: sharedEmberPort.port,
     });

--- a/typescript/clients/web-ag-ui/scripts/smoke/start-wallet-qa-stack.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/start-wallet-qa-stack.ts
@@ -640,6 +640,9 @@ async function main() {
   const explicitPortfolioManagerWalletId = readString(
     process.env.WALLET_QA_PORTFOLIO_MANAGER_OWS_WALLET_ID,
   );
+  const explicitPortfolioManagerOcaExecutorWalletId = readString(
+    process.env.WALLET_QA_PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_ID,
+  );
   const explicitEmberLendingWalletId = readString(
     process.env.WALLET_QA_EMBER_LENDING_OWS_WALLET_ID,
   );
@@ -660,6 +663,10 @@ async function main() {
     portfolioManagerWalletName:
       explicitPortfolioManagerWalletId ??
       readString(portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OWS_WALLET_NAME),
+    portfolioManagerOcaExecutorWalletName:
+      explicitPortfolioManagerOcaExecutorWalletId ??
+      readString(portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME) ??
+      undefined,
     emberLendingWalletName:
       explicitEmberLendingWalletId ??
       readString(emberLendingBaseEnv.EMBER_LENDING_OWS_WALLET_NAME),
@@ -765,6 +772,17 @@ async function main() {
         : resolvedWalletIds.portfolioManagerWalletId
         ? {
             PORTFOLIO_MANAGER_OWS_WALLET_NAME: resolvedWalletIds.portfolioManagerWalletId,
+          }
+        : {}),
+      ...(explicitPortfolioManagerOcaExecutorWalletId
+        ? {
+            PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME:
+              explicitPortfolioManagerOcaExecutorWalletId,
+          }
+        : resolvedWalletIds.portfolioManagerOcaExecutorWalletId
+        ? {
+            PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME:
+              resolvedWalletIds.portfolioManagerOcaExecutorWalletId,
           }
         : {}),
     },

--- a/typescript/clients/web-ag-ui/scripts/smoke/support/runtimePrep.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/support/runtimePrep.ts
@@ -38,6 +38,7 @@ type StartManagedSharedEmberHarnessDependencies =
   };
 
 const DEFAULT_MANAGED_AGENT_ID = 'ember-lending';
+const HIDDEN_OCA_EXECUTOR_AGENT_ID = 'agent-oca-executor';
 const DEFAULT_OWS_CHAIN = 'evm';
 const MAX_DECIMAL_TYPED_DATA_BIGINT = 1n << 128n;
 const EIP712_DOMAIN_TYPE = [
@@ -56,9 +57,34 @@ function readHexAddress(value: unknown): `0x${string}` | null {
   return normalized?.startsWith('0x') ? (normalized.toLowerCase() as `0x${string}`) : null;
 }
 
-function withDefaultManagedPlannerAgentId(input: {
+function normalizeManagedAgentIds(input: {
+  managedAgentId?: string;
+  managedAgentIds?: readonly string[];
+}): string[] {
+  const managedAgentIds = new Set<string>();
+
+  for (const agentId of input.managedAgentIds ?? []) {
+    const normalized = readString(agentId);
+    if (normalized !== null) {
+      managedAgentIds.add(normalized);
+    }
+  }
+
+  const managedAgentId = readString(input.managedAgentId);
+  if (managedAgentId !== null) {
+    managedAgentIds.add(managedAgentId);
+  }
+
+  if (managedAgentIds.size === 0) {
+    managedAgentIds.add(DEFAULT_MANAGED_AGENT_ID);
+  }
+
+  return Array.from(managedAgentIds);
+}
+
+function withManagedPlannerAgentIds(input: {
   env?: NodeJS.ProcessEnv;
-  managedAgentId: string;
+  managedAgentIds: readonly string[];
 }): NodeJS.ProcessEnv {
   const env = input.env ?? process.env;
   const configuredAgentIds = new Set(
@@ -68,7 +94,9 @@ function withDefaultManagedPlannerAgentId(input: {
       .filter(Boolean),
   );
 
-  configuredAgentIds.add(input.managedAgentId);
+  for (const managedAgentId of input.managedAgentIds) {
+    configuredAgentIds.add(managedAgentId);
+  }
 
   return {
     ...env,
@@ -91,6 +119,14 @@ function hasManagedSubmissionBinding(input: {
     | Record<string, unknown>
     | undefined;
   return submissionBackends?.[input.managedAgentId] !== undefined;
+}
+
+function formatMissingManagedSubmissionBindingMessage(managedAgentIds: readonly string[]): string {
+  if (managedAgentIds.length === 1) {
+    return `Managed Shared Ember bootstrap requires a seeded subagent runtime binding for ${managedAgentIds[0]}.`;
+  }
+
+  return `Managed Shared Ember bootstrap requires seeded subagent runtime bindings for ${managedAgentIds.join(', ')}.`;
 }
 
 export function parseDotEnvFile(filePath: string): Record<string, string> {
@@ -393,28 +429,49 @@ async function maybeCreateSubagentRuntimes(input: {
   const lendingEnv = parseDotEnvFile(
     path.join(input.vibekitRoot, 'typescript/clients/web-ag-ui/apps/agent-ember-lending/.env'),
   );
-  const lendingWalletName =
-    readString(process.env.EMBER_LENDING_OWS_WALLET_NAME) ??
-    readString(lendingEnv.EMBER_LENDING_OWS_WALLET_NAME);
-  const lendingVaultPath =
-    readString(process.env.EMBER_LENDING_OWS_VAULT_PATH) ??
-    readString(lendingEnv.EMBER_LENDING_OWS_VAULT_PATH);
-
-  if (!lendingWalletName) {
-    return undefined;
-  }
-
+  const portfolioManagerAppRoot = path.join(
+    input.vibekitRoot,
+    'typescript/clients/web-ag-ui/apps/agent-portfolio-manager',
+  );
   const lendingAppRoot = path.join(
     input.vibekitRoot,
     'typescript/clients/web-ag-ui/apps/agent-ember-lending',
   );
-  const requireFromLending = createRequire(path.join(lendingAppRoot, 'package.json'));
-  const { getWallet } = requireFromLending('@open-wallet-standard/core') as {
+  const runtimeWalletConfig =
+    input.managedAgentId === HIDDEN_OCA_EXECUTOR_AGENT_ID
+      ? {
+          label: 'Hidden OCA executor',
+          appRoot: portfolioManagerAppRoot,
+          walletName:
+            readString(process.env.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME) ??
+            readString(portfolioManagerEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME),
+          vaultPath:
+            readString(process.env.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH) ??
+            readString(portfolioManagerEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH) ??
+            controllerVaultPath,
+        }
+      : {
+          label: 'Ember-lending',
+          appRoot: lendingAppRoot,
+          walletName:
+            readString(process.env.EMBER_LENDING_OWS_WALLET_NAME) ??
+            readString(lendingEnv.EMBER_LENDING_OWS_WALLET_NAME),
+          vaultPath:
+            readString(process.env.EMBER_LENDING_OWS_VAULT_PATH) ??
+            readString(lendingEnv.EMBER_LENDING_OWS_VAULT_PATH),
+        };
+
+  if (!runtimeWalletConfig.walletName) {
+    return undefined;
+  }
+
+  const requireFromRuntimeApp = createRequire(path.join(runtimeWalletConfig.appRoot, 'package.json'));
+  const { getWallet } = requireFromRuntimeApp('@open-wallet-standard/core') as {
     getWallet: (walletName: string, vaultPath?: string) => {
       accounts: Array<{ address?: string }>;
     };
   };
-  const wallet = getWallet(lendingWalletName, lendingVaultPath ?? undefined);
+  const wallet = getWallet(runtimeWalletConfig.walletName, runtimeWalletConfig.vaultPath ?? undefined);
   const agentWallet =
     wallet.accounts
       .map((account) => readHexAddress(account.address))
@@ -422,7 +479,7 @@ async function maybeCreateSubagentRuntimes(input: {
 
   if (!agentWallet) {
     throw new Error(
-      `Ember-lending OWS wallet "${lendingWalletName}" did not resolve an EVM address for runtime binding bootstrap.`,
+      `${runtimeWalletConfig.label} OWS wallet "${runtimeWalletConfig.walletName}" did not resolve an EVM address for runtime binding bootstrap.`,
     );
   }
 
@@ -434,10 +491,6 @@ async function maybeCreateSubagentRuntimes(input: {
     },
   };
   if (controllerWalletName) {
-    const portfolioManagerAppRoot = path.join(
-      input.vibekitRoot,
-      'typescript/clients/web-ag-ui/apps/agent-portfolio-manager',
-    );
     const requireFromPortfolioManager = createRequire(
       path.join(portfolioManagerAppRoot, 'package.json'),
     );
@@ -623,6 +676,7 @@ async function maybeCreateSubagentRuntimes(input: {
       settlementProjector: {
         projectConfirmedExecution(input: {
           request: unknown;
+          transactionPlan?: unknown;
           reservation?: unknown;
           sourceUnits?: unknown[];
           requestId: string;
@@ -651,6 +705,7 @@ async function maybeCreateSubagentRuntimes(input: {
   )) as {
     projectLendingExecutionSuccessorPlans: (input: {
       request: unknown;
+      transactionPlan?: unknown;
       sourceUnits: unknown[];
       executionId: string;
       transactionHash: string;
@@ -681,6 +736,10 @@ async function maybeCreateSubagentRuntimes(input: {
         executionId,
         transactionHash,
       }) {
+        if (input.managedAgentId === HIDDEN_OCA_EXECUTOR_AGENT_ID) {
+          return [];
+        }
+
         return accountingModule.projectLendingExecutionSuccessorPlans({
           request,
           transactionPlan,
@@ -721,10 +780,14 @@ export async function startManagedSharedEmberHarness(input: {
   specRoot: string;
   vibekitRoot: string;
   managedAgentId?: string;
+  managedAgentIds?: readonly string[];
   host?: string;
   port?: number;
 }, dependencies: StartManagedSharedEmberHarnessDependencies = {}): Promise<StartedServer> {
-  const managedAgentId = input.managedAgentId ?? DEFAULT_MANAGED_AGENT_ID;
+  const managedAgentIds = normalizeManagedAgentIds({
+    managedAgentId: input.managedAgentId,
+    managedAgentIds: input.managedAgentIds,
+  });
   const host = input.host ?? '127.0.0.1';
   const port = input.port ?? 0;
 
@@ -763,7 +826,7 @@ export async function startManagedSharedEmberHarness(input: {
     {
       specRoot: input.specRoot,
       vibekitRoot: input.vibekitRoot,
-      managedAgentId,
+      managedAgentIds,
     },
     {
       ...dependencies,
@@ -783,12 +846,16 @@ export async function resolveManagedSharedEmberBootstrap(
     specRoot: string;
     vibekitRoot: string;
     managedAgentId?: string;
+    managedAgentIds?: readonly string[];
   },
   dependencies: ResolveManagedSharedEmberBootstrapDependencies = {},
 ): Promise<SharedEmberReferenceBootstrap> {
-  const managedAgentId = input.managedAgentId ?? DEFAULT_MANAGED_AGENT_ID;
-  const managedPlannerEnv = withDefaultManagedPlannerAgentId({
-    managedAgentId,
+  const managedAgentIds = normalizeManagedAgentIds({
+    managedAgentId: input.managedAgentId,
+    managedAgentIds: input.managedAgentIds,
+  });
+  const managedPlannerEnv = withManagedPlannerAgentIds({
+    managedAgentIds,
   });
   const bootstrap = await (
     dependencies.resolveReferenceBootstrap ??
@@ -809,24 +876,33 @@ export async function resolveManagedSharedEmberBootstrap(
       return bootstrapModule.resolveSharedEmberReferenceBootstrapFromEnv(env);
     })
   )(managedPlannerEnv);
-  const managedOnboardingIssuers = await (
-    dependencies.createManagedOnboardingIssuers ?? maybeCreateManagedOnboardingIssuers
-  )({
-    specRoot: input.specRoot,
-    vibekitRoot: input.vibekitRoot,
-    managedAgentId,
-  });
-  const subagentRuntimes = await (
-    dependencies.createSubagentRuntimes ?? maybeCreateSubagentRuntimes
-  )({
-    specRoot: input.specRoot,
-    vibekitRoot: input.vibekitRoot,
-    managedAgentId,
-  });
+  const createManagedOnboardingIssuers =
+    dependencies.createManagedOnboardingIssuers ?? maybeCreateManagedOnboardingIssuers;
+  const createSubagentRuntimes = dependencies.createSubagentRuntimes ?? maybeCreateSubagentRuntimes;
+  const managedOnboardingIssuerEntries = await Promise.all(
+    managedAgentIds.map((managedAgentId) =>
+      createManagedOnboardingIssuers({
+        specRoot: input.specRoot,
+        vibekitRoot: input.vibekitRoot,
+        managedAgentId,
+      }),
+    ),
+  );
+  const subagentRuntimeEntries = await Promise.all(
+    managedAgentIds.map((managedAgentId) =>
+      createSubagentRuntimes({
+        specRoot: input.specRoot,
+        vibekitRoot: input.vibekitRoot,
+        managedAgentId,
+      }),
+    ),
+  );
+  const managedOnboardingIssuers = Object.assign({}, ...managedOnboardingIssuerEntries);
+  const subagentRuntimes = Object.assign({}, ...subagentRuntimeEntries);
 
   const mergedBootstrap = {
     ...bootstrap,
-    ...(managedOnboardingIssuers === undefined
+    ...(Object.keys(managedOnboardingIssuers).length === 0
       ? {}
       : {
           managedOnboardingIssuers: {
@@ -835,7 +911,7 @@ export async function resolveManagedSharedEmberBootstrap(
             ...managedOnboardingIssuers,
           },
         }),
-    ...(subagentRuntimes === undefined
+    ...(Object.keys(subagentRuntimes).length === 0
       ? {}
       : {
           subagentRuntimes: {
@@ -845,15 +921,15 @@ export async function resolveManagedSharedEmberBootstrap(
         }),
   };
 
-  if (
-    !hasManagedSubmissionBinding({
-      bootstrap: mergedBootstrap,
-      managedAgentId,
-    })
-  ) {
-    throw new Error(
-      `Managed Shared Ember bootstrap requires a seeded subagent runtime binding for ${managedAgentId}.`,
-    );
+  const missingManagedAgentIds = managedAgentIds.filter(
+    (managedAgentId) =>
+      !hasManagedSubmissionBinding({
+        bootstrap: mergedBootstrap,
+        managedAgentId,
+      }),
+  );
+  if (missingManagedAgentIds.length > 0) {
+    throw new Error(formatMissingManagedSubmissionBindingMessage(missingManagedAgentIds));
   }
 
   return mergedBootstrap;

--- a/typescript/clients/web-ag-ui/scripts/smoke/support/walletQaStack.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/support/walletQaStack.ts
@@ -266,6 +266,13 @@ export function buildWalletQaEnvironmentOverrides(input: {
       SHARED_EMBER_BASE_URL: input.sharedEmberBaseUrl,
       ONCHAIN_ACTIONS_API_URL: input.onchainActionsApiUrl,
       PORTFOLIO_MANAGER_OWS_VAULT_PATH: input.portfolioManagerOwsVaultPath,
+      ...(input.portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME
+        ? {
+            PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH:
+              input.portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH ??
+              input.portfolioManagerOwsVaultPath,
+          }
+        : {}),
     },
     emberLendingEnv: {
       ...input.emberLendingBaseEnv,
@@ -342,10 +349,12 @@ export function resolveManagedWalletIds(input: {
   portfolioManagerWallets: OwsWalletRecord[];
   emberLendingWallets: OwsWalletRecord[];
   portfolioManagerWalletName: string | null;
+  portfolioManagerOcaExecutorWalletName?: string | null;
   emberLendingWalletName: string | null;
   controllerSignerAddress?: string | null;
 }): {
   portfolioManagerWalletId: string | null;
+  portfolioManagerOcaExecutorWalletId: string | null;
   emberLendingWalletId: string | null;
 } {
   const portfolioManagerCandidates =
@@ -368,6 +377,24 @@ export function resolveManagedWalletIds(input: {
       );
     }
   }
+
+  const explicitOcaExecutorWallet =
+    input.portfolioManagerOcaExecutorWalletName === null ||
+    input.portfolioManagerOcaExecutorWalletName === undefined
+      ? null
+      : input.portfolioManagerWallets.find(
+          (wallet) =>
+            wallet.id === input.portfolioManagerOcaExecutorWalletName ||
+            wallet.name === input.portfolioManagerOcaExecutorWalletName,
+        ) ?? null;
+  const inferredOcaExecutorWallet =
+    explicitOcaExecutorWallet ??
+    (input.portfolioManagerOcaExecutorWalletName === undefined &&
+    portfolioManagerCandidates.length > 1
+      ? portfolioManagerCandidates.find(
+          (wallet) => wallet.id !== selectedPortfolioManager?.id,
+        ) ?? null
+      : null);
 
   const emberLendingCandidates =
     input.emberLendingWalletName === null
@@ -405,6 +432,7 @@ export function resolveManagedWalletIds(input: {
 
   return {
     portfolioManagerWalletId: selectedPortfolioManager?.id ?? null,
+    portfolioManagerOcaExecutorWalletId: inferredOcaExecutorWallet?.id ?? null,
     emberLendingWalletId: selectedEmberLending?.id ?? null,
   };
 }

--- a/typescript/clients/web-ag-ui/scripts/smoke/support/walletQaStack.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/support/walletQaStack.ts
@@ -396,11 +396,8 @@ export function resolveManagedWalletIds(input: {
         ) ?? null;
   const inferredOcaExecutorWallet =
     explicitOcaExecutorWallet ??
-    (input.portfolioManagerOcaExecutorWalletName === undefined &&
-    portfolioManagerCandidates.length > 1
-      ? portfolioManagerCandidates.find(
-          (wallet) => wallet.id !== selectedPortfolioManager?.id,
-        ) ?? null
+    (input.portfolioManagerOcaExecutorWalletName === undefined
+      ? selectedPortfolioManager
       : null);
 
   const emberLendingCandidates =

--- a/typescript/clients/web-ag-ui/scripts/smoke/support/walletQaStack.ts
+++ b/typescript/clients/web-ag-ui/scripts/smoke/support/walletQaStack.ts
@@ -254,6 +254,13 @@ export function buildWalletQaEnvironmentOverrides(input: {
     sharedEmberEnv.PORTFOLIO_MANAGER_OWS_WALLET_NAME =
       input.portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OWS_WALLET_NAME;
   }
+  if (input.portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME) {
+    sharedEmberEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME =
+      input.portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_WALLET_NAME;
+    sharedEmberEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH =
+      input.portfolioManagerBaseEnv.PORTFOLIO_MANAGER_OCA_EXECUTOR_OWS_VAULT_PATH ??
+      input.portfolioManagerOwsVaultPath;
+  }
   if (input.emberLendingBaseEnv.EMBER_LENDING_OWS_WALLET_NAME) {
     sharedEmberEnv.EMBER_LENDING_OWS_WALLET_NAME =
       input.emberLendingBaseEnv.EMBER_LENDING_OWS_WALLET_NAME;

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -329,6 +329,10 @@ importers:
     dependenciesMeta:
       agent-runtime-postgres:
         injected: false
+    devDependencies:
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
 
   agent-runtime/lib/postgres:
     dependencies:


### PR DESCRIPTION
## Summary
- registers PM-owned hidden `agent-oca-executor` identity metadata and best-effort startup readiness
- adds the hidden spot-swap executor, OCA swap preparation, delegated signing/submission, PM structured dispatch, and conflict-only retry handling
- keeps the executor out of public web registry/CopilotKit/direct command surfaces and documents ADR 0017 readiness semantics

## Validation
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent-portfolio-manager test:unit`
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent-portfolio-manager test:int`
- `pnpm --dir typescript/clients/web-ag-ui/apps/agent-portfolio-manager build`
- `pnpm --dir typescript/clients/web-ag-ui/apps/web test:unit src/config/agents.unit.test.ts src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts src/app/api/agent-command/route.unit.test.ts`
- `pnpm --dir typescript/clients/web-ag-ui/apps/web exec eslint src/config/agents.unit.test.ts src/app/api/copilotkit/copilotRuntimeRegistry.unit.test.ts src/app/api/agent-command/route.unit.test.ts`
- `git diff --check`

## Notes
- Depends on Shared Ember support from EmberAGI/ember-orchestration-v1-spec#287.
- Closes #582.