### PR TITLE
feat(onboarding): add wallet profiler seed panel

### DIFF
--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/[seedId]/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/[seedId]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+import {
+  getWalletProfilerSeedPreview,
+  isWalletProfilerSeedPreviewEnabled,
+} from '../store';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ seedId: string }> },
+): Promise<NextResponse> {
+  if (!isWalletProfilerSeedPreviewEnabled()) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Wallet profiler seed preview is disabled.',
+      },
+      { status: 404 },
+    );
+  }
+
+  const { seedId } = await params;
+  const seed = getWalletProfilerSeedPreview(seedId);
+  if (!seed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Wallet profiler seed not found.',
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    emberOnboardingSeed: seed,
+  });
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+import {
+  isWalletProfilerSeedPreviewEnabled,
+  storeWalletProfilerSeedPreview,
+} from './store';
+import { isEmberOnboardingSeed } from '@/utils/emberOnboardingSeed';
+
+export async function POST(request: Request): Promise<NextResponse> {
+  if (!isWalletProfilerSeedPreviewEnabled()) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Wallet profiler seed preview is disabled.',
+      },
+      { status: 404 },
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Invalid wallet profiler seed.',
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!isEmberOnboardingSeed(payload)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Invalid wallet profiler seed.',
+      },
+      { status: 400 },
+    );
+  }
+
+  const { previewUrl, seedId } = storeWalletProfilerSeedPreview({
+    origin: new URL(request.url).origin,
+    seed: payload,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    previewUrl,
+    seedId,
+  });
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/route.unit.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { GET } from './[seedId]/route';
+import { POST } from './route';
+import { clearWalletProfilerSeedPreviewStore } from './store';
+import type { EmberOnboardingSeed } from '@/types/agent';
+
+const walletProfilerSeed: EmberOnboardingSeed = {
+  pm_setup: {
+    risk_level: 'medium',
+    diagnosis_summary: 'Active DeFi user with missing reserve policy.',
+    portfolio_intent_summary:
+      'Use Portfolio Agent to preserve upside while enforcing reserve discipline.',
+    operator_caveats: ['Only the lending mandate is persisted today.'],
+  },
+  first_managed_mandate: {
+    target_agent_id: 'ember-lending',
+    target_agent_key: 'ember-lending-primary',
+    managed_mandate: {
+      lending_policy: {
+        collateral_policy: {
+          assets: [
+            {
+              asset: 'USDC',
+              max_allocation_pct: 35,
+            },
+          ],
+        },
+        borrow_policy: {
+          allowed_assets: [],
+        },
+        risk_policy: {
+          max_ltv_bps: 4500,
+          min_health_factor: '1.60',
+        },
+      },
+    },
+  },
+  future_subagent_plan: {
+    status: 'exploratory_not_persisted',
+    summary: 'Future strategy is not persisted by current onboarding.',
+  },
+};
+
+describe('/api/dev/wallet-profiler-seed', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_UI_PREVIEW = 'true';
+    clearWalletProfilerSeedPreviewStore();
+  });
+
+  it('stores a valid preview seed and returns a short seedId URL', async () => {
+    const response = await POST(
+      new Request('http://localhost:3000/api/dev/wallet-profiler-seed', {
+        method: 'POST',
+        body: JSON.stringify(walletProfilerSeed),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: true;
+      seedId: string;
+      previewUrl: string;
+    };
+
+    expect(body.ok).toBe(true);
+    expect(body.seedId).toMatch(/^[a-f0-9-]{36}$/);
+    expect(body.previewUrl).toContain('/hire-agents/agent-portfolio-manager');
+    expect(body.previewUrl).toContain('__fixture=wallet-profiler-seed');
+    expect(body.previewUrl).toContain(`seedId=${body.seedId}`);
+    expect(body.previewUrl).not.toContain('__walletProfilerSeed');
+
+    const storedResponse = await GET(
+      new Request(`http://localhost:3000/api/dev/wallet-profiler-seed/${body.seedId}`),
+      { params: Promise.resolve({ seedId: body.seedId }) },
+    );
+
+    expect(storedResponse.status).toBe(200);
+    await expect(storedResponse.json()).resolves.toEqual({
+      ok: true,
+      emberOnboardingSeed: walletProfilerSeed,
+    });
+  });
+
+  it('rejects the dev endpoint when UI preview mode is disabled', async () => {
+    delete process.env.NEXT_PUBLIC_UI_PREVIEW;
+
+    const response = await POST(
+      new Request('http://localhost:3000/api/dev/wallet-profiler-seed', {
+        method: 'POST',
+        body: JSON.stringify(walletProfilerSeed),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Wallet profiler seed preview is disabled.',
+    });
+  });
+
+  it('rejects invalid seed payloads', async () => {
+    const response = await POST(
+      new Request('http://localhost:3000/api/dev/wallet-profiler-seed', {
+        method: 'POST',
+        body: JSON.stringify({ pm_setup: {} }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Invalid wallet profiler seed.',
+    });
+  });
+
+  it('returns 404 for unknown seed ids', async () => {
+    const response = await GET(
+      new Request('http://localhost:3000/api/dev/wallet-profiler-seed/missing'),
+      { params: Promise.resolve({ seedId: 'missing' }) },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Wallet profiler seed not found.',
+    });
+  });
+});

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/store.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/dev/wallet-profiler-seed/store.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from 'node:crypto';
+
+import type { EmberOnboardingSeed } from '@/types/agent';
+
+const walletProfilerSeedPreviewStore = new Map<string, EmberOnboardingSeed>();
+
+export function isWalletProfilerSeedPreviewEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.NEXT_PUBLIC_UI_PREVIEW === 'true';
+}
+
+export function storeWalletProfilerSeedPreview(args: {
+  origin: string;
+  seed: EmberOnboardingSeed;
+}): { previewUrl: string; seedId: string } {
+  const seedId = randomUUID();
+  walletProfilerSeedPreviewStore.set(seedId, args.seed);
+
+  const previewUrl = new URL('/hire-agents/agent-portfolio-manager', args.origin);
+  previewUrl.searchParams.set('__uiState', 'onboarding');
+  previewUrl.searchParams.set('__fixture', 'wallet-profiler-seed');
+  previewUrl.searchParams.set('seedId', seedId);
+
+  return {
+    previewUrl: previewUrl.toString(),
+    seedId,
+  };
+}
+
+export function getWalletProfilerSeedPreview(seedId: string): EmberOnboardingSeed | null {
+  return walletProfilerSeedPreviewStore.get(seedId) ?? null;
+}
+
+export function clearWalletProfilerSeedPreviewStore(): void {
+  walletProfilerSeedPreviewStore.clear();
+}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
@@ -12,9 +12,10 @@ import { invokeAgentCommandRoute } from '@/utils/agentCommandRoute';
 import { getAgentThreadId } from '@/utils/agentThread';
 import { navigateToHref } from '@/utils/hardNavigation';
 import { isPrivyConfigured } from '@/utils/privyConfig';
+import type { EmberOnboardingSeed } from '@/types/agent';
 
 type UiPreviewState = 'prehire' | 'onboarding' | 'active';
-type UiPreviewFixture = 'managed';
+type UiPreviewFixture = 'managed' | 'wallet-profiler-seed';
 type AgentRouteTab = 'blockers' | 'metrics' | 'transactions' | 'chat';
 
 const EMPTY_MESSAGES: Message[] = [];
@@ -26,6 +27,7 @@ function parseUiPreviewState(value: string | null): UiPreviewState | null {
 
 function parseUiPreviewFixture(value: string | null): UiPreviewFixture | null {
   if (value === 'managed') return value;
+  if (value === 'wallet-profiler-seed') return value;
   return null;
 }
 
@@ -115,6 +117,106 @@ function buildUiPreviewDomainProjection(args: {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isManagedLendingMandate(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.lending_policy)) {
+    return false;
+  }
+
+  const { collateral_policy, borrow_policy, risk_policy } = value.lending_policy;
+  if (
+    !isRecord(collateral_policy) ||
+    !Array.isArray(collateral_policy.assets) ||
+    !isRecord(borrow_policy) ||
+    !isStringArray(borrow_policy.allowed_assets) ||
+    !isRecord(risk_policy)
+  ) {
+    return false;
+  }
+
+  return (
+    collateral_policy.assets.every(
+      (asset) =>
+        isRecord(asset) &&
+        typeof asset.asset === 'string' &&
+        typeof asset.max_allocation_pct === 'number',
+    ) &&
+    typeof risk_policy.max_ltv_bps === 'number' &&
+    typeof risk_policy.min_health_factor === 'string'
+  );
+}
+
+function isEmberOnboardingSeed(value: unknown): value is EmberOnboardingSeed {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { pm_setup, first_managed_mandate, future_subagent_plan } = value;
+  if (
+    !isRecord(pm_setup) ||
+    !isRecord(first_managed_mandate) ||
+    !isRecord(future_subagent_plan)
+  ) {
+    return false;
+  }
+
+  return (
+    (pm_setup.risk_level === 'low' ||
+      pm_setup.risk_level === 'medium' ||
+      pm_setup.risk_level === 'high') &&
+    typeof pm_setup.diagnosis_summary === 'string' &&
+    typeof pm_setup.portfolio_intent_summary === 'string' &&
+    isStringArray(pm_setup.operator_caveats) &&
+    first_managed_mandate.target_agent_id === 'ember-lending' &&
+    typeof first_managed_mandate.target_agent_key === 'string' &&
+    isManagedLendingMandate(first_managed_mandate.managed_mandate) &&
+    future_subagent_plan.status === 'exploratory_not_persisted' &&
+    typeof future_subagent_plan.summary === 'string'
+  );
+}
+
+function parseWalletProfilerSeedParam(value: string | null): EmberOnboardingSeed | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(value)) as unknown;
+    return isEmberOnboardingSeed(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildUiPreviewActiveInterrupt(args: {
+  agentId: string;
+  fixture: UiPreviewFixture | null;
+  uiState: UiPreviewState | null;
+  walletProfilerSeed: EmberOnboardingSeed | null;
+}): ComponentProps<typeof AgentDetailPage>['activeInterrupt'] {
+  if (
+    args.agentId !== 'agent-portfolio-manager' ||
+    args.uiState !== 'onboarding' ||
+    args.fixture !== 'wallet-profiler-seed' ||
+    !args.walletProfilerSeed
+  ) {
+    return null;
+  }
+
+  return {
+    type: 'portfolio-manager-setup-request',
+    message: 'Review the wallet-profiler onboarding seed.',
+    emberOnboardingSeed: args.walletProfilerSeed,
+  };
+}
+
 export default function AgentDetailRoute({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const searchParams = useSearchParams();
@@ -187,6 +289,9 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const requestedTab = parseAgentRouteTab(searchParams.get('tab'));
   const uiPreviewTab = uiPreviewEnabled ? parseAgentRouteTab(searchParams.get('__tab')) : null;
   const uiPreviewFixture = uiPreviewEnabled ? parseUiPreviewFixture(searchParams.get('__fixture')) : null;
+  const walletProfilerSeed = uiPreviewEnabled
+    ? parseWalletProfilerSeedParam(searchParams.get('__walletProfilerSeed'))
+    : null;
   const selectedTab = requestedTab ?? uiPreviewTab;
   const selectedLifecyclePhase = selectedLifecycleState?.phase;
   const portfolioManagerThreadId =
@@ -348,6 +453,12 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
       fixture: uiPreviewFixture,
       uiState: uiPreviewState,
     });
+    const previewActiveInterrupt = buildUiPreviewActiveInterrupt({
+      agentId: previewAgentId,
+      fixture: uiPreviewFixture,
+      uiState: uiPreviewState,
+      walletProfilerSeed,
+    });
     const previewTaskStatus =
       uiPreviewState === 'active' && uiPreviewFixture === 'managed' ? 'working' : undefined;
 
@@ -399,7 +510,7 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
         }
         onSync={() => undefined}
         onBack={handleBack}
-        activeInterrupt={null}
+        activeInterrupt={previewActiveInterrupt}
         allowedPools={[]}
         onInterruptSubmit={() => undefined}
         taskId={undefined}

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useCallback, useEffect, useRef, type ComponentProps } from 'react';
+import { use, useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
 import { useSearchParams } from 'next/navigation';
 import type { Message } from '@ag-ui/core';
 import { useLogin } from '@privy-io/react-auth';
@@ -13,6 +13,10 @@ import { getAgentThreadId } from '@/utils/agentThread';
 import { navigateToHref } from '@/utils/hardNavigation';
 import { isPrivyConfigured } from '@/utils/privyConfig';
 import type { EmberOnboardingSeed } from '@/types/agent';
+import {
+  isEmberOnboardingSeed,
+  parseWalletProfilerSeedParam,
+} from '@/utils/emberOnboardingSeed';
 
 type UiPreviewState = 'prehire' | 'onboarding' | 'active';
 type UiPreviewFixture = 'managed' | 'wallet-profiler-seed';
@@ -117,84 +121,6 @@ function buildUiPreviewDomainProjection(args: {
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
-}
-
-function isManagedLendingMandate(value: unknown): boolean {
-  if (!isRecord(value) || !isRecord(value.lending_policy)) {
-    return false;
-  }
-
-  const { collateral_policy, borrow_policy, risk_policy } = value.lending_policy;
-  if (
-    !isRecord(collateral_policy) ||
-    !Array.isArray(collateral_policy.assets) ||
-    !isRecord(borrow_policy) ||
-    !isStringArray(borrow_policy.allowed_assets) ||
-    !isRecord(risk_policy)
-  ) {
-    return false;
-  }
-
-  return (
-    collateral_policy.assets.every(
-      (asset) =>
-        isRecord(asset) &&
-        typeof asset.asset === 'string' &&
-        typeof asset.max_allocation_pct === 'number',
-    ) &&
-    typeof risk_policy.max_ltv_bps === 'number' &&
-    typeof risk_policy.min_health_factor === 'string'
-  );
-}
-
-function isEmberOnboardingSeed(value: unknown): value is EmberOnboardingSeed {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  const { pm_setup, first_managed_mandate, future_subagent_plan } = value;
-  if (
-    !isRecord(pm_setup) ||
-    !isRecord(first_managed_mandate) ||
-    !isRecord(future_subagent_plan)
-  ) {
-    return false;
-  }
-
-  return (
-    (pm_setup.risk_level === 'low' ||
-      pm_setup.risk_level === 'medium' ||
-      pm_setup.risk_level === 'high') &&
-    typeof pm_setup.diagnosis_summary === 'string' &&
-    typeof pm_setup.portfolio_intent_summary === 'string' &&
-    isStringArray(pm_setup.operator_caveats) &&
-    first_managed_mandate.target_agent_id === 'ember-lending' &&
-    typeof first_managed_mandate.target_agent_key === 'string' &&
-    isManagedLendingMandate(first_managed_mandate.managed_mandate) &&
-    future_subagent_plan.status === 'exploratory_not_persisted' &&
-    typeof future_subagent_plan.summary === 'string'
-  );
-}
-
-function parseWalletProfilerSeedParam(value: string | null): EmberOnboardingSeed | null {
-  if (!value) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(decodeURIComponent(value)) as unknown;
-    return isEmberOnboardingSeed(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
 function buildUiPreviewActiveInterrupt(args: {
   agentId: string;
   fixture: UiPreviewFixture | null;
@@ -254,6 +180,8 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const selectedIsHired = agent.isHired;
   const isRestoringState = Boolean(agent.threadId && !agent.hasAuthoritativeState);
   const projectionHydrationKeyRef = useRef<string | null>(null);
+  const [seedIdWalletProfilerSeed, setSeedIdWalletProfilerSeed] =
+    useState<{ seed: EmberOnboardingSeed | null; seedId: string } | null>(null);
 
   const handleBack = () => {
     navigateToHref('/hire-agents');
@@ -289,9 +217,15 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
   const requestedTab = parseAgentRouteTab(searchParams.get('tab'));
   const uiPreviewTab = uiPreviewEnabled ? parseAgentRouteTab(searchParams.get('__tab')) : null;
   const uiPreviewFixture = uiPreviewEnabled ? parseUiPreviewFixture(searchParams.get('__fixture')) : null;
-  const walletProfilerSeed = uiPreviewEnabled
+  const encodedWalletProfilerSeed = uiPreviewEnabled
     ? parseWalletProfilerSeedParam(searchParams.get('__walletProfilerSeed'))
     : null;
+  const walletProfilerSeedId = uiPreviewEnabled ? searchParams.get('seedId') : null;
+  const walletProfilerSeed =
+    encodedWalletProfilerSeed ??
+    (seedIdWalletProfilerSeed?.seedId === walletProfilerSeedId
+      ? seedIdWalletProfilerSeed.seed
+      : null);
   const selectedTab = requestedTab ?? uiPreviewTab;
   const selectedLifecyclePhase = selectedLifecycleState?.phase;
   const portfolioManagerThreadId =
@@ -302,6 +236,58 @@ export default function AgentDetailRoute({ params }: { params: Promise<{ id: str
     selectedAgentId === 'agent-ember-lending' && agent.threadId
       ? agent.threadId
       : getAgentThreadId('agent-ember-lending', privyWallet?.address);
+
+  useEffect(() => {
+    if (
+      !uiPreviewEnabled ||
+      uiPreviewState !== 'onboarding' ||
+      uiPreviewFixture !== 'wallet-profiler-seed' ||
+      !walletProfilerSeedId ||
+      encodedWalletProfilerSeed
+    ) {
+      return;
+    }
+
+    let active = true;
+
+    void fetch(`/api/dev/wallet-profiler-seed/${encodeURIComponent(walletProfilerSeedId)}`)
+      .then(async (response) => {
+        if (!response.ok) {
+          return null;
+        }
+
+        const body = (await response.json()) as { emberOnboardingSeed?: unknown };
+        return isEmberOnboardingSeed(body.emberOnboardingSeed)
+          ? body.emberOnboardingSeed
+          : null;
+      })
+      .then((seed) => {
+        if (active) {
+          setSeedIdWalletProfilerSeed({
+            seed,
+            seedId: walletProfilerSeedId,
+          });
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setSeedIdWalletProfilerSeed({
+            seed: null,
+            seedId: walletProfilerSeedId,
+          });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    encodedWalletProfilerSeed,
+    uiPreviewEnabled,
+    uiPreviewFixture,
+    uiPreviewState,
+    walletProfilerSeedId,
+  ]);
 
   useEffect(() => {
     if (!routeHasRegisteredAgent) {

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
@@ -199,6 +199,7 @@ function readCapturedProps(): Record<string, unknown> {
 describe('AgentDetailRoute managed mandate wiring', () => {
   let container: HTMLDivElement;
   let root: Root;
+  const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     delete process.env.NEXT_PUBLIC_UI_PREVIEW;
@@ -233,6 +234,7 @@ describe('AgentDetailRoute managed mandate wiring', () => {
       root.unmount();
     });
     container.remove();
+    globalThis.fetch = originalFetch;
   });
 
   async function renderRoute(agentId: string): Promise<void> {
@@ -444,6 +446,47 @@ describe('AgentDetailRoute managed mandate wiring', () => {
     mocks.searchParams.set('__walletProfilerSeed', encodeURIComponent('{"pm_setup":{}'));
 
     await renderRoute('agent-portfolio-manager');
+
+    expect(readCapturedProps().activeInterrupt).toBeNull();
+  });
+
+  it('fetches a wallet-profiler seed by seedId in UI preview mode', async () => {
+    process.env.NEXT_PUBLIC_UI_PREVIEW = 'true';
+    mocks.searchParams.set('__uiState', 'onboarding');
+    mocks.searchParams.set('__fixture', 'wallet-profiler-seed');
+    mocks.searchParams.set('seedId', 'seed-123');
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      expect(input.toString()).toBe('/api/dev/wallet-profiler-seed/seed-123');
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          emberOnboardingSeed: walletProfilerSeed,
+        }),
+        { status: 200 },
+      );
+    });
+
+    await renderRoute('agent-portfolio-manager');
+    await flushEffects();
+    await flushEffects();
+
+    expect(readCapturedProps().activeInterrupt).toEqual({
+      type: 'portfolio-manager-setup-request',
+      message: 'Review the wallet-profiler onboarding seed.',
+      emberOnboardingSeed: walletProfilerSeed,
+    });
+  });
+
+  it('ignores unknown seedId lookups instead of passing a seeded interrupt', async () => {
+    process.env.NEXT_PUBLIC_UI_PREVIEW = 'true';
+    mocks.searchParams.set('__uiState', 'onboarding');
+    mocks.searchParams.set('__fixture', 'wallet-profiler-seed');
+    mocks.searchParams.set('seedId', 'missing');
+    globalThis.fetch = vi.fn(async () => new Response('not found', { status: 404 }));
+
+    await renderRoute('agent-portfolio-manager');
+    await flushEffects();
+    await flushEffects();
 
     expect(readCapturedProps().activeInterrupt).toBeNull();
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/[id]/page.unit.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AgentDetailRoute from './page';
+import type { EmberOnboardingSeed } from '@/types/agent';
 
 // React's act() helper expects this flag under the lightweight jsdom runner.
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   applyDomainProjection: vi.fn(),
   agentValue: null as Record<string, unknown> | null,
   capturedProps: null as Record<string, unknown> | null,
+  searchParams: new Map<string, string>(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -29,7 +31,7 @@ vi.mock('next/navigation', () => ({
     replace: mocks.replace,
   }),
   useSearchParams: () => ({
-    get: () => null,
+    get: (key: string) => mocks.searchParams.get(key) ?? null,
   }),
 }));
 
@@ -73,6 +75,43 @@ vi.mock('@/components/AgentDetailPage', () => ({
     return React.createElement('div', { 'data-testid': 'agent-detail-page' });
   },
 }));
+
+const walletProfilerSeed: EmberOnboardingSeed = {
+  pm_setup: {
+    risk_level: 'medium',
+    diagnosis_summary: 'Active DeFi user with missing reserve policy.',
+    portfolio_intent_summary:
+      'Use Portfolio Agent to preserve upside while enforcing reserve discipline.',
+    operator_caveats: ['Only the lending mandate is persisted today.'],
+  },
+  first_managed_mandate: {
+    target_agent_id: 'ember-lending',
+    target_agent_key: 'ember-lending-primary',
+    managed_mandate: {
+      lending_policy: {
+        collateral_policy: {
+          assets: [
+            {
+              asset: 'USDC',
+              max_allocation_pct: 35,
+            },
+          ],
+        },
+        borrow_policy: {
+          allowed_assets: [],
+        },
+        risk_policy: {
+          max_ltv_bps: 4500,
+          min_health_factor: '1.60',
+        },
+      },
+    },
+  },
+  future_subagent_plan: {
+    status: 'exploratory_not_persisted',
+    summary: 'Future strategy is not persisted by current onboarding.',
+  },
+};
 
 function createAgentValue(overrides: Record<string, unknown> = {}) {
   return {
@@ -162,14 +201,17 @@ describe('AgentDetailRoute managed mandate wiring', () => {
   let root: Root;
 
   beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_UI_PREVIEW;
     mocks.push.mockReset();
     mocks.replace.mockReset();
     mocks.navigateToHref.mockReset();
     mocks.login.mockReset();
     mocks.invokeAgentCommandRoute.mockReset();
+    mocks.invokeAgentCommandRoute.mockResolvedValue({ ok: true });
     mocks.getAgentThreadId.mockReset();
     mocks.applyDomainProjection.mockReset();
     mocks.capturedProps = null;
+    mocks.searchParams.clear();
     mocks.agentValue = createAgentValue();
     mocks.getAgentThreadId.mockImplementation((agentId: string) => {
       if (agentId === 'agent-portfolio-manager') {
@@ -362,6 +404,48 @@ describe('AgentDetailRoute managed mandate wiring', () => {
     expect(props.isRestoringState).toBe(true);
     expect(props.hasLoadedView).toBe(false);
     expect(mocks.invokeAgentCommandRoute).not.toHaveBeenCalled();
+  });
+
+  it('passes an encoded wallet-profiler seed into the PM setup interrupt in UI preview mode', async () => {
+    process.env.NEXT_PUBLIC_UI_PREVIEW = 'true';
+    mocks.searchParams.set('__uiState', 'onboarding');
+    mocks.searchParams.set('__fixture', 'wallet-profiler-seed');
+    mocks.searchParams.set(
+      '__walletProfilerSeed',
+      encodeURIComponent(JSON.stringify(walletProfilerSeed)),
+    );
+
+    await renderRoute('agent-portfolio-manager');
+
+    expect(readCapturedProps().activeInterrupt).toEqual({
+      type: 'portfolio-manager-setup-request',
+      message: 'Review the wallet-profiler onboarding seed.',
+      emberOnboardingSeed: walletProfilerSeed,
+    });
+  });
+
+  it('ignores wallet-profiler seed preview parameters when UI preview mode is disabled', async () => {
+    mocks.searchParams.set('__uiState', 'onboarding');
+    mocks.searchParams.set('__fixture', 'wallet-profiler-seed');
+    mocks.searchParams.set(
+      '__walletProfilerSeed',
+      encodeURIComponent(JSON.stringify(walletProfilerSeed)),
+    );
+
+    await renderRoute('agent-portfolio-manager');
+
+    expect(readCapturedProps().activeInterrupt).toBeNull();
+  });
+
+  it('ignores invalid wallet-profiler seed preview JSON instead of passing it through', async () => {
+    process.env.NEXT_PUBLIC_UI_PREVIEW = 'true';
+    mocks.searchParams.set('__uiState', 'onboarding');
+    mocks.searchParams.set('__fixture', 'wallet-profiler-seed');
+    mocks.searchParams.set('__walletProfilerSeed', encodeURIComponent('{"pm_setup":{}'));
+
+    await renderRoute('agent-portfolio-manager');
+
+    expect(readCapturedProps().activeInterrupt).toBeNull();
   });
 
   it('routes hosted lending edits through the PM-owned command and then rehydrates the lending thread projection', async () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/preview-route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/preview-route.unit.test.ts
@@ -16,9 +16,10 @@ describe('Hire agents preview route wiring', () => {
     expect(source).toContain("const requestedTab = parseAgentRouteTab(searchParams.get('tab'));");
     expect(source).toContain("const uiPreviewTab = uiPreviewEnabled ? parseAgentRouteTab(searchParams.get('__tab')) : null;");
     expect(source).toContain("const uiPreviewFixture = uiPreviewEnabled ? parseUiPreviewFixture(searchParams.get('__fixture')) : null;");
-    expect(source).toContain(
-      "const walletProfilerSeed = uiPreviewEnabled\n    ? parseWalletProfilerSeedParam(searchParams.get('__walletProfilerSeed'))\n    : null;",
-    );
+    expect(source).toContain("const walletProfilerSeedId = uiPreviewEnabled ? searchParams.get('seedId') : null;");
+    expect(source).toContain('const walletProfilerSeed =\n    encodedWalletProfilerSeed ??');
+    expect(source).toContain('seedIdWalletProfilerSeed?.seedId === walletProfilerSeedId');
+    expect(source).toContain("fetch(`/api/dev/wallet-profiler-seed/${encodeURIComponent(walletProfilerSeedId)}`)");
     expect(source).toContain('const selectedTab = requestedTab ?? uiPreviewTab;');
     expect(source).toContain('const previewLifecycleState = buildUiPreviewLifecycleState({');
     expect(source).toContain('const previewDomainProjection = buildUiPreviewDomainProjection({');

--- a/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/preview-route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/hire-agents/preview-route.unit.test.ts
@@ -9,19 +9,24 @@ describe('Hire agents preview route wiring', () => {
     const source = fs.readFileSync(routePath, 'utf8');
 
     expect(source).toContain("type AgentRouteTab = 'blockers' | 'metrics' | 'transactions' | 'chat';");
-    expect(source).toContain("type UiPreviewFixture = 'managed';");
+    expect(source).toContain("type UiPreviewFixture = 'managed' | 'wallet-profiler-seed';");
     expect(source).not.toContain("value === 'settings'");
     expect(source).toContain("const uiPreviewEnabled = process.env.NEXT_PUBLIC_UI_PREVIEW === 'true';");
     expect(source).not.toContain("process.env.NODE_ENV === 'development'");
     expect(source).toContain("const requestedTab = parseAgentRouteTab(searchParams.get('tab'));");
     expect(source).toContain("const uiPreviewTab = uiPreviewEnabled ? parseAgentRouteTab(searchParams.get('__tab')) : null;");
     expect(source).toContain("const uiPreviewFixture = uiPreviewEnabled ? parseUiPreviewFixture(searchParams.get('__fixture')) : null;");
+    expect(source).toContain(
+      "const walletProfilerSeed = uiPreviewEnabled\n    ? parseWalletProfilerSeedParam(searchParams.get('__walletProfilerSeed'))\n    : null;",
+    );
     expect(source).toContain('const selectedTab = requestedTab ?? uiPreviewTab;');
     expect(source).toContain('const previewLifecycleState = buildUiPreviewLifecycleState({');
     expect(source).toContain('const previewDomainProjection = buildUiPreviewDomainProjection({');
+    expect(source).toContain('const previewActiveInterrupt = buildUiPreviewActiveInterrupt({');
     expect(source).toContain('fixture: uiPreviewFixture,');
     expect(source).toContain('lifecycleState={previewLifecycleState}');
     expect(source).toContain('domainProjection={previewDomainProjection}');
+    expect(source).toContain('activeInterrupt={previewActiveInterrupt}');
     expect(source).not.toContain('lastOnboardingBootstrap:');
     expect(source).not.toContain('onboarding={');
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.portfolioManagerSetup.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.portfolioManagerSetup.unit.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentDetailPage } from './AgentDetailPage';
+import type { EmberOnboardingSeed } from '../types/agent';
 
 vi.mock('../hooks/usePrivyWalletClient', () => {
   return {
@@ -25,6 +26,7 @@ vi.mock('../hooks/usePrivyWalletClient', () => {
 function renderPortfolioManagerSetupPage(
   container: HTMLDivElement,
   onInterruptSubmit: ReturnType<typeof vi.fn>,
+  emberOnboardingSeed?: EmberOnboardingSeed,
 ) {
   const root = createRoot(container);
 
@@ -53,6 +55,7 @@ function renderPortfolioManagerSetupPage(
         activeInterrupt: {
           type: 'portfolio-manager-setup-request',
           message: 'configure portfolio manager',
+          emberOnboardingSeed,
         },
         onInterruptSubmit,
       }),
@@ -61,6 +64,44 @@ function renderPortfolioManagerSetupPage(
 
   return root;
 }
+
+const walletProfilerSeed: EmberOnboardingSeed = {
+  pm_setup: {
+    risk_level: 'medium',
+    diagnosis_summary: 'Active DeFi user with missing reserve policy.',
+    portfolio_intent_summary:
+      'Use Portfolio Agent to preserve upside while enforcing reserve discipline.',
+    operator_caveats: [
+      'Only the lending mandate is persisted today.',
+      'The broader portfolio plan is PM context until a PM mandate contract exists.',
+    ],
+  },
+  first_managed_mandate: {
+    target_agent_id: 'ember-lending',
+    target_agent_key: 'ember-lending-primary',
+    managed_mandate: {
+      lending_policy: {
+        collateral_policy: {
+          assets: [
+            { asset: 'USDC', max_allocation_pct: 35 },
+            { asset: 'WETH', max_allocation_pct: 15 },
+          ],
+        },
+        borrow_policy: {
+          allowed_assets: [],
+        },
+        risk_policy: {
+          max_ltv_bps: 4500,
+          min_health_factor: '1.60',
+        },
+      },
+    },
+  },
+  future_subagent_plan: {
+    status: 'exploratory_not_persisted',
+    summary: 'Future subagent strategy is not persisted by current onboarding.',
+  },
+};
 
 function setInputValue(input: HTMLInputElement, value: string) {
   const descriptor = Object.getOwnPropertyDescriptor(
@@ -120,6 +161,7 @@ describe('AgentDetailPage portfolio-manager setup', () => {
 
     expect(lendingAvatar?.getAttribute('src')).toBe('/ember-lending-avatar.svg');
     expect(lendingLink?.getAttribute('href')).toBe('/hire-agents/agent-ember-lending');
+    expect(container.textContent).not.toContain('Wallet profiler seed');
     expect(editCollateralPolicyButton).not.toBeNull();
     expect(container.querySelector('button[aria-label="Edit maximum LTV"]')).toBeNull();
     expect(container.querySelector('button[aria-label="Edit minimum health factor"]')).toBeNull();
@@ -185,6 +227,49 @@ describe('AgentDetailPage portfolio-manager setup', () => {
             },
           },
         },
+      },
+    });
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('shows a wallet-profiler seed panel and submits the seeded lending mandate', () => {
+    const onInterruptSubmit = vi.fn();
+    const root = renderPortfolioManagerSetupPage(
+      container,
+      onInterruptSubmit,
+      walletProfilerSeed,
+    );
+    const submitButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent?.includes('Approve'),
+    ) as HTMLButtonElement | undefined;
+
+    expect(container.textContent).toContain('Wallet profiler seed');
+    expect(container.textContent).toContain(walletProfilerSeed.pm_setup.diagnosis_summary);
+    expect(container.textContent).toContain(
+      walletProfilerSeed.pm_setup.portfolio_intent_summary,
+    );
+    expect(container.textContent).toContain('Risk level: medium');
+    expect(container.textContent).toContain('USDC 35%');
+    expect(container.textContent).toContain('WETH 15%');
+    expect(container.textContent).toContain('Only the lending mandate is persisted today.');
+
+    act(() => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onInterruptSubmit).toHaveBeenCalledWith({
+      walletAddress: '0x00000000000000000000000000000000000000a1',
+      portfolioMandate: {
+        approved: true,
+        riskLevel: 'medium',
+      },
+      firstManagedMandate: {
+        targetAgentId: 'ember-lending',
+        targetAgentKey: 'ember-lending-primary',
+        managedMandate: walletProfilerSeed.first_managed_mandate.managed_mandate,
       },
     });
 

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -2518,6 +2518,16 @@ function AgentBlockersTab({
   });
   const isPortfolioManagerSetupInterrupt =
     activeInterrupt?.type === 'portfolio-manager-setup-request';
+  const portfolioManagerSetupSeed = isPortfolioManagerSetupInterrupt
+    ? activeInterrupt.emberOnboardingSeed
+    : undefined;
+  const portfolioManagerSetupFirstManagedMandateTargetKey =
+    portfolioManagerSetupSeed?.first_managed_mandate.target_agent_key ??
+    'ember-lending-primary';
+  const portfolioManagerSetupSeedCollateralSummary =
+    portfolioManagerSetupSeed?.first_managed_mandate.managed_mandate.lending_policy.collateral_policy.assets
+      .map((asset) => `${asset.asset} ${asset.max_allocation_pct}%`)
+      .join(', ');
 
   useEffect(() => {
     if (!isPortfolioManagerSetupInterrupt) {
@@ -2650,19 +2660,20 @@ function AgentBlockersTab({
   };
 
   const portfolioManagerSetupManagedMandate = useMemo<ManagedMandateInput>(
-    () => ({
-      lending_policy: buildManagedLendingPolicy({
-        existingManagedMandate: null,
-        collateralPolicies: [
-          {
-            asset: DEFAULT_MANAGED_LENDING_COLLATERAL_ASSET,
-            max_allocation_pct: DEFAULT_MANAGED_LENDING_MAX_ALLOCATION_PCT,
-          },
-        ],
-        allowedBorrowAssets: [],
-      }),
-    }),
-    [],
+    () =>
+      portfolioManagerSetupSeed?.first_managed_mandate.managed_mandate ?? {
+        lending_policy: buildManagedLendingPolicy({
+          existingManagedMandate: null,
+          collateralPolicies: [
+            {
+              asset: DEFAULT_MANAGED_LENDING_COLLATERAL_ASSET,
+              max_allocation_pct: DEFAULT_MANAGED_LENDING_MAX_ALLOCATION_PCT,
+            },
+          ],
+          allowedBorrowAssets: [],
+        }),
+      },
+    [portfolioManagerSetupSeed],
   );
 
   const submitPortfolioManagerSetupMandate = async (
@@ -2697,7 +2708,7 @@ function AgentBlockersTab({
       },
       firstManagedMandate: {
         targetAgentId: 'ember-lending',
-        targetAgentKey: 'ember-lending-primary',
+        targetAgentKey: portfolioManagerSetupFirstManagedMandateTargetKey,
         managedMandate,
       },
     });
@@ -3099,6 +3110,37 @@ function AgentBlockersTab({
                 )}
 
                 <div className="space-y-4 mb-6">
+                  {portfolioManagerSetupSeed && (
+                    <div className={`${DETAIL_INSET_CLASS} border-[#d8a85f]/45 bg-[#fff7ea] p-4`}>
+                      <div className="mb-2 text-sm font-medium text-[#503826]">
+                        Wallet profiler seed
+                      </div>
+                      <p className="text-xs leading-5 text-[#624d3f]">
+                        {portfolioManagerSetupSeed.pm_setup.diagnosis_summary}
+                      </p>
+                      <p className="mt-2 text-xs leading-5 text-[#7c6757]">
+                        {portfolioManagerSetupSeed.pm_setup.portfolio_intent_summary}
+                      </p>
+                      <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-[#624d3f]">
+                        <span className="rounded-full border border-[#e7c88f] bg-white px-2.5 py-1">
+                          Risk level: {portfolioManagerSetupSeed.pm_setup.risk_level}
+                        </span>
+                        {portfolioManagerSetupSeedCollateralSummary && (
+                          <span className="rounded-full border border-[#e7c88f] bg-white px-2.5 py-1">
+                            First lending lane: {portfolioManagerSetupSeedCollateralSummary}
+                          </span>
+                        )}
+                      </div>
+                      {portfolioManagerSetupSeed.pm_setup.operator_caveats.length > 0 && (
+                        <ul className="mt-3 space-y-1 text-[11px] leading-4 text-[#8b725f]">
+                          {portfolioManagerSetupSeed.pm_setup.operator_caveats.map((caveat) => (
+                            <li key={caveat}>{caveat}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  )}
+
                   <div className={`${DETAIL_INSET_CLASS} p-4`}>
                     <div className="mb-2 text-sm font-medium text-[#503826]">Root delegation setup</div>
                     <p className="text-xs text-[#7c6757]">

--- a/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
@@ -183,6 +183,7 @@ export type PortfolioManagerSetupRequestInterrupt = {
   type: 'portfolio-manager-setup-request';
   message: string;
   payloadSchema?: Record<string, unknown>;
+  emberOnboardingSeed?: EmberOnboardingSeed;
 };
 
 export type FundingTokenRequestInterrupt = {
@@ -271,6 +272,24 @@ export interface ManagedMandateInput extends Record<string, unknown> {
       max_ltv_bps: number;
       min_health_factor: string;
     };
+  };
+}
+
+export interface EmberOnboardingSeed {
+  pm_setup: {
+    risk_level: 'low' | 'medium' | 'high';
+    diagnosis_summary: string;
+    portfolio_intent_summary: string;
+    operator_caveats: string[];
+  };
+  first_managed_mandate: {
+    target_agent_id: 'ember-lending';
+    target_agent_key: string;
+    managed_mandate: ManagedMandateInput;
+  };
+  future_subagent_plan: {
+    status: 'exploratory_not_persisted';
+    summary: string;
   };
 }
 

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/emberOnboardingSeed.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/emberOnboardingSeed.ts
@@ -1,0 +1,79 @@
+import type { EmberOnboardingSeed } from '@/types/agent';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isManagedLendingMandate(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.lending_policy)) {
+    return false;
+  }
+
+  const { collateral_policy, borrow_policy, risk_policy } = value.lending_policy;
+  if (
+    !isRecord(collateral_policy) ||
+    !Array.isArray(collateral_policy.assets) ||
+    !isRecord(borrow_policy) ||
+    !isStringArray(borrow_policy.allowed_assets) ||
+    !isRecord(risk_policy)
+  ) {
+    return false;
+  }
+
+  return (
+    collateral_policy.assets.every(
+      (asset) =>
+        isRecord(asset) &&
+        typeof asset.asset === 'string' &&
+        typeof asset.max_allocation_pct === 'number',
+    ) &&
+    typeof risk_policy.max_ltv_bps === 'number' &&
+    typeof risk_policy.min_health_factor === 'string'
+  );
+}
+
+export function isEmberOnboardingSeed(value: unknown): value is EmberOnboardingSeed {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { pm_setup, first_managed_mandate, future_subagent_plan } = value;
+  if (
+    !isRecord(pm_setup) ||
+    !isRecord(first_managed_mandate) ||
+    !isRecord(future_subagent_plan)
+  ) {
+    return false;
+  }
+
+  return (
+    (pm_setup.risk_level === 'low' ||
+      pm_setup.risk_level === 'medium' ||
+      pm_setup.risk_level === 'high') &&
+    typeof pm_setup.diagnosis_summary === 'string' &&
+    typeof pm_setup.portfolio_intent_summary === 'string' &&
+    isStringArray(pm_setup.operator_caveats) &&
+    first_managed_mandate.target_agent_id === 'ember-lending' &&
+    typeof first_managed_mandate.target_agent_key === 'string' &&
+    isManagedLendingMandate(first_managed_mandate.managed_mandate) &&
+    future_subagent_plan.status === 'exploratory_not_persisted' &&
+    typeof future_subagent_plan.summary === 'string'
+  );
+}
+
+export function parseWalletProfilerSeedParam(value: string | null): EmberOnboardingSeed | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(value)) as unknown;
+    return isEmberOnboardingSeed(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- adds optional `emberOnboardingSeed` data to the Portfolio Agent setup interrupt
- renders a concise wallet-profiler diagnosis/intent/caveat panel above the existing root delegation setup
- preloads the existing managed lending mandate editor from the profiler seed while preserving the no-seed default path
- adds a `NEXT_PUBLIC_UI_PREVIEW=true` handoff path for internal preview testing
- adds a dev-only seedId handoff endpoint so QA can use short preview URLs instead of giant encoded seed URLs

## Tests
- `pnpm test:unit src/app/api/dev/wallet-profiler-seed/route.unit.test.ts src/app/hire-agents/preview-route.unit.test.ts src/app/hire-agents/[id]/page.unit.test.tsx src/components/AgentDetailPage.portfolioManagerSetup.unit.test.tsx`
- `pnpm lint:fix`
- `pnpm lint`
- `pnpm build`

Closes #652
Closes #654
Closes #655
Related: EmberAGI/ember-wallet-profiler#3, EmberAGI/ember-wallet-profiler#4, EmberAGI/ember-wallet-profiler#5, EmberAGI/ember-wallet-profiler#2