### PR TITLE
fix(web): align mandate onboarding validation

### DIFF
--- a/typescript/agent-runtime/src/syncInstalledArtifacts.ts
+++ b/typescript/agent-runtime/src/syncInstalledArtifacts.ts
@@ -1,5 +1,5 @@
 import type { Stats } from 'node:fs';
-import { cp, mkdir, rm, stat } from 'node:fs/promises';
+import { cp, mkdir, realpath, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 type RetryableError = NodeJS.ErrnoException;
@@ -7,6 +7,7 @@ type RetryableError = NodeJS.ErrnoException;
 type FileOps = {
   cp: typeof cp;
   mkdir: typeof mkdir;
+  realpath: (path: string) => Promise<string>;
   rm: typeof rm;
   stat: (path: string) => Promise<Stats>;
 };
@@ -21,7 +22,7 @@ type CopyArtifactDirParams = {
 };
 
 const DEFAULT_MAX_REPLACE_ATTEMPTS = 3;
-const DEFAULT_MAX_LOCK_ATTEMPTS = 120;
+const DEFAULT_MAX_LOCK_ATTEMPTS = 1200;
 const DEFAULT_RETRY_DELAY_MS = 25;
 const RETRYABLE_REPLACE_ERROR_CODES = new Set(['EBUSY', 'EEXIST', 'ENOENT', 'ENOTEMPTY', 'EPERM']);
 const RETRYABLE_LOCK_ERROR_CODES = new Set(['EBUSY', 'EEXIST', 'ENOTEMPTY', 'EPERM']);
@@ -29,6 +30,7 @@ const RETRYABLE_LOCK_ERROR_CODES = new Set(['EBUSY', 'EEXIST', 'ENOTEMPTY', 'EPE
 const DEFAULT_FILE_OPS: FileOps = {
   cp,
   mkdir,
+  realpath,
   rm,
   stat,
 };
@@ -54,6 +56,38 @@ const isRetryableLockError = (error: unknown): error is RetryableError =>
   'code' in error &&
   typeof (error as { code?: unknown }).code === 'string' &&
   RETRYABLE_LOCK_ERROR_CODES.has((error as { code: string }).code);
+
+const isMissingPathError = (error: unknown): error is RetryableError =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT';
+
+async function isSameFilesystemEntry(
+  sourcePath: string,
+  targetPath: string,
+  fileOps: FileOps,
+): Promise<boolean> {
+  try {
+    const [sourceStats, targetStats] = await Promise.all([
+      fileOps.stat(sourcePath),
+      fileOps.stat(targetPath),
+    ]);
+
+    return (
+      typeof sourceStats.dev === 'number' &&
+      typeof sourceStats.ino === 'number' &&
+      sourceStats.dev === targetStats.dev &&
+      sourceStats.ino === targetStats.ino
+    );
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
 
 async function withDirectoryLock(input: {
   fileOps: FileOps;
@@ -103,6 +137,15 @@ export async function copyArtifactDir({
   }
 
   await fileOps.mkdir(targetDir, { recursive: true });
+  const [realSourceDir, realTargetDir] = await Promise.all([
+    fileOps.realpath(sourceDir),
+    fileOps.realpath(targetDir),
+  ]);
+
+  if (realSourceDir === realTargetDir) {
+    return;
+  }
+
   const lockDir = `${targetDir}.sync-lock`;
 
   await withDirectoryLock({
@@ -113,7 +156,12 @@ export async function copyArtifactDir({
     run: async () => {
       for (let attempt = 1; attempt <= maxReplaceAttempts; attempt += 1) {
         try {
-          await fileOps.cp(sourceDir, targetDir, { recursive: true, force: true });
+          await fileOps.cp(sourceDir, targetDir, {
+            recursive: true,
+            force: true,
+            filter: async (sourcePath, targetPath) =>
+              !(await isSameFilesystemEntry(sourcePath, targetPath, fileOps)),
+          });
           return;
         } catch (error) {
           if (!isRetryableReplaceError(error) || attempt === maxReplaceAttempts) {

--- a/typescript/agent-runtime/src/syncInstalledArtifacts.ts
+++ b/typescript/agent-runtime/src/syncInstalledArtifacts.ts
@@ -90,14 +90,18 @@ export async function copyArtifactDir({
   maxReplaceAttempts = DEFAULT_MAX_REPLACE_ATTEMPTS,
   retryDelayMs = DEFAULT_RETRY_DELAY_MS,
 }: CopyArtifactDirParams): Promise<void> {
-  const sourceDir = path.join(sourceRoot, relativeDir);
+  const sourceDir = path.resolve(sourceRoot, relativeDir);
   const sourceStats = await fileOps.stat(sourceDir);
 
   if (!sourceStats.isDirectory()) {
     return;
   }
 
-  const targetDir = path.join(targetRoot, relativeDir);
+  const targetDir = path.resolve(targetRoot, relativeDir);
+  if (sourceDir === targetDir) {
+    return;
+  }
+
   await fileOps.mkdir(targetDir, { recursive: true });
   const lockDir = `${targetDir}.sync-lock`;
 

--- a/typescript/agent-runtime/src/syncInstalledArtifacts.unit.test.ts
+++ b/typescript/agent-runtime/src/syncInstalledArtifacts.unit.test.ts
@@ -13,6 +13,7 @@ describe('syncInstalledArtifacts', () => {
       }),
     );
     const mkdir = vi.fn(() => Promise.resolve(undefined));
+    const realpath = vi.fn((targetPath: string) => Promise.resolve(targetPath));
     const rm = vi.fn(() => Promise.resolve(undefined));
     const cp = vi.fn(() => Promise.resolve(undefined));
 
@@ -24,6 +25,7 @@ describe('syncInstalledArtifacts', () => {
         fileOps: {
           stat,
           mkdir,
+          realpath,
           rm,
           cp,
         },
@@ -40,6 +42,7 @@ describe('syncInstalledArtifacts', () => {
     expect(cp).toHaveBeenCalledWith('/source/dist', '/target/dist', {
       recursive: true,
       force: true,
+      filter: expect.any(Function),
     });
   });
 
@@ -50,6 +53,7 @@ describe('syncInstalledArtifacts', () => {
       }),
     );
     const mkdir = vi.fn(() => Promise.resolve(undefined));
+    const realpath = vi.fn((targetPath: string) => Promise.resolve(targetPath));
     const rm = vi.fn(() => Promise.resolve(undefined));
     const cp = vi
       .fn()
@@ -66,6 +70,7 @@ describe('syncInstalledArtifacts', () => {
         fileOps: {
           stat,
           mkdir,
+          realpath,
           rm,
           cp,
         },
@@ -80,10 +85,12 @@ describe('syncInstalledArtifacts', () => {
     expect(cp).toHaveBeenNthCalledWith(1, '/source/dist', '/target/dist', {
       recursive: true,
       force: true,
+      filter: expect.any(Function),
     });
     expect(cp).toHaveBeenNthCalledWith(2, '/source/dist', '/target/dist', {
       recursive: true,
       force: true,
+      filter: expect.any(Function),
     });
   });
 
@@ -94,6 +101,7 @@ describe('syncInstalledArtifacts', () => {
       }),
     );
     const mkdir = vi.fn(() => Promise.resolve(undefined));
+    const realpath = vi.fn((targetPath: string) => Promise.resolve(targetPath));
     const rm = vi.fn(() => Promise.resolve(undefined));
     const cp = vi.fn(() => Promise.resolve(undefined));
 
@@ -105,6 +113,7 @@ describe('syncInstalledArtifacts', () => {
         fileOps: {
           stat,
           mkdir,
+          realpath,
           rm,
           cp,
         },
@@ -112,9 +121,117 @@ describe('syncInstalledArtifacts', () => {
     ).resolves.toBeUndefined();
 
     expect(stat).toHaveBeenCalledWith('/workspace/agent-runtime/dist');
+    expect(realpath).not.toHaveBeenCalled();
     expect(mkdir).not.toHaveBeenCalled();
     expect(rm).not.toHaveBeenCalled();
     expect(cp).not.toHaveBeenCalled();
+  });
+
+  it('skips artifact sync when a pnpm file snapshot resolves to the package source directory', async () => {
+    const stat = vi.fn(() =>
+      Promise.resolve({
+        isDirectory: () => true,
+      }),
+    );
+    const mkdir = vi.fn(() => Promise.resolve(undefined));
+    const realpath = vi.fn((targetPath: string) =>
+      Promise.resolve(
+        targetPath.endsWith('/dist')
+          ? '/workspace/node_modules/.pnpm/agent-runtime-pi@file+agent-runtime+lib+pi/node_modules/agent-runtime-pi/dist'
+          : targetPath,
+      ),
+    );
+    const rm = vi.fn(() => Promise.resolve(undefined));
+    const cp = vi.fn(() => Promise.resolve(undefined));
+
+    await expect(
+      copyArtifactDir({
+        sourceRoot: '/workspace/agent-runtime/lib/pi',
+        relativeDir: 'dist',
+        targetRoot:
+          '/workspace/node_modules/.pnpm/agent-runtime-pi@file+agent-runtime+lib+pi/node_modules/agent-runtime-pi',
+        fileOps: {
+          stat,
+          mkdir,
+          realpath,
+          rm,
+          cp,
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mkdir).toHaveBeenCalledWith(
+      '/workspace/node_modules/.pnpm/agent-runtime-pi@file+agent-runtime+lib+pi/node_modules/agent-runtime-pi/dist',
+      { recursive: true },
+    );
+    expect(rm).not.toHaveBeenCalled();
+    expect(cp).not.toHaveBeenCalled();
+  });
+
+  it('skips hardlinked files that already point at the source artifact', async () => {
+    const stat = vi.fn((targetPath: string) => {
+      if (targetPath === '/source/dist' || targetPath === '/target/dist') {
+        return Promise.resolve({
+          dev: targetPath === '/source/dist' ? 1 : 2,
+          ino: targetPath === '/source/dist' ? 10 : 20,
+          isDirectory: () => true,
+        });
+      }
+
+      if (targetPath.endsWith('/syncInstalledArtifacts.d.ts')) {
+        return Promise.resolve({
+          dev: 3,
+          ino: 30,
+          isDirectory: () => false,
+        });
+      }
+
+      if (targetPath === '/source/dist/new.js') {
+        return Promise.resolve({
+          dev: 3,
+          ino: 31,
+          isDirectory: () => false,
+        });
+      }
+
+      return Promise.reject(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    });
+    const mkdir = vi.fn(() => Promise.resolve(undefined));
+    const realpath = vi.fn((targetPath: string) => Promise.resolve(targetPath));
+    const rm = vi.fn(() => Promise.resolve(undefined));
+    const cp = vi.fn(() => Promise.resolve(undefined));
+
+    await expect(
+      copyArtifactDir({
+        sourceRoot: '/source',
+        relativeDir: 'dist',
+        targetRoot: '/target',
+        fileOps: {
+          stat,
+          mkdir,
+          realpath,
+          rm,
+          cp,
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    const options = cp.mock.calls[0]?.[2];
+
+    expect(options).toEqual({
+      recursive: true,
+      force: true,
+      filter: expect.any(Function),
+    });
+    await expect(
+      options?.filter?.(
+        '/source/dist/syncInstalledArtifacts.d.ts',
+        '/target/dist/syncInstalledArtifacts.d.ts',
+      ),
+    ).resolves.toBe(false);
+    await expect(options?.filter?.('/source/dist/new.js', '/target/dist/new.js')).resolves.toBe(
+      true,
+    );
   });
 
   it('waits for a per-target sync lock before syncing installed artifacts', async () => {
@@ -128,6 +245,7 @@ describe('syncInstalledArtifacts', () => {
       }),
     );
     let lockAttempt = 0;
+    const realpath = vi.fn((targetPath: string) => Promise.resolve(targetPath));
     const mkdir = vi.fn((targetPath: string, options?: { recursive?: boolean }) => {
       if (targetPath === '/target/dist') {
         expect(options).toEqual({ recursive: true });
@@ -166,10 +284,11 @@ describe('syncInstalledArtifacts', () => {
           relativeDir: 'dist',
           targetRoot: '/target',
           fileOps: {
-            stat,
-            mkdir,
-            rm,
-            cp,
+          stat,
+          mkdir,
+          realpath,
+          rm,
+          cp,
           },
           retryDelayMs: 0,
         }),
@@ -178,10 +297,11 @@ describe('syncInstalledArtifacts', () => {
           relativeDir: 'dist',
           targetRoot: '/target',
           fileOps: {
-            stat,
-            mkdir,
-            rm,
-            cp,
+          stat,
+          mkdir,
+          realpath,
+          rm,
+          cp,
           },
           retryDelayMs: 0,
         }),

--- a/typescript/agent-runtime/src/syncInstalledArtifacts.unit.test.ts
+++ b/typescript/agent-runtime/src/syncInstalledArtifacts.unit.test.ts
@@ -87,6 +87,36 @@ describe('syncInstalledArtifacts', () => {
     });
   });
 
+  it('skips artifact sync when the installed snapshot resolves to the package source directory', async () => {
+    const stat = vi.fn(() =>
+      Promise.resolve({
+        isDirectory: () => true,
+      }),
+    );
+    const mkdir = vi.fn(() => Promise.resolve(undefined));
+    const rm = vi.fn(() => Promise.resolve(undefined));
+    const cp = vi.fn(() => Promise.resolve(undefined));
+
+    await expect(
+      copyArtifactDir({
+        sourceRoot: '/workspace/agent-runtime',
+        relativeDir: 'dist',
+        targetRoot: '/workspace/agent-runtime',
+        fileOps: {
+          stat,
+          mkdir,
+          rm,
+          cp,
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(stat).toHaveBeenCalledWith('/workspace/agent-runtime/dist');
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(rm).not.toHaveBeenCalled();
+    expect(cp).not.toHaveBeenCalled();
+  });
+
   it('waits for a per-target sync lock before syncing installed artifacts', async () => {
     let releaseAfterSecondLockAttempt: (() => void) | null = null;
     const secondLockAttemptObserved = new Promise<void>((resolve) => {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -2444,7 +2444,7 @@ function readManagedMandateEditorProjection(value: unknown): ManagedMandateEdito
   const targetAgentId = readString(editor['targetAgentId']);
   const targetAgentKey = readString(editor['targetAgentKey']);
   const mandateRef = readString(editor['mandateRef']);
-  const managedMandate = isRecord(editor['managedMandate']) ? editor['managedMandate'] : null;
+  const managedMandate = readManagedMandate(editor['managedMandate']);
   if (
     targetAgentId !== FIRST_MANAGED_AGENT_TYPE ||
     targetAgentKey === null ||
@@ -2569,8 +2569,8 @@ function readPortfolioManagerMandateEditorProjection(
 
   if (
     targetAgentId !== PORTFOLIO_MANAGER_MANDATE_ROUTE_ID ||
-    targetAgentKey === null ||
-    mandateRef === null ||
+    targetAgentKey !== PORTFOLIO_MANAGER_MANDATE_KEY ||
+    mandateRef !== PORTFOLIO_MANAGER_MANDATE_REF ||
     managedMandate === null
   ) {
     return null;

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -40,6 +40,7 @@ export type PortfolioManagerLifecycleState = {
   pendingOnboardingWalletAddress: `0x${string}` | null;
   pendingApprovedSetup?: PortfolioManagerApprovedSetup | null;
   pendingSpotSwapConflict?: PortfolioManagerPendingSpotSwapConflict | null;
+  portfolioManagerMandate?: PortfolioManagerMandatePayload | null;
 };
 
 type PortfolioManagerPendingSpotSwapConflict = {
@@ -128,6 +129,7 @@ function buildDefaultLifecycleState(): PortfolioManagerLifecycleState {
     pendingOnboardingWalletAddress: null,
     pendingApprovedSetup: null,
     pendingSpotSwapConflict: null,
+    portfolioManagerMandate: null,
   };
 }
 
@@ -865,7 +867,11 @@ const FIRST_MANAGED_AGENT_BENCHMARK_ASSET = 'USD';
 const FIRST_MANAGED_AGENT_KEY = 'ember-lending-primary';
 const PORTFOLIO_MANAGER_ROUTE_AGENT_ID = 'agent-portfolio-manager';
 const FIRST_MANAGED_AGENT_ROUTE_ID = 'agent-ember-lending';
+const PORTFOLIO_MANAGER_MANDATE_ROUTE_ID = 'agent-portfolio-manager';
+const PORTFOLIO_MANAGER_MANDATE_KEY = 'portfolio-manager-primary';
+const PORTFOLIO_MANAGER_MANDATE_TITLE = 'Portfolio Manager Mandate';
 const FIRST_MANAGED_AGENT_TITLE = 'Ember Lending';
+const PORTFOLIO_MANAGER_MANDATE_REF = 'mandate-portfolio-manager';
 const PM_SIGNING_TRACE_ENABLED = process.env['DEBUG_PM_SIGNING'] === '1';
 
 function tracePmSigning(step: string, details?: Record<string, unknown>) {
@@ -881,6 +887,8 @@ type PortfolioManagerPortfolioMandate = {
   approved: true;
   riskLevel: typeof PORTFOLIO_MANAGER_DEFAULT_RISK_LEVEL;
 };
+
+type PortfolioManagerMandatePayload = Record<string, unknown>;
 
 type ManagedMandate = Record<string, unknown> & {
   lending_policy: Record<string, unknown> & {
@@ -920,6 +928,20 @@ type ManagedMandateEditorProjection = {
     rootAsset: string | null;
     quantity: string | null;
   } | null;
+};
+
+type PortfolioManagerMandateEditorProjection = {
+  ownerAgentId: typeof PORTFOLIO_MANAGER_ROUTE_AGENT_ID;
+  targetAgentId: typeof PORTFOLIO_MANAGER_ROUTE_AGENT_ID;
+  targetAgentRouteId: typeof PORTFOLIO_MANAGER_MANDATE_ROUTE_ID;
+  targetAgentKey: typeof PORTFOLIO_MANAGER_MANDATE_KEY;
+  targetAgentTitle: typeof PORTFOLIO_MANAGER_MANDATE_TITLE;
+  mandateRef: typeof PORTFOLIO_MANAGER_MANDATE_REF;
+  managedMandate: PortfolioManagerMandatePayload;
+  agentWallet: `0x${string}` | null;
+  rootUserWallet: `0x${string}` | null;
+  rootedWalletContextId: string | null;
+  reservation: null;
 };
 
 type PortfolioProjectionEconomicExposureInput = {
@@ -1033,6 +1055,7 @@ type PortfolioManagerFirstManagedMandate = {
 type PortfolioManagerApprovedSetup = {
   portfolioMandate: PortfolioManagerPortfolioMandate;
   firstManagedMandate: PortfolioManagerFirstManagedMandate;
+  portfolioManagerMandate?: PortfolioManagerMandatePayload | null;
 };
 
 type PortfolioManagerSetupInput = PortfolioManagerApprovedSetup & {
@@ -1040,8 +1063,8 @@ type PortfolioManagerSetupInput = PortfolioManagerApprovedSetup & {
 };
 
 type ManagedMandateUpdateInput = {
-  targetAgentId: typeof FIRST_MANAGED_AGENT_TYPE;
-  managedMandate: ManagedMandate;
+  targetAgentId: typeof FIRST_MANAGED_AGENT_TYPE | typeof PORTFOLIO_MANAGER_ROUTE_AGENT_ID;
+  managedMandate: PortfolioManagerMandatePayload | ManagedMandate;
 };
 
 type PortfolioManagerUnsignedDelegation = {
@@ -1765,8 +1788,15 @@ function parsePortfolioManagerSetupInput(input: unknown): PortfolioManagerSetupI
 
   const portfolioMandate = 'portfolioMandate' in input ? input.portfolioMandate : null;
   const firstManagedMandate = 'firstManagedMandate' in input ? input.firstManagedMandate : null;
+  const portfolioManagerMandate = 'portfolioManagerMandate' in input
+    ? input.portfolioManagerMandate
+    : null;
   const parsedPortfolioMandate = parsePortfolioMandate(portfolioMandate);
   const parsedFirstManagedMandate = parseFirstManagedMandate(firstManagedMandate);
+  const parsedPortfolioManagerMandate =
+    portfolioManagerMandate === null || !isRecord(portfolioManagerMandate)
+      ? null
+      : portfolioManagerMandate;
 
   if (!parsedPortfolioMandate || !parsedFirstManagedMandate) {
     return null;
@@ -1776,6 +1806,7 @@ function parsePortfolioManagerSetupInput(input: unknown): PortfolioManagerSetupI
     walletAddress: walletAddress as `0x${string}`,
     portfolioMandate: parsedPortfolioMandate,
     firstManagedMandate: parsedFirstManagedMandate,
+    portfolioManagerMandate: parsedPortfolioManagerMandate,
   };
 }
 
@@ -1785,15 +1816,31 @@ function parseManagedMandateUpdateInput(input: unknown): ManagedMandateUpdateInp
   }
 
   const targetAgentId = readString(input['targetAgentId']);
-  const managedMandate = readManagedMandate(input['managedMandate']);
+  const managedMandate = isRecord(input['managedMandate']) ? input['managedMandate'] : null;
 
-  if (targetAgentId !== FIRST_MANAGED_AGENT_TYPE || managedMandate === null) {
+  if (
+    !managedMandate ||
+    (targetAgentId !== FIRST_MANAGED_AGENT_TYPE &&
+      targetAgentId !== PORTFOLIO_MANAGER_MANDATE_ROUTE_ID)
+  ) {
+    return null;
+  }
+
+  if (targetAgentId === PORTFOLIO_MANAGER_MANDATE_ROUTE_ID) {
+    return {
+      targetAgentId: PORTFOLIO_MANAGER_MANDATE_ROUTE_ID,
+      managedMandate,
+    };
+  }
+
+  const validatedManagedMandate = readManagedMandate(managedMandate);
+  if (validatedManagedMandate === null) {
     return null;
   }
 
   return {
     targetAgentId: FIRST_MANAGED_AGENT_TYPE,
-    managedMandate,
+    managedMandate: validatedManagedMandate,
   };
 }
 
@@ -2133,6 +2180,14 @@ function readApprovedSetupFromOnboardingBootstrap(
     'firstManagedMandate' in approvedOnboardingSetup
       ? parseFirstManagedMandate(approvedOnboardingSetup.firstManagedMandate)
       : null;
+  const portfolioManagerMandate =
+    'portfolioManagerMandate' in approvedOnboardingSetup
+      ? approvedOnboardingSetup.portfolioManagerMandate
+      : null;
+  const parsedPortfolioManagerMandate =
+    portfolioManagerMandate === null || !isRecord(portfolioManagerMandate)
+      ? null
+      : portfolioManagerMandate;
 
   if (!portfolioMandate || !firstManagedMandate) {
     return null;
@@ -2141,6 +2196,7 @@ function readApprovedSetupFromOnboardingBootstrap(
   return {
     portfolioMandate,
     firstManagedMandate,
+    portfolioManagerMandate: parsedPortfolioManagerMandate,
   };
 }
 
@@ -2388,7 +2444,7 @@ function readManagedMandateEditorProjection(value: unknown): ManagedMandateEdito
   const targetAgentId = readString(editor['targetAgentId']);
   const targetAgentKey = readString(editor['targetAgentKey']);
   const mandateRef = readString(editor['mandateRef']);
-  const managedMandate = readManagedMandate(editor['managedMandate']);
+  const managedMandate = isRecord(editor['managedMandate']) ? editor['managedMandate'] : null;
   if (
     targetAgentId !== FIRST_MANAGED_AGENT_TYPE ||
     targetAgentKey === null ||
@@ -2452,6 +2508,85 @@ function buildManagedMandateEditorProjectionFromOnboardingBootstrap(
     agentWallet: null,
     rootUserWallet: readOnboardingBootstrapWalletAddress(value),
     rootedWalletContextId: readOnboardingBootstrapRootedWalletContextId(value),
+    reservation: null,
+  };
+}
+
+function buildPortfolioManagerMandateEditorProjection(
+  params: {
+    rootUserWallet: `0x${string}` | null;
+    lastRootedWalletContextId: string | null;
+    portfolioManagerMandate: PortfolioManagerMandatePayload;
+  },
+): PortfolioManagerMandateEditorProjection {
+  return {
+    ownerAgentId: PORTFOLIO_MANAGER_ROUTE_AGENT_ID,
+    targetAgentId: PORTFOLIO_MANAGER_MANDATE_ROUTE_ID,
+    targetAgentRouteId: PORTFOLIO_MANAGER_MANDATE_ROUTE_ID,
+    targetAgentKey: PORTFOLIO_MANAGER_MANDATE_KEY,
+    targetAgentTitle: PORTFOLIO_MANAGER_MANDATE_TITLE,
+    mandateRef: PORTFOLIO_MANAGER_MANDATE_REF,
+    managedMandate: params.portfolioManagerMandate,
+    agentWallet: params.rootUserWallet,
+    rootUserWallet: params.rootUserWallet,
+    rootedWalletContextId: params.lastRootedWalletContextId,
+    reservation: null,
+  };
+}
+
+function readPortfolioManagerMandateProjectionFromState(
+  state: PortfolioManagerLifecycleState,
+): PortfolioManagerMandateEditorProjection | null {
+  if (!state.portfolioManagerMandate) {
+    return null;
+  }
+
+  return buildPortfolioManagerMandateEditorProjection({
+    rootUserWallet: readPortfolioManagerContextWalletAddress(state),
+    lastRootedWalletContextId: state.lastRootedWalletContextId,
+    portfolioManagerMandate: state.portfolioManagerMandate,
+  });
+}
+
+function readPortfolioManagerMandateEditorProjection(
+  value: unknown,
+): PortfolioManagerMandateEditorProjection | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const editor = isRecord(value['portfolioManagerMandateEditor'])
+    ? value['portfolioManagerMandateEditor']
+    : null;
+  if (!editor) {
+    return null;
+  }
+
+  const targetAgentId = readString(editor['targetAgentId']);
+  const targetAgentKey = readString(editor['targetAgentKey']);
+  const mandateRef = readString(editor['mandateRef']);
+  const managedMandate = isRecord(editor['managedMandate']) ? editor['managedMandate'] : null;
+
+  if (
+    targetAgentId !== PORTFOLIO_MANAGER_MANDATE_ROUTE_ID ||
+    targetAgentKey === null ||
+    mandateRef === null ||
+    managedMandate === null
+  ) {
+    return null;
+  }
+
+  return {
+    ownerAgentId: PORTFOLIO_MANAGER_ROUTE_AGENT_ID,
+    targetAgentId: PORTFOLIO_MANAGER_MANDATE_ROUTE_ID,
+    targetAgentRouteId: PORTFOLIO_MANAGER_MANDATE_ROUTE_ID,
+    targetAgentKey,
+    targetAgentTitle: PORTFOLIO_MANAGER_MANDATE_TITLE,
+    mandateRef,
+    managedMandate,
+    agentWallet: readHexAddress(editor['agentWallet']),
+    rootUserWallet: readHexAddress(editor['rootUserWallet']),
+    rootedWalletContextId: readString(editor['rootedWalletContextId']),
     reservation: null,
   };
 }
@@ -2861,6 +2996,9 @@ export function createPortfolioManagerDomain(
       const visibleManagedMandateProjection =
         liveManagedMandateProjection ??
         (currentState.phase === 'active' ? projectedManagedMandateProjection : null);
+      const visiblePortfolioManagerMandateProjection =
+        readPortfolioManagerMandateProjectionFromState(currentState) ??
+        readPortfolioManagerMandateEditorProjection(currentProjection);
 
       context.push(`  <lifecycle_phase>${currentState.phase}</lifecycle_phase>`);
 
@@ -2942,41 +3080,28 @@ export function createPortfolioManagerDomain(
       const approvedSetup = readApprovedSetupFromOnboardingBootstrap(
         currentState.lastOnboardingBootstrap,
       );
-      if (visibleManagedMandateProjection) {
-        const managedMandate = visibleManagedMandateProjection.managedMandate;
-        context.push('  <managed_agent_mandates>');
-        context.push(
-          `    <managed_agent agent_key="${escapeXml(
-            visibleManagedMandateProjection.targetAgentKey,
-          )}" agent_type="${escapeXml(
-            visibleManagedMandateProjection.targetAgentId,
-          )}" approved="true" mandate_ref="${escapeXml(visibleManagedMandateProjection.mandateRef)}">`,
-        );
-        appendStructuredXmlNode({
-          lines: context,
-          indent: '      ',
-          tag: 'managed_mandate',
-          value: managedMandate,
-        });
-        context.push('    </managed_agent>');
-        context.push('  </managed_agent_mandates>');
-      } else if (currentState.phase !== 'active' && approvedSetup) {
-        const mandateSources = readOnboardingMandateSources(currentState.lastOnboardingBootstrap);
-        const firstManagedMandateSource =
-          mandateSources.find(
-            (mandate) => mandate.agent_id === approvedSetup.firstManagedMandate.targetAgentId,
-          ) ?? null;
+      const mandateSources = approvedSetup ? readOnboardingMandateSources(currentState.lastOnboardingBootstrap) : [];
+      const firstManagedMandateSource =
+        currentState.phase !== 'active'
+          ? mandateSources.find(
+              (mandate) => mandate.agent_id === approvedSetup?.firstManagedMandate.targetAgentId,
+            ) ?? null
+          : null;
 
-        if (firstManagedMandateSource) {
-          const firstManagedMandate = approvedSetup.firstManagedMandate;
-          const managedMandate = firstManagedMandate.managedMandate;
-          context.push('  <managed_agent_mandates>');
+      if (
+        visibleManagedMandateProjection ||
+        (currentState.phase !== 'active' && firstManagedMandateSource) ||
+        visiblePortfolioManagerMandateProjection
+      ) {
+        context.push('  <managed_agent_mandates>');
+        if (visibleManagedMandateProjection) {
+          const managedMandate = visibleManagedMandateProjection.managedMandate;
           context.push(
             `    <managed_agent agent_key="${escapeXml(
-              firstManagedMandate.targetAgentKey,
+              visibleManagedMandateProjection.targetAgentKey,
             )}" agent_type="${escapeXml(
-              firstManagedMandate.targetAgentId,
-            )}" approved="true" mandate_ref="${escapeXml(firstManagedMandateSource.mandate_ref)}">`,
+              visibleManagedMandateProjection.targetAgentId,
+            )}" approved="true" mandate_ref="${escapeXml(visibleManagedMandateProjection.mandateRef)}">`,
           );
           appendStructuredXmlNode({
             lines: context,
@@ -2985,8 +3110,50 @@ export function createPortfolioManagerDomain(
             value: managedMandate,
           });
           context.push('    </managed_agent>');
-          context.push('  </managed_agent_mandates>');
         }
+        if (
+          currentState.phase !== 'active' &&
+          firstManagedMandateSource &&
+          firstManagedMandateSource.agent_id !== visibleManagedMandateProjection?.targetAgentId
+        ) {
+          const firstManagedMandate = approvedSetup?.firstManagedMandate;
+          if (firstManagedMandate) {
+            const managedMandate = firstManagedMandate.managedMandate;
+            context.push(
+              `    <managed_agent agent_key="${escapeXml(
+                firstManagedMandate.targetAgentKey,
+              )}" agent_type="${escapeXml(
+                firstManagedMandate.targetAgentId,
+              )}" approved="true" mandate_ref="${escapeXml(firstManagedMandateSource.mandate_ref)}">`,
+            );
+            appendStructuredXmlNode({
+              lines: context,
+              indent: '      ',
+              tag: 'managed_mandate',
+              value: managedMandate,
+            });
+            context.push('    </managed_agent>');
+          }
+        }
+        if (visiblePortfolioManagerMandateProjection) {
+          context.push(
+            `    <managed_agent agent_key="${escapeXml(
+              visiblePortfolioManagerMandateProjection.targetAgentKey,
+            )}" agent_type="${escapeXml(
+              visiblePortfolioManagerMandateProjection.targetAgentId,
+            )}" approved="true" mandate_ref="${escapeXml(
+              visiblePortfolioManagerMandateProjection.mandateRef,
+            )}">`,
+          );
+          appendStructuredXmlNode({
+            lines: context,
+            indent: '      ',
+            tag: 'managed_mandate',
+            value: visiblePortfolioManagerMandateProjection.managedMandate,
+          });
+          context.push('    </managed_agent>');
+        }
+        context.push('  </managed_agent_mandates>');
       }
 
       context.push('</portfolio_manager_context>');
@@ -3073,6 +3240,7 @@ export function createPortfolioManagerDomain(
             pendingOnboardingWalletAddress: null,
             pendingApprovedSetup: null,
             pendingSpotSwapConflict: null,
+            portfolioManagerMandate: null,
           };
 
           return {
@@ -3117,9 +3285,11 @@ export function createPortfolioManagerDomain(
             phase: 'onboarding',
             activeWalletAddress: setupInput.walletAddress,
             pendingOnboardingWalletAddress: setupInput.walletAddress,
+            portfolioManagerMandate: setupInput.portfolioManagerMandate ?? null,
             pendingApprovedSetup: {
               portfolioMandate: setupInput.portfolioMandate,
               firstManagedMandate: setupInput.firstManagedMandate,
+              portfolioManagerMandate: setupInput.portfolioManagerMandate ?? null,
             },
           };
 
@@ -3438,16 +3608,31 @@ export function createPortfolioManagerDomain(
             activeWalletAddress: walletAddress,
             pendingOnboardingWalletAddress: null,
             pendingApprovedSetup: null,
+            portfolioManagerMandate:
+              approvedSetup.portfolioManagerMandate ?? currentState.portfolioManagerMandate ?? null,
           };
           const onboardingManagedMandateProjection =
             buildManagedMandateEditorProjectionFromOnboardingBootstrap(onboarding);
+          const onboardingPortfolioManagerMandateProjection =
+            approvedSetup.portfolioManagerMandate
+              ? buildPortfolioManagerMandateEditorProjection({
+                  rootUserWallet: readPortfolioManagerContextWalletAddress(nextState),
+                  lastRootedWalletContextId: nextState.lastRootedWalletContextId,
+                  portfolioManagerMandate: approvedSetup.portfolioManagerMandate,
+                })
+              : null;
 
           return {
             state: nextState,
-            ...(onboardingManagedMandateProjection
+            ...(onboardingManagedMandateProjection || onboardingPortfolioManagerMandateProjection
               ? {
                   domainProjectionUpdate: {
-                    managedMandateEditor: onboardingManagedMandateProjection,
+                    ...(onboardingManagedMandateProjection
+                      ? { managedMandateEditor: onboardingManagedMandateProjection }
+                      : {}),
+                    ...(onboardingPortfolioManagerMandateProjection
+                      ? { portfolioManagerMandateEditor: onboardingPortfolioManagerMandateProjection }
+                      : {}),
                   },
                 }
               : {}),
@@ -3571,6 +3756,9 @@ export function createPortfolioManagerDomain(
           });
           const managedMandateProjection = managedSnapshot.managedMandateProjection;
           const portfolioProjectionInput = managedSnapshot.portfolioProjectionInput;
+          const portfolioManagerMandateProjection = readPortfolioManagerMandateProjectionFromState(
+            currentState,
+          );
           const nextPhase = managedMandateProjection ? 'active' : currentState.phase;
           const nextRevision =
             managedMandateProjection === null && managedSnapshot.accountingStateReads.length === 0
@@ -3600,11 +3788,16 @@ export function createPortfolioManagerDomain(
 
           return {
             state: nextState,
-            ...(managedMandateProjection || portfolioProjectionInput
+            ...(managedMandateProjection ||
+            portfolioManagerMandateProjection ||
+            portfolioProjectionInput
               ? {
                   domainProjectionUpdate: {
                     ...(managedMandateProjection
                       ? { managedMandateEditor: managedMandateProjection }
+                      : {}),
+                    ...(portfolioManagerMandateProjection
+                      ? { portfolioManagerMandateEditor: portfolioManagerMandateProjection }
                       : {}),
                     ...(portfolioProjectionInput ? { portfolioProjectionInput } : {}),
                   },
@@ -3628,18 +3821,6 @@ export function createPortfolioManagerDomain(
           };
         }
         case 'update_managed_mandate': {
-          if (!options.protocolHost) {
-            return {
-              state: currentState,
-              outputs: {
-                status: {
-                  executionStatus: 'failed',
-                  statusMessage: 'Shared Ember Domain Service host is not configured.',
-                },
-              },
-            };
-          }
-
           const updateInput = parseManagedMandateUpdateInput(operation.input);
           if (!updateInput) {
             return {
@@ -3648,7 +3829,45 @@ export function createPortfolioManagerDomain(
                 status: {
                   executionStatus: 'failed',
                   statusMessage:
-                    'Managed mandate updates require targetAgentId and a durable managedMandate payload.',
+                  'Managed mandate updates require targetAgentId and a durable managedMandate payload.',
+                },
+              },
+            };
+          }
+
+          if (updateInput.targetAgentId === PORTFOLIO_MANAGER_MANDATE_ROUTE_ID) {
+            const nextState: PortfolioManagerLifecycleState = {
+              ...currentState,
+              portfolioManagerMandate: updateInput.managedMandate,
+            };
+            const nextProjection = buildPortfolioManagerMandateEditorProjection({
+              rootUserWallet: readPortfolioManagerContextWalletAddress(currentState),
+              lastRootedWalletContextId: currentState.lastRootedWalletContextId,
+              portfolioManagerMandate: updateInput.managedMandate,
+            });
+
+            return {
+              state: nextState,
+              domainProjectionUpdate: {
+                portfolioManagerMandateEditor: nextProjection,
+              },
+              outputs: {
+                status: {
+                  executionStatus: 'completed',
+                  statusMessage:
+                    'Portfolio manager mandate updated for local execution and persisted in session state.',
+                },
+              },
+            };
+          }
+
+          if (!options.protocolHost) {
+            return {
+              state: currentState,
+              outputs: {
+                status: {
+                  executionStatus: 'failed',
+                  statusMessage: 'Shared Ember Domain Service host is not configured.',
                 },
               },
             };

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.ts
@@ -3784,6 +3784,7 @@ export function createPortfolioManagerDomain(
               managedMandateProjection === null
                 ? (currentState.pendingApprovedSetup ?? null)
                 : null,
+            portfolioManagerMandate: currentState.portfolioManagerMandate ?? null,
           };
 
           return {

--- a/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/agent-portfolio-manager/src/sharedEmberAdapter.unit.test.ts
@@ -107,10 +107,19 @@ type PortfolioManagerSetupInputFixture = {
       };
     };
   };
+  portfolioManagerMandate?: Record<string, unknown>;
 };
 
 type ManagedMandateFixture =
   PortfolioManagerSetupInputFixture['firstManagedMandate']['managedMandate'];
+
+function createPortfolioManagerMandatePayload() {
+  return {
+    betaExposureCapPct: 65,
+    minimumCashUsd: 5000,
+    riskBudgetBps: 1800,
+  } as const;
+}
 
 function createManagedLendingPolicy(
   overrides: Partial<ManagedMandateFixture['lending_policy']> = {},
@@ -3437,6 +3446,143 @@ describe('createPortfolioManagerDomain', () => {
     });
   });
 
+  it('refreshes the persisted PM mandate projection from local lifecycle state', async () => {
+    const protocolHost = {
+      handleJsonRpc: vi.fn(async () => ({
+        jsonrpc: '2.0',
+        id: 'shared-ember-thread-1-read-portfolio-state',
+        result: {
+          protocol_version: 'v1',
+          revision: 3,
+          portfolio_state: {
+            agent_id: 'portfolio-manager',
+          },
+        },
+      })),
+      readCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 3,
+        events: [],
+      })),
+      acknowledgeCommittedEventOutbox: vi.fn(async () => ({
+        protocol_version: 'v1',
+        revision: 3,
+        consumer_id: 'portfolio-manager',
+        acknowledged_through_sequence: 0,
+      })),
+    };
+
+    const domain = createPortfolioManagerDomain({
+      protocolHost,
+      agentId: 'portfolio-manager',
+    });
+    const portfolioManagerMandate = createPortfolioManagerMandatePayload();
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'prehire',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 2,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: null,
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          portfolioManagerMandate,
+        },
+        operation: {
+          source: 'tool',
+          name: 'refresh_portfolio_state',
+        },
+      }),
+    ).resolves.toMatchObject({
+      domainProjectionUpdate: {
+        portfolioManagerMandateEditor: {
+          ownerAgentId: 'agent-portfolio-manager',
+          targetAgentId: 'agent-portfolio-manager',
+          targetAgentRouteId: 'agent-portfolio-manager',
+          targetAgentKey: 'portfolio-manager-primary',
+          targetAgentTitle: 'Portfolio Manager Mandate',
+          mandateRef: 'mandate-portfolio-manager',
+          managedMandate: portfolioManagerMandate,
+          agentWallet: '0x00000000000000000000000000000000000000a1',
+          rootUserWallet: '0x00000000000000000000000000000000000000a1',
+          rootedWalletContextId: 'rwc-user-protocol-001',
+          reservation: null,
+        },
+      },
+    });
+  });
+
+  it('saves portfolio-manager mandate updates to local lifecycle state without Shared Ember', async () => {
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+    });
+    const updatedPortfolioManagerMandate = {
+      ...createPortfolioManagerMandatePayload(),
+      minimumCashUsd: 6100,
+    };
+
+    await expect(
+      domain.handleOperation?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 12,
+          lastRootDelegation: null,
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          portfolioManagerMandate: {
+            betaExposureCapPct: 50,
+            minimumCashUsd: 2500,
+            riskBudgetBps: 1400,
+          },
+        },
+        operation: {
+          source: 'command',
+          name: 'update_managed_mandate',
+          input: {
+            targetAgentId: 'agent-portfolio-manager',
+            managedMandate: updatedPortfolioManagerMandate,
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      state: {
+        phase: 'active',
+        lastSharedEmberRevision: 12,
+        portfolioManagerMandate: updatedPortfolioManagerMandate,
+      },
+      domainProjectionUpdate: {
+        portfolioManagerMandateEditor: {
+          ownerAgentId: 'agent-portfolio-manager',
+          targetAgentId: 'agent-portfolio-manager',
+          targetAgentRouteId: 'agent-portfolio-manager',
+          targetAgentKey: 'portfolio-manager-primary',
+          targetAgentTitle: 'Portfolio Manager Mandate',
+          mandateRef: 'mandate-portfolio-manager',
+          managedMandate: updatedPortfolioManagerMandate,
+          agentWallet: '0x00000000000000000000000000000000000000a1',
+          rootUserWallet: '0x00000000000000000000000000000000000000a1',
+          rootedWalletContextId: 'rwc-user-protocol-001',
+          reservation: null,
+        },
+      },
+      outputs: {
+        status: {
+          executionStatus: 'completed',
+          statusMessage:
+            'Portfolio manager mandate updated for local execution and persisted in session state.',
+        },
+      },
+    });
+  });
+
   it('routes post-activation managed-mandate edits through the PM-owned protocol command and rehydrates live state', async () => {
     let managedAgentReadCount = 0;
     const protocolHost = {
@@ -5205,6 +5351,43 @@ describe('createPortfolioManagerDomain', () => {
         '    <conflict>',
         '      <reservationId>res-ember-lending-weth-001</reservationId>',
         '  </pending_spot_swap_conflict>',
+      ]),
+    );
+  });
+
+  it('uses portfolio-manager mandate state directly in system context hydration', async () => {
+    const domain = createPortfolioManagerDomain({
+      agentId: 'portfolio-manager',
+    });
+
+    await expect(
+      domain.systemContext?.({
+        threadId: 'thread-1',
+        state: {
+          phase: 'active',
+          lastPortfolioState: null,
+          lastSharedEmberRevision: 4,
+          lastRootDelegation: {
+            root_delegation_id: 'root-a1',
+          },
+          lastOnboardingBootstrap: createOnboardingBootstrap(),
+          lastRootedWalletContextId: 'rwc-user-protocol-001',
+          activeWalletAddress: '0x00000000000000000000000000000000000000a1',
+          pendingOnboardingWalletAddress: null,
+          portfolioManagerMandate: createPortfolioManagerMandatePayload(),
+        },
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        '  <managed_agent_mandates>',
+        '    <managed_agent agent_key="portfolio-manager-primary" agent_type="agent-portfolio-manager" approved="true" mandate_ref="mandate-portfolio-manager">',
+        '      <managed_mandate>',
+        '        <betaExposureCapPct>65</betaExposureCapPct>',
+        '        <minimumCashUsd>5000</minimumCashUsd>',
+        '        <riskBudgetBps>1800</riskBudgetBps>',
+        '      </managed_mandate>',
+        '    </managed_agent>',
+        '  </managed_agent_mandates>',
       ]),
     );
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.ts
@@ -84,6 +84,14 @@ function readThrownErrorMessage(error: unknown): string {
   return 'Agent command failed.';
 }
 
+function serializeResumePayloadForRuntime(resume: unknown): string {
+  if (typeof resume === 'string') {
+    return resume;
+  }
+
+  return JSON.stringify(resume) ?? 'null';
+}
+
 async function readAuthoritativeStateDocument(params: {
   threadId: string;
   events: readonly BaseEvent[];
@@ -207,7 +215,7 @@ export async function POST(req: NextRequest): Promise<Response> {
               : {}),
           }
         : {
-            resume: parsedPayload.data.resume,
+            resume: serializeResumePayloadForRuntime(parsedPayload.data.resume),
           };
     const runEvents = await lastValueFrom(
       agent

--- a/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/app/api/agent-command/route.unit.test.ts
@@ -190,7 +190,7 @@ describe('POST /api/agent-command', () => {
         threadId: 'thread-1',
         forwardedProps: {
           command: {
-            resume: resumePayload,
+            resume: JSON.stringify(resumePayload),
           },
         },
       }),

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.agentContracts.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.agentContracts.unit.test.ts
@@ -530,8 +530,9 @@ describe('AgentDetailPage (cross-agent contracts)', () => {
     });
 
     expect(html).toContain('Ember Portfolio Agent Setup');
-    expect(html).toContain('Root delegation setup');
-    expect(html).toContain('live wallet observation');
+    expect(html).toContain('Portfolio manager mandate');
+    expect(html).not.toContain('Root delegation setup');
+    expect(html).not.toContain('live wallet observation');
     expect(html).not.toContain('USDC Allocation');
     expect(html).not.toContain('Portfolio policy bootstrap');
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.internalBranches.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.internalBranches.unit.test.ts
@@ -812,9 +812,10 @@ describe('AgentDetailPage internals: blockers variants', () => {
 
     const html = renderBlockers(delegationInterrupt);
 
-    expect(html).toContain('Review &amp; Sign Delegations');
-    expect(html).toContain('Warnings');
-    expect(html).toContain('Authorize spend for CLMM strategy');
+    expect(html).toContain('Authorize portfolio manager');
+    expect(html).toContain('Sign once to let this portfolio manager operate the mandates you approved.');
+    expect(html).not.toContain('Warnings');
+    expect(html).not.toContain('Authorize spend for CLMM strategy');
     expect(html).toContain('Switch Chain');
     expect(html).toContain('Sign &amp; Continue');
   });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedAgents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedAgents.unit.test.ts
@@ -64,6 +64,25 @@ function createManagedMandateEditorProjection(overrides: Record<string, unknown>
   };
 }
 
+function createPortfolioManagerMandateEditorProjection(overrides: Record<string, unknown> = {}) {
+  return {
+    portfolioManagerMandateEditor: {
+      ownerAgentId: 'agent-portfolio-manager',
+      targetAgentId: 'agent-portfolio-manager',
+      targetAgentRouteId: 'agent-portfolio-manager',
+      targetAgentKey: 'portfolio-manager-primary',
+      targetAgentTitle: 'Portfolio Manager Mandate',
+      mandateRef: 'mandate-portfolio-manager',
+      managedMandate: {
+        betaExposureCapPct: 60,
+        riskBudgetBps: 1500,
+        minimumCashUsd: 2500,
+      },
+      ...overrides,
+    },
+  };
+}
+
 function renderManagedAgentDetail(
   overrides: Partial<React.ComponentProps<typeof AgentDetailPage>>,
 ) {
@@ -319,7 +338,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
     expect(html).toContain('Artifact: shared-ember-portfolio-state');
   });
 
-  it('renders only the shared managed-mandate workbench on the portfolio-manager detail page', () => {
+  it('renders only the portfolio manager mandate workbench on the portfolio-manager detail page', () => {
     const html = renderToStaticMarkup(
       React.createElement(AgentDetailPage, {
         agentId: 'agent-portfolio-manager',
@@ -344,25 +363,29 @@ describe('AgentDetailPage managed-agent affordances', () => {
         lifecycleState: {
           phase: 'active',
         } as never,
-        domainProjection: createManagedMandateEditorProjection(),
+        domainProjection: createPortfolioManagerMandateEditorProjection(),
       }),
     );
 
-    expect(html).toContain('Edit collateral policy');
-    expect(html).toContain('Edit allowed borrow assets');
+    expect(html).toContain('Portfolio manager mandate');
+    expect(html).toContain('Beta exposure cap (%)');
+    expect(html).toContain('Risk budget (bps)');
+    expect(html).toContain('Minimum cash reserve (USD)');
     expect(html).toContain('Send message');
     expect(html).not.toContain('Settings and policies');
     expect(html).not.toMatch(new RegExp('<button[^>]*>\\s*Metrics\\s*</button>'));
     expect(html).not.toMatch(new RegExp('<button[^>]*>\\s*Activity\\s*</button>'));
     expect(html).not.toMatch(new RegExp('<button[^>]*>\\s*Chat\\s*</button>'));
-    expect(html).toContain('Save managed mandate');
+    expect(html).toContain('Save portfolio mandate');
     expect(html).not.toContain('Managed lending lane');
     expect(html).not.toContain('View lending agent');
     expect(html).not.toContain('lending.supply');
     expect(html.indexOf('Ember Portfolio Agent')).toBeLessThan(html.indexOf('Ember AI Team'));
     expect(html.indexOf('Ember AI Team')).toBeLessThan(html.indexOf('desc'));
-    expect(html.indexOf('desc')).toBeLessThan(html.indexOf('Save managed mandate'));
-    expect(html.indexOf('Save managed mandate')).toBeLessThan(html.indexOf('Send message'));
+    expect(html).not.toContain('Edit collateral policy');
+    expect(html).not.toContain('Edit allowed borrow assets');
+    expect(html.indexOf('desc')).toBeLessThan(html.indexOf('Save portfolio mandate'));
+    expect(html.indexOf('Save portfolio mandate')).toBeLessThan(html.indexOf('Send message'));
   });
 
   it('keeps managed lending lane details hidden while portfolio-manager onboarding is in progress', () => {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedAgents.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedAgents.unit.test.ts
@@ -175,7 +175,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
     expect(html).toContain('Edit collateral policy');
     expect(html).toContain('Edit allowed borrow assets');
     expect(html).toContain('>Manage<');
-    expect(html).toContain('Save managed mandate');
+    expect(html).toContain('Save lending mandate');
     expect(html).toContain('Send message');
     expect(html).not.toContain('Managed lending lane');
     expect(html).not.toContain('View lending agent');
@@ -201,7 +201,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
     );
     expect(html.indexOf('Ember Lending')).toBeLessThan(html.indexOf('Ember AI Team'));
     expect(html.indexOf('Ember AI Team')).toBeLessThan(html.indexOf('desc'));
-    expect(html.indexOf('desc')).toBeLessThan(html.indexOf('Save managed mandate'));
+    expect(html.indexOf('desc')).toBeLessThan(html.indexOf('Save lending mandate'));
   });
 
   it('keeps lending chat visible while the thread is input-required', () => {
@@ -311,7 +311,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
       }),
     });
 
-    expect(html).toContain('Save managed mandate');
+    expect(html).toContain('Save lending mandate');
     expect(html).not.toContain('Reservation');
     expect(html).not.toContain('lending.supply');
     expect(html).not.toContain(longReservationId);
@@ -363,20 +363,25 @@ describe('AgentDetailPage managed-agent affordances', () => {
         lifecycleState: {
           phase: 'active',
         } as never,
+        onboardingFlow: {
+          status: 'completed',
+          revision: 4,
+          steps: [],
+        } as never,
         domainProjection: createPortfolioManagerMandateEditorProjection(),
       }),
     );
 
     expect(html).toContain('Portfolio manager mandate');
-    expect(html).toContain('Beta exposure cap (%)');
-    expect(html).toContain('Risk budget (bps)');
-    expect(html).toContain('Minimum cash reserve (USD)');
+    expect(html).toContain('Beta exposure cap');
+    expect(html).toContain('Risk budget');
+    expect(html).toContain('Minimum cash reserve');
     expect(html).toContain('Send message');
     expect(html).not.toContain('Settings and policies');
     expect(html).not.toMatch(new RegExp('<button[^>]*>\\s*Metrics\\s*</button>'));
     expect(html).not.toMatch(new RegExp('<button[^>]*>\\s*Activity\\s*</button>'));
     expect(html).not.toMatch(new RegExp('<button[^>]*>\\s*Chat\\s*</button>'));
-    expect(html).toContain('Save portfolio mandate');
+    expect(html).toContain('Save PM mandate');
     expect(html).not.toContain('Managed lending lane');
     expect(html).not.toContain('View lending agent');
     expect(html).not.toContain('lending.supply');
@@ -384,8 +389,8 @@ describe('AgentDetailPage managed-agent affordances', () => {
     expect(html.indexOf('Ember AI Team')).toBeLessThan(html.indexOf('desc'));
     expect(html).not.toContain('Edit collateral policy');
     expect(html).not.toContain('Edit allowed borrow assets');
-    expect(html.indexOf('desc')).toBeLessThan(html.indexOf('Save portfolio mandate'));
-    expect(html.indexOf('Save portfolio mandate')).toBeLessThan(html.indexOf('Send message'));
+    expect(html.indexOf('desc')).toBeLessThan(html.indexOf('Save PM mandate'));
+    expect(html.indexOf('Save PM mandate')).toBeLessThan(html.indexOf('Send message'));
   });
 
   it('keeps managed lending lane details hidden while portfolio-manager onboarding is in progress', () => {
@@ -423,7 +428,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
     );
 
     expect(html).not.toContain('Managed lending lane');
-    expect(html).not.toContain('Save managed mandate');
+    expect(html).not.toContain('Save lending mandate');
     expect(html).not.toContain('/hire-agents/agent-ember-lending');
   });
 
@@ -462,7 +467,7 @@ describe('AgentDetailPage managed-agent affordances', () => {
     );
 
     expect(html).not.toContain('Managed lending lane');
-    expect(html).not.toContain('Save managed mandate');
+    expect(html).not.toContain('Save lending mandate');
     expect(html).not.toContain('/hire-agents/agent-ember-lending');
   });
 });

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedMandateEditor.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedMandateEditor.unit.test.tsx
@@ -87,6 +87,11 @@ describe('AgentDetailPage managed mandate editor', () => {
           lifecycleState: {
             phase: 'active',
           } as never,
+          onboardingFlow: {
+            status: 'completed',
+            revision: 4,
+            steps: [],
+          } as never,
           domainProjection: {
             portfolioManagerMandateEditor: {
               ownerAgentId: 'agent-portfolio-manager',
@@ -107,10 +112,10 @@ describe('AgentDetailPage managed mandate editor', () => {
     });
 
     const lendingSaveButton = [...container.querySelectorAll('button')].find((button) =>
-      button.textContent?.includes('Save managed mandate'),
+      button.textContent?.includes('Save lending mandate'),
     );
     const portfolioManagerSaveButton = [...container.querySelectorAll('button')].find((button) =>
-      button.textContent?.includes('Save portfolio mandate'),
+      button.textContent?.includes('Save PM mandate'),
     );
 
     expect(lendingSaveButton).toBeUndefined();
@@ -213,7 +218,7 @@ describe('AgentDetailPage managed mandate editor', () => {
       'button[aria-label="Edit minimum health factor"]',
     ) as HTMLButtonElement | null;
     const submitButton = [...container.querySelectorAll('button')].find((button) =>
-      button.textContent?.includes('Save managed mandate'),
+      button.textContent?.includes('Save lending mandate'),
     );
 
     expect(editCollateralPolicyButton).toBeDefined();
@@ -322,6 +327,11 @@ describe('AgentDetailPage managed mandate editor', () => {
           lifecycleState: {
             phase: 'active',
           } as never,
+          onboardingFlow: {
+            status: 'completed',
+            revision: 4,
+            steps: [],
+          } as never,
           domainProjection: {
             portfolioManagerMandateEditor: {
               ownerAgentId: 'agent-portfolio-manager',
@@ -352,7 +362,7 @@ describe('AgentDetailPage managed mandate editor', () => {
       'input[name="portfolio-manager-mandate-minimum-cash-usd"]',
     ) as HTMLInputElement | null;
     const submitButton = [...container.querySelectorAll('button')].find((button) =>
-      button.textContent?.includes('Save portfolio mandate'),
+      button.textContent?.includes('Save PM mandate'),
     );
 
     expect(betaExposureInput).toBeDefined();
@@ -389,7 +399,7 @@ describe('AgentDetailPage managed mandate editor', () => {
     });
   });
 
-  it('renders the portfolio manager mandate editor while portfolio manager onboarding is active', async () => {
+  it('hides the portfolio manager mandate editor while portfolio manager onboarding is active', async () => {
     const root = createRoot(container);
 
     await act(async () => {
@@ -451,11 +461,11 @@ describe('AgentDetailPage managed mandate editor', () => {
       'input[name="portfolio-manager-mandate-minimum-cash-usd"]',
     ) as HTMLInputElement | null;
 
-    expect(betaExposureInput).toBeDefined();
-    expect(riskBudgetInput).toBeDefined();
-    expect(minimumCashInput).toBeDefined();
-    expect(container.textContent).toContain('Portfolio manager mandate');
-    expect(container.textContent).toContain('Save portfolio mandate');
+    expect(betaExposureInput).toBeNull();
+    expect(riskBudgetInput).toBeNull();
+    expect(minimumCashInput).toBeNull();
+    expect(container.textContent).not.toContain('Portfolio manager mandate');
+    expect(container.textContent).not.toContain('Save PM mandate');
 
     await act(async () => {
       root.unmount();

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedMandateEditor.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.managedMandateEditor.unit.test.tsx
@@ -59,7 +59,7 @@ describe('AgentDetailPage managed mandate editor', () => {
     container.remove();
   });
 
-  it('shows the lending avatar rail next to the mandate editor on the portfolio manager page', async () => {
+  it('renders the portfolio manager mandate editor on the portfolio manager page', async () => {
     const root = createRoot(container);
 
     await act(async () => {
@@ -88,31 +88,17 @@ describe('AgentDetailPage managed mandate editor', () => {
             phase: 'active',
           } as never,
           domainProjection: {
-            managedMandateEditor: {
+            portfolioManagerMandateEditor: {
               ownerAgentId: 'agent-portfolio-manager',
-              targetAgentId: 'ember-lending',
-              targetAgentRouteId: 'agent-ember-lending',
-              targetAgentKey: 'ember-lending-primary',
-              targetAgentTitle: 'Ember Lending',
-              mandateRef: 'mandate-ember-lending-001',
+              targetAgentId: 'agent-portfolio-manager',
+              targetAgentRouteId: 'agent-portfolio-manager',
+              targetAgentKey: 'portfolio-manager-primary',
+              targetAgentTitle: 'Portfolio Manager Mandate',
+              mandateRef: 'mandate-portfolio-manager',
               managedMandate: {
-                lending_policy: {
-                  collateral_policy: {
-                    assets: [
-                      {
-                        asset: 'USDC',
-                        max_allocation_pct: 35,
-                      },
-                    ],
-                  },
-                  borrow_policy: {
-                    allowed_assets: ['WETH'],
-                  },
-                  risk_policy: {
-                    max_ltv_bps: 7000,
-                    min_health_factor: '1.25',
-                  },
-                },
+                betaExposureCapPct: 65,
+                riskBudgetBps: 1800,
+                minimumCashUsd: 5000,
               },
             },
           },
@@ -120,15 +106,17 @@ describe('AgentDetailPage managed mandate editor', () => {
       );
     });
 
-    const lendingAvatar = container.querySelector('img[alt="Ember Lending"]');
-    const lendingLink = container.querySelector(
-      'a[aria-label="Open Ember Lending"]',
-    ) as HTMLAnchorElement | null;
+    const lendingSaveButton = [...container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Save managed mandate'),
+    );
+    const portfolioManagerSaveButton = [...container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Save portfolio mandate'),
+    );
 
-    expect(lendingAvatar).not.toBeNull();
-    expect(lendingAvatar?.getAttribute('src')).toBe('/ember-lending-avatar.svg');
-    expect(lendingLink?.getAttribute('href')).toBe('/hire-agents/agent-ember-lending');
-    expect(container.textContent).toContain('Aave');
+    expect(lendingSaveButton).toBeUndefined();
+    expect(portfolioManagerSaveButton).toBeDefined();
+    expect(container.textContent).toContain('Portfolio manager mandate');
+    expect(container.textContent).toContain('Beta exposure cap');
 
     await act(async () => {
       root.unmount();
@@ -299,6 +287,175 @@ describe('AgentDetailPage managed mandate editor', () => {
         },
       },
     });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('renders and saves the portfolio manager mandate editor with numeric inputs', async () => {
+    const onManagedMandateSave = vi.fn(async () => undefined);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AgentDetailPage, {
+          agentId: 'agent-portfolio-manager',
+          agentName: 'Ember Portfolio Agent',
+          agentDescription: 'desc',
+          creatorName: 'Ember AI Team',
+          creatorVerified: true,
+          profile: {
+            chains: ['Arbitrum'],
+            protocols: ['Pi Runtime', 'Shared Ember Domain Service'],
+            tokens: ['USDC'],
+          },
+          metrics: {},
+          isHired: true,
+          isHiring: false,
+          hasLoadedView: true,
+          onHire: () => {},
+          onFire: () => {},
+          onSync: () => {},
+          onBack: () => {},
+          allowedPools: [],
+          lifecycleState: {
+            phase: 'active',
+          } as never,
+          domainProjection: {
+            portfolioManagerMandateEditor: {
+              ownerAgentId: 'agent-portfolio-manager',
+              targetAgentId: 'agent-portfolio-manager',
+              targetAgentRouteId: 'agent-portfolio-manager',
+              targetAgentKey: 'portfolio-manager-primary',
+              targetAgentTitle: 'Portfolio Manager Mandate',
+              mandateRef: 'mandate-portfolio-manager',
+              managedMandate: {
+                betaExposureCapPct: 65,
+                riskBudgetBps: 1800,
+                minimumCashUsd: 5000,
+              },
+            },
+          },
+          onManagedMandateSave,
+        }),
+      );
+    });
+
+    const betaExposureInput = container.querySelector(
+      'input[name="portfolio-manager-mandate-beta-exposure-cap-pct"]',
+    ) as HTMLInputElement | null;
+    const riskBudgetInput = container.querySelector(
+      'input[name="portfolio-manager-mandate-risk-budget-bps"]',
+    ) as HTMLInputElement | null;
+    const minimumCashInput = container.querySelector(
+      'input[name="portfolio-manager-mandate-minimum-cash-usd"]',
+    ) as HTMLInputElement | null;
+    const submitButton = [...container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Save portfolio mandate'),
+    );
+
+    expect(betaExposureInput).toBeDefined();
+    expect(riskBudgetInput).toBeDefined();
+    expect(minimumCashInput).toBeDefined();
+    expect(submitButton).toBeDefined();
+    expect(betaExposureInput!.value).toBe('65');
+    expect(riskBudgetInput!.value).toBe('1800');
+    expect(minimumCashInput!.value).toBe('5000');
+
+    await act(async () => {
+      setInputValue(betaExposureInput!, '68.5');
+      setInputValue(riskBudgetInput!, '2000');
+      setInputValue(minimumCashInput!, '4000');
+    });
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onManagedMandateSave).toHaveBeenCalledWith({
+      ownerAgentId: 'agent-portfolio-manager',
+      targetAgentId: 'agent-portfolio-manager',
+      targetAgentRouteId: 'agent-portfolio-manager',
+      managedMandate: {
+        betaExposureCapPct: 68.5,
+        riskBudgetBps: 2000,
+        minimumCashUsd: 4000,
+      },
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('renders the portfolio manager mandate editor while portfolio manager onboarding is active', async () => {
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AgentDetailPage, {
+          agentId: 'agent-portfolio-manager',
+          agentName: 'Ember Portfolio Agent',
+          agentDescription: 'desc',
+          creatorName: 'Ember AI Team',
+          creatorVerified: true,
+          profile: {
+            chains: ['Arbitrum'],
+            protocols: ['Pi Runtime', 'Shared Ember Domain Service'],
+            tokens: ['USDC'],
+          },
+          metrics: {},
+          isHired: true,
+          isHiring: false,
+          hasLoadedView: true,
+          onHire: () => {},
+          onFire: () => {},
+          onSync: () => {},
+          onBack: () => {},
+          allowedPools: [],
+          lifecycleState: {
+            phase: 'onboarding',
+          } as never,
+          onboardingFlow: {
+            status: 'in_progress',
+            revision: 1,
+            steps: [],
+          } as never,
+          domainProjection: {
+            portfolioManagerMandateEditor: {
+              ownerAgentId: 'agent-portfolio-manager',
+              targetAgentId: 'agent-portfolio-manager',
+              targetAgentRouteId: 'agent-portfolio-manager',
+              targetAgentKey: 'portfolio-manager-primary',
+              targetAgentTitle: 'Portfolio Manager Mandate',
+              mandateRef: 'mandate-portfolio-manager',
+              managedMandate: {
+                betaExposureCapPct: 65,
+                riskBudgetBps: 1800,
+                minimumCashUsd: 5000,
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    const betaExposureInput = container.querySelector(
+      'input[name="portfolio-manager-mandate-beta-exposure-cap-pct"]',
+    ) as HTMLInputElement | null;
+    const riskBudgetInput = container.querySelector(
+      'input[name="portfolio-manager-mandate-risk-budget-bps"]',
+    ) as HTMLInputElement | null;
+    const minimumCashInput = container.querySelector(
+      'input[name="portfolio-manager-mandate-minimum-cash-usd"]',
+    ) as HTMLInputElement | null;
+
+    expect(betaExposureInput).toBeDefined();
+    expect(riskBudgetInput).toBeDefined();
+    expect(minimumCashInput).toBeDefined();
+    expect(container.textContent).toContain('Portfolio manager mandate');
+    expect(container.textContent).toContain('Save portfolio mandate');
 
     await act(async () => {
       root.unmount();

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.portfolioManagerSetup.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.portfolioManagerSetup.unit.test.tsx
@@ -115,7 +115,7 @@ describe('AgentDetailPage portfolio-manager setup', () => {
       'a[aria-label="Open Ember Lending"]',
     ) as HTMLAnchorElement | null;
     const submitButton = [...container.querySelectorAll('button')].find(
-      (button) => button.textContent?.includes('Approve'),
+      (button) => button.textContent?.includes('Continue onboarding'),
     ) as HTMLButtonElement | undefined;
 
     expect(lendingAvatar?.getAttribute('src')).toBe('/ember-lending-avatar.svg');
@@ -159,6 +159,7 @@ describe('AgentDetailPage portfolio-manager setup', () => {
         approved: true,
         riskLevel: 'medium',
       },
+      portfolioManagerMandate: {},
       firstManagedMandate: {
         targetAgentId: 'ember-lending',
         targetAgentKey: 'ember-lending-primary',

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -1440,8 +1440,9 @@ export function AgentDetailPage({
   });
   const managedRuntimePhaseIsActive = lifecycleState?.phase === 'active';
   const managedOnboardingRuntimeActive = lifecycleState?.phase === 'onboarding';
+  const portfolioManagerOnboardingComplete = onboardingFlow?.status === 'completed';
   const portfolioManagedContextVisible = isPortfolioAgent
-    ? managedRuntimePhaseIsActive
+    ? managedRuntimePhaseIsActive && portfolioManagerOnboardingComplete
     : managedRuntimePhaseIsActive && !isOnboardingActive;
   const visiblePortfolioManagerMandateEditorView =
     portfolioManagedContextVisible && isPortfolioAgent

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -108,6 +108,191 @@ const AGENT_X_URL = 'https://x.com/emberagi';
 const MANAGED_LENDING_NETWORK = 'arbitrum';
 const MANAGED_LENDING_PROTOCOL = 'aave';
 const MANAGED_LENDING_CONTROL_PATH = 'lending.supply';
+const DEFAULT_PORTFOLIO_MANAGER_MANDATE_INPUT = {} satisfies PortfolioManagerMandateInput;
+type PortfolioManagerMandateNumericKey =
+  | 'betaExposureCapPct'
+  | 'riskBudgetBps'
+  | 'minimumCashUsd'
+  | 'maxDrawdownPct'
+  | 'targetVolatilityPct'
+  | 'maxSingleAssetAllocationPct'
+  | 'rebalanceThresholdPct'
+  | 'maxLeverageRatio'
+  | 'liquidityBufferPct'
+  | 'maxPerpsAllocationPct'
+  | 'maxPredictionMarketsAllocationPct'
+  | 'maxNftAllocationPct'
+  | 'maxMemecoinAllocationPct'
+  | 'maxRwaAllocationPct'
+  | 'maxIlliquidAllocationPct';
+type PortfolioManagerMandatePillOption = {
+  key: PortfolioManagerMandateNumericKey;
+  label: string;
+  shortLabel: string;
+  helper: string;
+  unit: string;
+  placeholder: string;
+  inputName: string;
+  ariaLabel: string;
+};
+const PORTFOLIO_MANAGER_MANDATE_PILL_OPTIONS: PortfolioManagerMandatePillOption[] = [
+  {
+    key: 'betaExposureCapPct',
+    label: 'Beta exposure cap',
+    shortLabel: 'Beta cap',
+    helper: 'Maximum portfolio beta exposure allowed before the PM should de-risk.',
+    unit: '%',
+    placeholder: '65',
+    inputName: 'portfolio-manager-mandate-beta-exposure-cap-pct',
+    ariaLabel: 'Portfolio manager beta exposure cap',
+  },
+  {
+    key: 'riskBudgetBps',
+    label: 'Risk budget',
+    shortLabel: 'Risk budget',
+    helper: 'Portfolio-wide risk budget expressed in basis points.',
+    unit: 'bps',
+    placeholder: '500',
+    inputName: 'portfolio-manager-mandate-risk-budget-bps',
+    ariaLabel: 'Portfolio manager risk budget',
+  },
+  {
+    key: 'minimumCashUsd',
+    label: 'Minimum cash reserve',
+    shortLabel: 'Cash reserve',
+    helper: 'Minimum unallocated cash the PM should keep available.',
+    unit: 'USD',
+    placeholder: '10',
+    inputName: 'portfolio-manager-mandate-minimum-cash-usd',
+    ariaLabel: 'Portfolio manager minimum cash reserve',
+  },
+  {
+    key: 'maxDrawdownPct',
+    label: 'Maximum drawdown',
+    shortLabel: 'Drawdown',
+    helper: 'Loss threshold where the PM should stop adding risk and preserve capital.',
+    unit: '%',
+    placeholder: '12',
+    inputName: 'portfolio-manager-mandate-max-drawdown-pct',
+    ariaLabel: 'Portfolio manager maximum drawdown',
+  },
+  {
+    key: 'targetVolatilityPct',
+    label: 'Target volatility',
+    shortLabel: 'Volatility',
+    helper: 'Annualized volatility target used to size portfolio risk.',
+    unit: '%',
+    placeholder: '18',
+    inputName: 'portfolio-manager-mandate-target-volatility-pct',
+    ariaLabel: 'Portfolio manager target volatility',
+  },
+  {
+    key: 'maxSingleAssetAllocationPct',
+    label: 'Max single-asset allocation',
+    shortLabel: 'Single asset',
+    helper: 'Concentration cap for any one asset across the managed portfolio.',
+    unit: '%',
+    placeholder: '35',
+    inputName: 'portfolio-manager-mandate-max-single-asset-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum single asset allocation',
+  },
+  {
+    key: 'rebalanceThresholdPct',
+    label: 'Rebalance threshold',
+    shortLabel: 'Rebalance',
+    helper: 'Drift from target allocation that should trigger rebalancing.',
+    unit: '%',
+    placeholder: '7.5',
+    inputName: 'portfolio-manager-mandate-rebalance-threshold-pct',
+    ariaLabel: 'Portfolio manager rebalance threshold',
+  },
+  {
+    key: 'maxLeverageRatio',
+    label: 'Maximum leverage ratio',
+    shortLabel: 'Leverage',
+    helper: 'Portfolio leverage ceiling before the PM must reduce borrowed exposure.',
+    unit: 'x',
+    placeholder: '1.2',
+    inputName: 'portfolio-manager-mandate-max-leverage-ratio',
+    ariaLabel: 'Portfolio manager maximum leverage ratio',
+  },
+  {
+    key: 'liquidityBufferPct',
+    label: 'Liquidity buffer',
+    shortLabel: 'Liquidity',
+    helper: 'Portfolio percentage reserved for withdrawals, redeployments, and execution costs.',
+    unit: '%',
+    placeholder: '8',
+    inputName: 'portfolio-manager-mandate-liquidity-buffer-pct',
+    ariaLabel: 'Portfolio manager liquidity buffer',
+  },
+  {
+    key: 'maxPerpsAllocationPct',
+    label: 'Max portfolio in perps',
+    shortLabel: 'Perps cap',
+    helper: 'Maximum portfolio percentage the PM may allocate to perpetual futures exposure.',
+    unit: '%',
+    placeholder: '15',
+    inputName: 'portfolio-manager-mandate-max-perps-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum allocation to perps',
+  },
+  {
+    key: 'maxPredictionMarketsAllocationPct',
+    label: 'Max portfolio in prediction markets',
+    shortLabel: 'Prediction cap',
+    helper: 'Maximum portfolio percentage the PM may allocate to prediction-market positions.',
+    unit: '%',
+    placeholder: '10',
+    inputName: 'portfolio-manager-mandate-max-prediction-markets-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum allocation to prediction markets',
+  },
+  {
+    key: 'maxNftAllocationPct',
+    label: 'Max portfolio in NFTs',
+    shortLabel: 'NFT cap',
+    helper: 'Maximum portfolio percentage the PM may allocate to NFT or NFT-backed exposure.',
+    unit: '%',
+    placeholder: '5',
+    inputName: 'portfolio-manager-mandate-max-nft-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum allocation to NFTs',
+  },
+  {
+    key: 'maxMemecoinAllocationPct',
+    label: 'Max portfolio in memecoins',
+    shortLabel: 'Memecoin cap',
+    helper: 'Maximum portfolio percentage the PM may allocate to memecoin exposure.',
+    unit: '%',
+    placeholder: '3',
+    inputName: 'portfolio-manager-mandate-max-memecoin-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum allocation to memecoins',
+  },
+  {
+    key: 'maxRwaAllocationPct',
+    label: 'Max portfolio in RWAs',
+    shortLabel: 'RWA cap',
+    helper: 'Maximum portfolio percentage the PM may allocate to tokenized real-world assets.',
+    unit: '%',
+    placeholder: '20',
+    inputName: 'portfolio-manager-mandate-max-rwa-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum allocation to RWAs',
+  },
+  {
+    key: 'maxIlliquidAllocationPct',
+    label: 'Max portfolio in illiquid assets',
+    shortLabel: 'Illiquid cap',
+    helper: 'Maximum portfolio percentage the PM may allocate to illiquid or thinly traded positions.',
+    unit: '%',
+    placeholder: '12',
+    inputName: 'portfolio-manager-mandate-max-illiquid-allocation-pct',
+    ariaLabel: 'Portfolio manager maximum allocation to illiquid assets',
+  },
+];
+const PORTFOLIO_MANAGER_MANDATE_KEYS_TO_STRIP = [
+  ...PORTFOLIO_MANAGER_MANDATE_PILL_OPTIONS.map((option) => option.key),
+  'betaExposureTarget',
+  'riskToleranceScore',
+  'minUndeployedCashBps',
+] as const;
 const DETAIL_PAGE_SHELL_CLASS =
   'flex-1 overflow-y-auto bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.78),rgba(248,241,232,0.96)_38%,#efe3d2_100%)] p-8 text-[#261a12]';
 const DETAIL_CARD_CLASS =
@@ -764,6 +949,7 @@ function ManagedMandateEditorCard(props: {
   availableTokenSymbols?: string[];
   tokenIconBySymbol: Record<string, string>;
   onSave?: (input: ManagedMandateEditorSubmitInput) => Promise<void> | void;
+  submitLabel?: string;
   chrome?: 'card' | 'plain';
 }) {
   return (
@@ -778,6 +964,7 @@ function ManagedMandateEditorCard(props: {
       availableTokenSymbols={props.availableTokenSymbols}
       tokenIconBySymbolOverride={props.tokenIconBySymbol}
       chrome={props.chrome}
+      submitLabel={props.submitLabel}
       onSave={(input) =>
         props.onSave?.({
           ownerAgentId: input.ownerAgentId,
@@ -790,68 +977,182 @@ function ManagedMandateEditorCard(props: {
   );
 }
 
+function readPortfolioManagerMandatePillOption(
+  key: PortfolioManagerMandateNumericKey,
+): PortfolioManagerMandatePillOption {
+  const option = PORTFOLIO_MANAGER_MANDATE_PILL_OPTIONS.find((candidate) => candidate.key === key);
+  if (!option) {
+    throw new Error(`Unsupported portfolio manager mandate key: ${key}`);
+  }
+  return option;
+}
+
+function readSelectedPortfolioManagerMandateKeys(
+  mandate: PortfolioManagerMandateInput,
+): PortfolioManagerMandateNumericKey[] {
+  return PORTFOLIO_MANAGER_MANDATE_PILL_OPTIONS
+    .filter((option) => readPortfolioManagerNumber(mandate[option.key]) !== undefined)
+    .map((option) => option.key);
+}
+
+function buildPortfolioManagerMandateInputValues(
+  mandate: PortfolioManagerMandateInput,
+): Record<PortfolioManagerMandateNumericKey, string> {
+  const betaExposureCapPct = readPortfolioManagerNumber(mandate.betaExposureCapPct);
+  const riskBudgetBps = readPortfolioManagerNumber(mandate.riskBudgetBps);
+  const minimumCashUsd = readPortfolioManagerNumber(mandate.minimumCashUsd);
+  const maxDrawdownPct = readPortfolioManagerNumber(mandate.maxDrawdownPct);
+  const targetVolatilityPct = readPortfolioManagerNumber(mandate.targetVolatilityPct);
+  const maxSingleAssetAllocationPct = readPortfolioManagerNumber(
+    mandate.maxSingleAssetAllocationPct,
+  );
+  const rebalanceThresholdPct = readPortfolioManagerNumber(mandate.rebalanceThresholdPct);
+  const maxLeverageRatio = readPortfolioManagerNumber(mandate.maxLeverageRatio);
+  const liquidityBufferPct = readPortfolioManagerNumber(mandate.liquidityBufferPct);
+  const maxPerpsAllocationPct = readPortfolioManagerNumber(mandate.maxPerpsAllocationPct);
+  const maxPredictionMarketsAllocationPct = readPortfolioManagerNumber(
+    mandate.maxPredictionMarketsAllocationPct,
+  );
+  const maxNftAllocationPct = readPortfolioManagerNumber(mandate.maxNftAllocationPct);
+  const maxMemecoinAllocationPct = readPortfolioManagerNumber(mandate.maxMemecoinAllocationPct);
+  const maxRwaAllocationPct = readPortfolioManagerNumber(mandate.maxRwaAllocationPct);
+  const maxIlliquidAllocationPct = readPortfolioManagerNumber(mandate.maxIlliquidAllocationPct);
+
+  return {
+    betaExposureCapPct: betaExposureCapPct === undefined ? '' : String(betaExposureCapPct),
+    riskBudgetBps: riskBudgetBps === undefined ? '' : String(riskBudgetBps),
+    minimumCashUsd: minimumCashUsd === undefined ? '' : String(minimumCashUsd),
+    maxDrawdownPct: maxDrawdownPct === undefined ? '' : String(maxDrawdownPct),
+    targetVolatilityPct: targetVolatilityPct === undefined ? '' : String(targetVolatilityPct),
+    maxSingleAssetAllocationPct:
+      maxSingleAssetAllocationPct === undefined ? '' : String(maxSingleAssetAllocationPct),
+    rebalanceThresholdPct:
+      rebalanceThresholdPct === undefined ? '' : String(rebalanceThresholdPct),
+    maxLeverageRatio: maxLeverageRatio === undefined ? '' : String(maxLeverageRatio),
+    liquidityBufferPct: liquidityBufferPct === undefined ? '' : String(liquidityBufferPct),
+    maxPerpsAllocationPct:
+      maxPerpsAllocationPct === undefined ? '' : String(maxPerpsAllocationPct),
+    maxPredictionMarketsAllocationPct:
+      maxPredictionMarketsAllocationPct === undefined
+        ? ''
+        : String(maxPredictionMarketsAllocationPct),
+    maxNftAllocationPct:
+      maxNftAllocationPct === undefined ? '' : String(maxNftAllocationPct),
+    maxMemecoinAllocationPct:
+      maxMemecoinAllocationPct === undefined ? '' : String(maxMemecoinAllocationPct),
+    maxRwaAllocationPct:
+      maxRwaAllocationPct === undefined ? '' : String(maxRwaAllocationPct),
+    maxIlliquidAllocationPct:
+      maxIlliquidAllocationPct === undefined ? '' : String(maxIlliquidAllocationPct),
+  };
+}
+
+function buildPortfolioManagerMandateFromDraft(params: {
+  baseMandate: PortfolioManagerMandateInput;
+  selectedKeys: PortfolioManagerMandateNumericKey[];
+  numberInputs: Record<PortfolioManagerMandateNumericKey, string>;
+  requireCompleteValues: boolean;
+}): PortfolioManagerMandateInput {
+  const nextMandate: Record<string, unknown> = { ...params.baseMandate };
+  for (const key of PORTFOLIO_MANAGER_MANDATE_KEYS_TO_STRIP) {
+    delete nextMandate[key];
+  }
+
+  for (const key of params.selectedKeys) {
+    const option = readPortfolioManagerMandatePillOption(key);
+    const rawValue = params.numberInputs[key].trim();
+    const numericValue = Number(rawValue);
+    if (rawValue.length === 0 || !Number.isFinite(numericValue)) {
+      if (params.requireCompleteValues) {
+        throw new Error(`${option.label} must be a valid number.`);
+      }
+      continue;
+    }
+    nextMandate[key] = numericValue;
+  }
+
+  return nextMandate as PortfolioManagerMandateInput;
+}
+
 function PortfolioManagerMandateWorkbenchCard(props: {
   view: PortfolioManagerMandateEditorView;
   onSave?: (input: PortfolioManagerMandateEditorSubmitInput) => Promise<void> | void;
+  onDraftChange?: (managedMandate: PortfolioManagerMandateInput) => void;
   submitLabel?: string;
   chrome?: 'card' | 'plain';
 }) {
-  const initialBetaExposureCapPct = readPortfolioManagerNumber(props.view.managedMandate.betaExposureCapPct);
-  const initialRiskBudgetBps = readPortfolioManagerNumber(props.view.managedMandate.riskBudgetBps);
-  const initialMinimumCashUsd = readPortfolioManagerNumber(props.view.managedMandate.minimumCashUsd);
-
-  const [betaExposureCapPctInput, setBetaExposureCapPctInput] = useState(
-    initialBetaExposureCapPct === undefined ? '' : String(initialBetaExposureCapPct),
+  const [selectedKeys, setSelectedKeys] = useState<PortfolioManagerMandateNumericKey[]>(() =>
+    readSelectedPortfolioManagerMandateKeys(props.view.managedMandate),
   );
-  const [riskBudgetBpsInput, setRiskBudgetBpsInput] = useState(
-    initialRiskBudgetBps === undefined ? '' : String(initialRiskBudgetBps),
-  );
-  const [minimumCashUsdInput, setMinimumCashUsdInput] = useState(
-    initialMinimumCashUsd === undefined ? '' : String(initialMinimumCashUsd),
-  );
+  const [numberInputs, setNumberInputs] = useState<
+    Record<PortfolioManagerMandateNumericKey, string>
+  >(() => buildPortfolioManagerMandateInputValues(props.view.managedMandate));
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    setBetaExposureCapPctInput(
-      readPortfolioManagerNumber(props.view.managedMandate.betaExposureCapPct) === undefined
-        ? ''
-        : String(readPortfolioManagerNumber(props.view.managedMandate.betaExposureCapPct)),
-    );
-    setRiskBudgetBpsInput(
-      readPortfolioManagerNumber(props.view.managedMandate.riskBudgetBps) === undefined
-        ? ''
-        : String(readPortfolioManagerNumber(props.view.managedMandate.riskBudgetBps)),
-    );
-    setMinimumCashUsdInput(
-      readPortfolioManagerNumber(props.view.managedMandate.minimumCashUsd) === undefined
-        ? ''
-        : String(readPortfolioManagerNumber(props.view.managedMandate.minimumCashUsd)),
-    );
+    setSelectedKeys(readSelectedPortfolioManagerMandateKeys(props.view.managedMandate));
+    setNumberInputs(buildPortfolioManagerMandateInputValues(props.view.managedMandate));
     setSubmitError(null);
-  }, [props.view.mandateRef, props.view.managedMandate]);
+  }, [
+    props.view.mandateRef,
+    props.view.ownerAgentId,
+    props.view.targetAgentId,
+    props.view.targetAgentKey,
+    props.view.targetAgentRouteId,
+  ]);
+
+  const emitDraftChange = (
+    nextSelectedKeys: PortfolioManagerMandateNumericKey[],
+    nextNumberInputs: Record<PortfolioManagerMandateNumericKey, string>,
+  ) => {
+    props.onDraftChange?.(
+      buildPortfolioManagerMandateFromDraft({
+        baseMandate: props.view.managedMandate,
+        selectedKeys: nextSelectedKeys,
+        numberInputs: nextNumberInputs,
+        requireCompleteValues: false,
+      }),
+    );
+  };
+
+  const handleTogglePill = (key: PortfolioManagerMandateNumericKey) => {
+    const isSelected = selectedKeys.includes(key);
+    const nextSelectedKeys = isSelected
+      ? selectedKeys.filter((selectedKey) => selectedKey !== key)
+      : PORTFOLIO_MANAGER_MANDATE_PILL_OPTIONS
+          .map((option) => option.key)
+          .filter((optionKey) => optionKey === key || selectedKeys.includes(optionKey));
+    setSelectedKeys(nextSelectedKeys);
+    setSubmitError(null);
+    if (isSelected) {
+      emitDraftChange(nextSelectedKeys, numberInputs);
+    }
+  };
+
+  const handleInputChange = (key: PortfolioManagerMandateNumericKey, value: string) => {
+    const nextNumberInputs = {
+      ...numberInputs,
+      [key]: value,
+    };
+    setNumberInputs(nextNumberInputs);
+    setSubmitError(null);
+    emitDraftChange(selectedKeys, nextNumberInputs);
+  };
 
   const handleSave = async () => {
     if (!props.onSave) {
       return;
     }
 
-    const betaExposureCapPct = Number(betaExposureCapPctInput.trim());
-    if (!Number.isFinite(betaExposureCapPct)) {
-      setSubmitError('Beta exposure cap must be a valid number.');
-      return;
-    }
-
-    const riskBudgetBps = Number(riskBudgetBpsInput.trim());
-    if (!Number.isFinite(riskBudgetBps)) {
-      setSubmitError('Risk budget must be a valid number.');
-      return;
-    }
-
-    const minimumCashUsd = Number(minimumCashUsdInput.trim());
-    if (!Number.isFinite(minimumCashUsd)) {
-      setSubmitError('Minimum cash threshold must be a valid number.');
-      return;
+    for (const key of selectedKeys) {
+      const option = readPortfolioManagerMandatePillOption(key);
+      const rawValue = numberInputs[key].trim();
+      const value = Number(rawValue);
+      if (rawValue.length === 0 || !Number.isFinite(value)) {
+        setSubmitError(`${option.label} must be a valid number.`);
+        return;
+      }
     }
 
     setIsSaving(true);
@@ -861,12 +1162,12 @@ function PortfolioManagerMandateWorkbenchCard(props: {
         ownerAgentId: props.view.ownerAgentId,
         targetAgentId: props.view.targetAgentId,
         targetAgentRouteId: props.view.targetAgentRouteId,
-        managedMandate: {
-          ...props.view.managedMandate,
-          betaExposureCapPct,
-          riskBudgetBps,
-          minimumCashUsd,
-        },
+        managedMandate: buildPortfolioManagerMandateFromDraft({
+          baseMandate: props.view.managedMandate,
+          selectedKeys,
+          numberInputs,
+          requireCompleteValues: true,
+        }),
       });
     } catch (error) {
       setSubmitError(error instanceof Error ? error.message : 'Portfolio mandate update failed.');
@@ -886,54 +1187,72 @@ function PortfolioManagerMandateWorkbenchCard(props: {
         <div>
           <div className="text-[0.88rem] font-semibold text-[#503826]">Portfolio manager mandate</div>
           <div className="mt-1 text-xs text-[#7c6757]">
-            Tune these portfolio-wide policy defaults before runtime dispatch.
+            Select the portfolio-wide constraints you want the PM to enforce.
           </div>
         </div>
 
-        <label className="space-y-1.5 block">
-          <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
-            Beta exposure cap (%)
-          </span>
-          <input
-            name="portfolio-manager-mandate-beta-exposure-cap-pct"
-            aria-label="Portfolio manager beta exposure cap"
-            type="number"
-            className={DETAIL_INPUT_CLASS}
-            value={betaExposureCapPctInput}
-            onChange={(event) => setBetaExposureCapPctInput(event.target.value)}
-            disabled={isSaving}
-          />
-        </label>
+        <div className="flex flex-wrap gap-2" aria-label="Portfolio manager mandate options">
+          {PORTFOLIO_MANAGER_MANDATE_PILL_OPTIONS.map((option) => {
+            const selected = selectedKeys.includes(option.key);
+            return (
+              <button
+                key={option.key}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => handleTogglePill(option.key)}
+                disabled={isSaving}
+                className={`rounded-full border px-3.5 py-2 text-xs font-semibold transition-all active:scale-[0.98] disabled:opacity-60 ${
+                  selected
+                    ? 'border-[#fd6731] bg-[#fff1e7] text-[#6a3216] shadow-[inset_0_1px_0_rgba(255,255,255,0.76),0_10px_24px_rgba(253,103,49,0.13)]'
+                    : 'border-[#eadac7] bg-white/70 text-[#7c6757] hover:border-[#d8bda3] hover:bg-[#fffaf2]'
+                }`}
+              >
+                {option.shortLabel}
+              </button>
+            );
+          })}
+        </div>
 
-        <label className="space-y-1.5 block">
-          <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
-            Risk budget (bps)
-          </span>
-          <input
-            name="portfolio-manager-mandate-risk-budget-bps"
-            aria-label="Portfolio manager risk budget"
-            type="number"
-            className={DETAIL_INPUT_CLASS}
-            value={riskBudgetBpsInput}
-            onChange={(event) => setRiskBudgetBpsInput(event.target.value)}
-            disabled={isSaving}
-          />
-        </label>
-
-        <label className="space-y-1.5 block">
-          <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
-            Minimum cash reserve (USD)
-          </span>
-          <input
-            name="portfolio-manager-mandate-minimum-cash-usd"
-            aria-label="Portfolio manager minimum cash reserve"
-            type="number"
-            className={DETAIL_INPUT_CLASS}
-            value={minimumCashUsdInput}
-            onChange={(event) => setMinimumCashUsdInput(event.target.value)}
-            disabled={isSaving}
-          />
-        </label>
+        {selectedKeys.length === 0 ? (
+          <div className="rounded-[18px] border border-dashed border-[#dfcab4] bg-[#fffaf2]/70 px-4 py-5 text-sm text-[#7c6757]">
+            No PM constraints selected yet. Pick one or more policy pills above to add numeric
+            mandate inputs.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {selectedKeys.map((key) => {
+              const option = readPortfolioManagerMandatePillOption(key);
+              return (
+                <label
+                  key={key}
+                  className="grid gap-2 rounded-[18px] border border-[#eadac7] bg-[#fffdf8] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.72)]"
+                >
+                  <span className="flex items-start justify-between gap-3">
+                    <span>
+                      <span className="block text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
+                        {option.label}
+                      </span>
+                      <span className="mt-1 block text-xs text-[#7c6757]">{option.helper}</span>
+                    </span>
+                    <span className="rounded-full border border-[#eadac7] bg-[#fff7ef] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[#7c6757]">
+                      {option.unit}
+                    </span>
+                  </span>
+                  <input
+                    name={option.inputName}
+                    aria-label={option.ariaLabel}
+                    type="number"
+                    className={`${DETAIL_INPUT_CLASS} font-mono`}
+                    value={numberInputs[key]}
+                    placeholder={option.placeholder}
+                    onChange={(event) => handleInputChange(key, event.target.value)}
+                    disabled={isSaving}
+                  />
+                </label>
+              );
+            })}
+          </div>
+        )}
 
         {submitError ? <p className="text-xs text-[#8a2f2f]">{submitError}</p> : null}
 
@@ -951,41 +1270,62 @@ function PortfolioManagerMandateWorkbenchCard(props: {
 }
 
 function PortfolioManagerMandateWorkbenchShell(props: {
+  variant: 'portfolio-manager' | 'managed-lending';
   children: ReactNode;
 }) {
-  const lendingAgentConfig = getAgentConfig('agent-ember-lending');
-  const lendingAgentHref = `/hire-agents/${lendingAgentConfig.id}`;
+  const shellAgentConfig = getAgentConfig(
+    props.variant === 'portfolio-manager' ? 'agent-portfolio-manager' : 'agent-ember-lending',
+  );
+  const shellAgentHref = `/hire-agents/${shellAgentConfig.id}`;
+  const shellLabel =
+    props.variant === 'portfolio-manager'
+      ? {
+          aria: 'Open Portfolio Manager',
+          eyebrow: 'PM',
+          title: 'Portfolio',
+          iconFallback: 'PM',
+        }
+      : {
+          aria: 'Open Ember Lending',
+          eyebrow: 'Aave',
+          title: 'Lending',
+          iconFallback: 'EL',
+        };
+  const railClassName =
+    props.variant === 'portfolio-manager'
+      ? 'from-[#fff4e9] to-[#f3dfca] text-[#6a3d20]'
+      : 'from-[#eef8f1] to-[#dceee2] text-[#315f3d]';
 
   return (
     <div className="flex items-stretch gap-4">
       <Link
-        href={lendingAgentHref}
-        aria-label="Open Ember Lending"
-        className="flex w-[92px] shrink-0 flex-col items-center justify-center gap-2 self-stretch border-r border-[#eadac7] pr-4 text-center transition-colors hover:text-[#2f2118]"
+        href={shellAgentHref}
+        aria-label={shellLabel.aria}
+        className="flex w-[92px] shrink-0 flex-col items-center justify-center gap-2 self-stretch border-r border-[#eadac7] pr-4 text-center transition-colors hover:text-[#2f2118] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#fd6731]/30"
       >
         <div
-          className="mx-auto flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-[#f4ece1]"
-          style={lendingAgentConfig.imageUrl && lendingAgentConfig.avatarBg
-            ? { background: lendingAgentConfig.avatarBg }
+          className={`mx-auto flex h-12 w-12 items-center justify-center overflow-hidden rounded-[18px] bg-gradient-to-br shadow-[inset_0_1px_0_rgba(255,255,255,0.72),0_10px_24px_rgba(99,70,43,0.10)] ${railClassName}`}
+          style={shellAgentConfig.imageUrl && shellAgentConfig.avatarBg
+            ? { background: shellAgentConfig.avatarBg }
             : undefined}
         >
-          {lendingAgentConfig.imageUrl ? (
+          {shellAgentConfig.imageUrl ? (
             <img
-              src={lendingAgentConfig.imageUrl}
-              alt="Ember Lending"
+              src={shellAgentConfig.imageUrl}
+              alt={shellLabel.aria.replace('Open ', '')}
               className="h-8 w-8 object-contain"
             />
           ) : (
-            <span className="text-lg" aria-hidden="true">
-              {lendingAgentConfig.avatar}
+            <span className="text-xs font-semibold" aria-hidden="true">
+              {shellAgentConfig.avatar ?? shellLabel.iconFallback}
             </span>
           )}
         </div>
         <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#9b826f]">
-          Aave
+          {shellLabel.eyebrow}
         </div>
         <div className="text-[11px] font-medium leading-[1.1] text-[#503826]">
-          Lending
+          {shellLabel.title}
         </div>
       </Link>
       <div className="min-w-0 flex-1 self-stretch">{props.children}</div>
@@ -1101,12 +1441,14 @@ export function AgentDetailPage({
   const managedRuntimePhaseIsActive = lifecycleState?.phase === 'active';
   const managedOnboardingRuntimeActive = lifecycleState?.phase === 'onboarding';
   const portfolioManagedContextVisible = isPortfolioAgent
-    ? managedRuntimePhaseIsActive || managedOnboardingRuntimeActive
+    ? managedRuntimePhaseIsActive
     : managedRuntimePhaseIsActive && !isOnboardingActive;
-  const visibleManagedMandateEditorView = portfolioManagedContextVisible
-    ? isPortfolioAgent
+  const visiblePortfolioManagerMandateEditorView =
+    portfolioManagedContextVisible && isPortfolioAgent
       ? portfolioManagerMandateEditorView
-      : managedMandateEditorView
+      : null;
+  const visibleManagedMandateEditorView = portfolioManagedContextVisible
+    ? managedMandateEditorView
     : null;
   const emberLendingChatEnabled =
     agentId === 'agent-ember-lending' &&
@@ -1457,23 +1799,34 @@ export function AgentDetailPage({
       onSendChatMessage={onSendChatMessage}
     />
   ) : null;
-  const managedAgentContextCards = visibleManagedMandateEditorView ? (
+  const managedAgentContextCards = visiblePortfolioManagerMandateEditorView || visibleManagedMandateEditorView ? (
     <div className={isPortfolioAgent ? 'mt-6 border-t border-[#eadac7] pt-5' : 'mt-6'}>
-      {isPortfolioAgent ? (
-        <PortfolioManagerMandateWorkbenchCard
-          view={visibleManagedMandateEditorView as PortfolioManagerMandateEditorView}
-          onSave={onManagedMandateSave}
-          chrome="plain"
-        />
-      ) : (
-        <ManagedMandateEditorCard
-          view={visibleManagedMandateEditorView as ManagedMandateEditorView}
-          availableTokenSymbols={managedMandateAvailableTokenSymbols}
-          tokenIconBySymbol={tokenIconBySymbol}
-          onSave={onManagedMandateSave}
-          chrome="plain"
-        />
-      )}
+      {visiblePortfolioManagerMandateEditorView ? (
+        <div className={`${DETAIL_INSET_CLASS} p-4`}>
+          <PortfolioManagerMandateWorkbenchShell variant="portfolio-manager">
+            <PortfolioManagerMandateWorkbenchCard
+              view={visiblePortfolioManagerMandateEditorView}
+              onSave={onManagedMandateSave}
+              submitLabel="Save PM mandate"
+              chrome="plain"
+            />
+          </PortfolioManagerMandateWorkbenchShell>
+        </div>
+      ) : null}
+      {visibleManagedMandateEditorView ? (
+        <div className={`${DETAIL_INSET_CLASS} p-4 ${visiblePortfolioManagerMandateEditorView ? 'mt-4' : ''}`}>
+          <PortfolioManagerMandateWorkbenchShell variant="managed-lending">
+            <ManagedMandateEditorCard
+              view={visibleManagedMandateEditorView}
+              availableTokenSymbols={managedMandateAvailableTokenSymbols}
+              tokenIconBySymbol={tokenIconBySymbol}
+              onSave={onManagedMandateSave}
+              submitLabel="Save lending mandate"
+              chrome="plain"
+            />
+          </PortfolioManagerMandateWorkbenchShell>
+        </div>
+      ) : null}
     </div>
   ) : null;
   const subagentWalletBar = emberLendingRuntimeView?.walletAddress ? (
@@ -2921,6 +3274,9 @@ function AgentBlockersTab({
     });
   };
 
+  const [portfolioManagerSetupMandate, setPortfolioManagerSetupMandate] =
+    useState<PortfolioManagerMandateInput>(() => DEFAULT_PORTFOLIO_MANAGER_MANDATE_INPUT);
+
   const portfolioManagerSetupManagedMandate = useMemo<ManagedMandateInput>(
     () => ({
       lending_policy: buildManagedLendingPolicy({
@@ -2939,6 +3295,7 @@ function AgentBlockersTab({
 
   const submitPortfolioManagerSetupMandate = async (
     managedMandate: ManagedMandateInput,
+    portfolioManagerMandate: PortfolioManagerMandateInput = portfolioManagerSetupMandate,
   ) => {
     setError(null);
 
@@ -2967,6 +3324,7 @@ function AgentBlockersTab({
         approved: true,
         riskLevel: 'medium',
       },
+      portfolioManagerMandate,
       firstManagedMandate: {
         targetAgentId: 'ember-lending',
         targetAgentKey: 'ember-lending-primary',
@@ -3291,17 +3649,6 @@ function AgentBlockersTab({
         </div>
       )}
 
-      {delegationsBypassEnabled && (
-        <div className="rounded-xl bg-yellow-500/10 border border-yellow-500/30 p-4">
-          <div className="text-yellow-300 text-sm font-medium mb-1">Wallet bypass enabled</div>
-          <p className="text-yellow-200 text-xs">
-            `DELEGATIONS_BYPASS=true` is set. When no wallet is connected, the UI will use
-            {` ${walletBypassAddress} `}for onboarding. Run the agent with
-            {` ${delegationsBypassEnv}=true `}to skip delegation signing.
-          </p>
-        </div>
-      )}
-
       <div>
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6">
           {/* Form Area */}
@@ -3372,23 +3719,31 @@ function AgentBlockersTab({
 
                 <div className="space-y-4 mb-6">
                   <div className={`${DETAIL_INSET_CLASS} p-4`}>
-                    <div className="mb-2 text-sm font-medium text-[#503826]">Root delegation setup</div>
-                    <p className="text-xs text-[#7c6757]">
-                      Shared Ember will observe your connected wallet directly during onboarding and derive
-                      the initial reserve state from that live wallet observation.
+                    <div className="mb-2 text-sm font-medium text-[#503826]">Portfolio manager mandate</div>
+                    <p className="mb-4 text-xs text-[#7c6757]">
+                      Tune the portfolio-wide PM mandate before approving managed lending control.
                     </p>
-                    <p className="mt-3 text-xs text-[#937c69]">
-                      Wallet: {connectedWalletAddress ? `${connectedWalletAddress.slice(0, 10)}…` : 'Not connected'}
-                    </p>
-                  </div>
-
-                  <div className={`${DETAIL_INSET_CLASS} p-4`}>
-                    <div className="mb-2 text-sm font-medium text-[#503826]">Portfolio mandate</div>
-                    <p className="text-xs text-[#7c6757]">
-                      Approve the preloaded medium-risk portfolio mandate so the portfolio manager can
-                      coordinate managed subagents without overriding your rooted wallet controls.
-                    </p>
-                    <p className="mt-3 text-xs text-[#937c69]">Risk level: Medium</p>
+                    <PortfolioManagerMandateWorkbenchShell variant="portfolio-manager">
+                      <PortfolioManagerMandateWorkbenchCard
+                        view={{
+                          ownerAgentId: agentId,
+                          targetAgentId: 'agent-portfolio-manager',
+                          targetAgentRouteId: 'agent-portfolio-manager',
+                          targetAgentKey: 'portfolio-manager-primary',
+                          title: 'Portfolio Manager Mandate',
+                          mandateRef: null,
+                          managedMandate: portfolioManagerSetupMandate,
+                        }}
+                        chrome="plain"
+                        submitLabel="Save PM mandate"
+                        onDraftChange={setPortfolioManagerSetupMandate}
+                        onSave={(input) =>
+                          setPortfolioManagerSetupMandate(
+                            input.managedMandate as PortfolioManagerMandateInput,
+                          )
+                        }
+                      />
+                    </PortfolioManagerMandateWorkbenchShell>
                   </div>
 
                   <div className={`${DETAIL_INSET_CLASS} p-4`}>
@@ -3396,7 +3751,7 @@ function AgentBlockersTab({
                     <p className="mb-4 text-xs text-[#7c6757]">
                       Configure the first lending mandate inline before handing control to the portfolio manager.
                     </p>
-                    <PortfolioManagerMandateWorkbenchShell>
+                    <PortfolioManagerMandateWorkbenchShell variant="managed-lending">
                       <ManagedMandateWorkbenchCard
                         view={{
                           ownerAgentId: agentId,
@@ -3408,7 +3763,7 @@ function AgentBlockersTab({
                         availableTokenSymbols={availableTokenSymbols}
                         tokenIconBySymbolOverride={tokenIconBySymbol}
                         chrome="plain"
-                        submitLabel="Approve & Continue"
+                        submitLabel="Continue onboarding"
                         onSave={(input) => submitPortfolioManagerSetupMandate(input.managedMandate)}
                       />
                     </PortfolioManagerMandateWorkbenchShell>
@@ -3645,31 +4000,16 @@ function AgentBlockersTab({
               </form>
             ) : showDelegationSigningForm ? (
               <div>
-                <h3 className="mb-4 text-lg font-semibold text-[#261a12]">Review & Sign Delegations</h3>
-                {activeInterrupt?.message && (
-                  <p className="mb-6 text-sm text-[#7c6757]">{activeInterrupt.message}</p>
-                )}
+                <h3 className="mb-4 text-lg font-semibold text-[#261a12]">Authorize portfolio manager</h3>
 
-                <div className="space-y-4 mb-6">
-                  {(activeInterrupt as unknown as { warnings?: string[] }).warnings?.length ? (
-                    <div className="rounded-xl bg-yellow-500/10 border border-yellow-500/30 p-4">
-                      <div className="text-yellow-300 text-sm font-medium mb-2">Warnings</div>
-                      <ul className="space-y-1 text-yellow-200 text-xs">
-                        {(activeInterrupt as unknown as { warnings: string[] }).warnings.map((w, index) => (
-                          <li key={`${index}-${w}`}>{w}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
-
-                  <div className={`${DETAIL_INSET_CLASS} p-4`}>
-                    <div className="mb-2 text-sm font-medium text-[#503826]">What you are authorizing</div>
-                    <ul className="space-y-1 text-xs text-[#7c6757]">
-                      {(activeInterrupt as unknown as { descriptions?: string[] }).descriptions?.map((d, index) => (
-                        <li key={`${index}-${d}`}>{d}</li>
-                      ))}
-                    </ul>
-                  </div>
+                <div className={`${DETAIL_INSET_CLASS} mb-6 p-4`}>
+                  <p className="text-sm font-medium text-[#503826]">
+                    Sign once to let this portfolio manager operate the mandates you approved.
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-[#7c6757]">
+                    This authorizes the portfolio manager to coordinate managed agents through your rooted
+                    delegation. Only continue if you trust this session and the mandate settings shown above.
+                  </p>
                 </div>
 
                 {error && <p className="text-red-400 text-sm mb-4">{error}</p>}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/AgentDetailPage.tsx
@@ -41,6 +41,7 @@ import type {
   OperatorConfigInput,
   PendleSetupInput,
   PortfolioManagerSetupInput,
+  PortfolioManagerMandateInput,
   FundWalletAcknowledgement,
   GmxSetupInput,
   PiOperatorNoteInput,
@@ -594,12 +595,24 @@ type ManagedMandateEditorView = {
   reservationSummary: string | null;
 };
 
+type PortfolioManagerMandateEditorView = {
+  ownerAgentId: string;
+  targetAgentId: string;
+  targetAgentRouteId: string;
+  targetAgentKey: string;
+  title: string;
+  mandateRef: string | null;
+  managedMandate: PortfolioManagerMandateInput;
+};
+
 type ManagedMandateEditorSubmitInput = {
   ownerAgentId: string;
   targetAgentId: string;
   targetAgentRouteId: string;
-  managedMandate: ManagedMandateInput;
+  managedMandate: Record<string, unknown>;
 };
+
+type PortfolioManagerMandateEditorSubmitInput = ManagedMandateEditorSubmitInput;
 
 function buildReservationSummaryFromProjection(
   reservation: Record<string, unknown> | null,
@@ -625,6 +638,17 @@ function buildReservationSummaryFromProjection(
   return normalizeReservationSummaryForDisplay(
     `Reservation ${reservationId} ${reservationAction}${quantitySummary}${controlPathSummary}.`,
   );
+}
+
+function readPortfolioManagerNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
 }
 
 function readManagedMandateEditorView(
@@ -666,6 +690,39 @@ function readManagedMandateEditorView(
     rootUserWallet: readString(editor['rootUserWallet']),
     rootedWalletContextId: readString(editor['rootedWalletContextId']),
     reservationSummary: buildReservationSummaryFromProjection(asRecord(editor['reservation'])),
+  };
+}
+
+function readPortfolioManagerMandateEditorView(
+  domainProjection: Record<string, unknown> | undefined,
+): PortfolioManagerMandateEditorView | null {
+  const editor = asRecord(domainProjection?.['portfolioManagerMandateEditor']);
+  if (!editor) {
+    return null;
+  }
+
+  const targetAgentRouteId = readString(editor['targetAgentRouteId']);
+  if (!targetAgentRouteId) {
+    return null;
+  }
+  const ownerAgentId = readString(editor['ownerAgentId']);
+  const targetAgentId = readString(editor['targetAgentId']);
+  const targetAgentKey = readString(editor['targetAgentKey']);
+  if (!ownerAgentId || !targetAgentId || !targetAgentKey) {
+    return null;
+  }
+
+  const managedMandateRecord = asRecord(editor['managedMandate']) ?? null;
+  const managedMandate: PortfolioManagerMandateInput = managedMandateRecord ?? {};
+
+  return {
+    ownerAgentId,
+    targetAgentId,
+    targetAgentRouteId,
+    targetAgentKey,
+    title: readString(editor['targetAgentTitle']) ?? 'Portfolio manager mandate',
+    mandateRef: readString(editor['mandateRef']),
+    managedMandate,
   };
 }
 
@@ -730,6 +787,166 @@ function ManagedMandateEditorCard(props: {
         })
       }
     />
+  );
+}
+
+function PortfolioManagerMandateWorkbenchCard(props: {
+  view: PortfolioManagerMandateEditorView;
+  onSave?: (input: PortfolioManagerMandateEditorSubmitInput) => Promise<void> | void;
+  submitLabel?: string;
+  chrome?: 'card' | 'plain';
+}) {
+  const initialBetaExposureCapPct = readPortfolioManagerNumber(props.view.managedMandate.betaExposureCapPct);
+  const initialRiskBudgetBps = readPortfolioManagerNumber(props.view.managedMandate.riskBudgetBps);
+  const initialMinimumCashUsd = readPortfolioManagerNumber(props.view.managedMandate.minimumCashUsd);
+
+  const [betaExposureCapPctInput, setBetaExposureCapPctInput] = useState(
+    initialBetaExposureCapPct === undefined ? '' : String(initialBetaExposureCapPct),
+  );
+  const [riskBudgetBpsInput, setRiskBudgetBpsInput] = useState(
+    initialRiskBudgetBps === undefined ? '' : String(initialRiskBudgetBps),
+  );
+  const [minimumCashUsdInput, setMinimumCashUsdInput] = useState(
+    initialMinimumCashUsd === undefined ? '' : String(initialMinimumCashUsd),
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setBetaExposureCapPctInput(
+      readPortfolioManagerNumber(props.view.managedMandate.betaExposureCapPct) === undefined
+        ? ''
+        : String(readPortfolioManagerNumber(props.view.managedMandate.betaExposureCapPct)),
+    );
+    setRiskBudgetBpsInput(
+      readPortfolioManagerNumber(props.view.managedMandate.riskBudgetBps) === undefined
+        ? ''
+        : String(readPortfolioManagerNumber(props.view.managedMandate.riskBudgetBps)),
+    );
+    setMinimumCashUsdInput(
+      readPortfolioManagerNumber(props.view.managedMandate.minimumCashUsd) === undefined
+        ? ''
+        : String(readPortfolioManagerNumber(props.view.managedMandate.minimumCashUsd)),
+    );
+    setSubmitError(null);
+  }, [props.view.mandateRef, props.view.managedMandate]);
+
+  const handleSave = async () => {
+    if (!props.onSave) {
+      return;
+    }
+
+    const betaExposureCapPct = Number(betaExposureCapPctInput.trim());
+    if (!Number.isFinite(betaExposureCapPct)) {
+      setSubmitError('Beta exposure cap must be a valid number.');
+      return;
+    }
+
+    const riskBudgetBps = Number(riskBudgetBpsInput.trim());
+    if (!Number.isFinite(riskBudgetBps)) {
+      setSubmitError('Risk budget must be a valid number.');
+      return;
+    }
+
+    const minimumCashUsd = Number(minimumCashUsdInput.trim());
+    if (!Number.isFinite(minimumCashUsd)) {
+      setSubmitError('Minimum cash threshold must be a valid number.');
+      return;
+    }
+
+    setIsSaving(true);
+    setSubmitError(null);
+    try {
+      await props.onSave({
+        ownerAgentId: props.view.ownerAgentId,
+        targetAgentId: props.view.targetAgentId,
+        targetAgentRouteId: props.view.targetAgentRouteId,
+        managedMandate: {
+          ...props.view.managedMandate,
+          betaExposureCapPct,
+          riskBudgetBps,
+          minimumCashUsd,
+        },
+      });
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Portfolio mandate update failed.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const rootClassName =
+    props.chrome === 'plain'
+      ? 'py-1'
+      : 'rounded-[22px] border border-[#eadac7] bg-white/80 px-3.5 py-3 shadow-[0_14px_28px_rgba(148,111,79,0.09)]';
+
+  return (
+    <div className={rootClassName}>
+      <div className="space-y-3">
+        <div>
+          <div className="text-[0.88rem] font-semibold text-[#503826]">Portfolio manager mandate</div>
+          <div className="mt-1 text-xs text-[#7c6757]">
+            Tune these portfolio-wide policy defaults before runtime dispatch.
+          </div>
+        </div>
+
+        <label className="space-y-1.5 block">
+          <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
+            Beta exposure cap (%)
+          </span>
+          <input
+            name="portfolio-manager-mandate-beta-exposure-cap-pct"
+            aria-label="Portfolio manager beta exposure cap"
+            type="number"
+            className={DETAIL_INPUT_CLASS}
+            value={betaExposureCapPctInput}
+            onChange={(event) => setBetaExposureCapPctInput(event.target.value)}
+            disabled={isSaving}
+          />
+        </label>
+
+        <label className="space-y-1.5 block">
+          <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
+            Risk budget (bps)
+          </span>
+          <input
+            name="portfolio-manager-mandate-risk-budget-bps"
+            aria-label="Portfolio manager risk budget"
+            type="number"
+            className={DETAIL_INPUT_CLASS}
+            value={riskBudgetBpsInput}
+            onChange={(event) => setRiskBudgetBpsInput(event.target.value)}
+            disabled={isSaving}
+          />
+        </label>
+
+        <label className="space-y-1.5 block">
+          <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[#9b826f]">
+            Minimum cash reserve (USD)
+          </span>
+          <input
+            name="portfolio-manager-mandate-minimum-cash-usd"
+            aria-label="Portfolio manager minimum cash reserve"
+            type="number"
+            className={DETAIL_INPUT_CLASS}
+            value={minimumCashUsdInput}
+            onChange={(event) => setMinimumCashUsdInput(event.target.value)}
+            disabled={isSaving}
+          />
+        </label>
+
+        {submitError ? <p className="text-xs text-[#8a2f2f]">{submitError}</p> : null}
+
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving}
+          className={`${DETAIL_NEUTRAL_BUTTON_CLASS} px-5 py-2`}
+        >
+          {isSaving ? 'Saving...' : props.submitLabel ?? 'Save portfolio mandate'}
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -864,6 +1081,10 @@ export function AgentDetailPage({
     () => readManagedMandateEditorView(domainProjection),
     [domainProjection],
   );
+  const portfolioManagerMandateEditorView = useMemo(
+    () => readPortfolioManagerMandateEditorView(domainProjection),
+    [domainProjection],
+  );
   const emberLendingRuntimeView = useMemo(
     () =>
       agentId === 'agent-ember-lending'
@@ -878,10 +1099,14 @@ export function AgentDetailPage({
     onboardingStatus: onboardingFlow?.status,
   });
   const managedRuntimePhaseIsActive = lifecycleState?.phase === 'active';
-  const portfolioManagedContextVisible =
-    managedRuntimePhaseIsActive && (!isPortfolioAgent || !isOnboardingActive);
+  const managedOnboardingRuntimeActive = lifecycleState?.phase === 'onboarding';
+  const portfolioManagedContextVisible = isPortfolioAgent
+    ? managedRuntimePhaseIsActive || managedOnboardingRuntimeActive
+    : managedRuntimePhaseIsActive && !isOnboardingActive;
   const visibleManagedMandateEditorView = portfolioManagedContextVisible
-    ? managedMandateEditorView
+    ? isPortfolioAgent
+      ? portfolioManagerMandateEditorView
+      : managedMandateEditorView
     : null;
   const emberLendingChatEnabled =
     agentId === 'agent-ember-lending' &&
@@ -1235,18 +1460,14 @@ export function AgentDetailPage({
   const managedAgentContextCards = visibleManagedMandateEditorView ? (
     <div className={isPortfolioAgent ? 'mt-6 border-t border-[#eadac7] pt-5' : 'mt-6'}>
       {isPortfolioAgent ? (
-        <PortfolioManagerMandateWorkbenchShell>
-          <ManagedMandateEditorCard
-            view={visibleManagedMandateEditorView}
-            availableTokenSymbols={managedMandateAvailableTokenSymbols}
-            tokenIconBySymbol={tokenIconBySymbol}
-            onSave={onManagedMandateSave}
-            chrome="plain"
-          />
-        </PortfolioManagerMandateWorkbenchShell>
+        <PortfolioManagerMandateWorkbenchCard
+          view={visibleManagedMandateEditorView as PortfolioManagerMandateEditorView}
+          onSave={onManagedMandateSave}
+          chrome="plain"
+        />
       ) : (
         <ManagedMandateEditorCard
-          view={visibleManagedMandateEditorView}
+          view={visibleManagedMandateEditorView as ManagedMandateEditorView}
           availableTokenSymbols={managedMandateAvailableTokenSymbols}
           tokenIconBySymbol={tokenIconBySymbol}
           onSave={onManagedMandateSave}

--- a/typescript/clients/web-ag-ui/apps/web/src/components/GlobalPortfolioTopBar.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/GlobalPortfolioTopBar.tsx
@@ -33,6 +33,10 @@ const LOADING_TOPBAR_VIEW: DashboardTopbarView = {
       liabilitiesValue: '--',
     },
     {
+      label: 'Total leverage',
+      value: '--',
+    },
+    {
       label: 'Net worth',
       value: '--',
     },

--- a/typescript/clients/web-ag-ui/apps/web/src/components/GlobalPortfolioTopBar.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/GlobalPortfolioTopBar.unit.test.tsx
@@ -125,6 +125,7 @@ describe('GlobalPortfolioTopBar', () => {
     expect(html).toContain('bg-[#FFFDF8]');
     expect(html).not.toContain('sticky top-0 z-40 bg-[#F7EFE3]');
     expect(html).toContain('Gross exposure');
+    expect(html).toContain('Total leverage');
     expect(html).toContain('Net worth');
     expect(html).toContain('Unmanaged');
     expect(html).toContain('Benchmark');
@@ -231,6 +232,7 @@ describe('GlobalPortfolioTopBar', () => {
     expect(html).toContain('sticky top-0 z-40');
     expect(html).toContain('src="/ember-sidebar-logo.png"');
     expect(html).toContain('Gross exposure');
+    expect(html).toContain('Total leverage');
     expect(html).toContain('Net worth');
     expect(html).toContain('Unmanaged');
     expect(html).toContain('Benchmark');

--- a/typescript/clients/web-ag-ui/apps/web/src/components/dashboard/PortfolioDashboardTopBar.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/dashboard/PortfolioDashboardTopBar.tsx
@@ -111,8 +111,8 @@ export function PortfolioDashboardTopBar(props: {
   rightAccessory?: React.ReactNode;
 }): React.JSX.Element {
   const gridClassName = props.view.benchmarkAssetLabel
-    ? 'sm:grid-cols-2 xl:grid-cols-[max-content_max-content_max-content_auto]'
-    : 'sm:grid-cols-2 xl:grid-cols-[max-content_max-content_max-content]';
+    ? 'sm:grid-cols-2 xl:grid-cols-[max-content_max-content_max-content_max-content_auto]'
+    : 'sm:grid-cols-2 xl:grid-cols-[max-content_max-content_max-content_max-content]';
 
   return (
     <section className="rounded-b-[24px] rounded-t-none border border-[#E4D5C7] bg-[#FFFCF7] px-4 py-3 shadow-[0_12px_28px_rgba(68,46,21,0.08)] md:px-5">

--- a/typescript/clients/web-ag-ui/apps/web/src/components/dashboard/PortfolioDashboardTopBar.unit.test.tsx
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/dashboard/PortfolioDashboardTopBar.unit.test.tsx
@@ -18,6 +18,10 @@ describe('PortfolioDashboardTopBar', () => {
               liabilitiesValue: '$100',
             },
             {
+              label: 'Total leverage',
+              value: '1.08x',
+            },
+            {
               label: 'Net worth',
               value: '$2.6K',
             },
@@ -35,6 +39,7 @@ describe('PortfolioDashboardTopBar', () => {
     expect(html).not.toMatch(/>Benchmark<\/div><button/);
     expect(html).toContain('>Benchmark<');
     expect(html).toContain('Gross exposure');
+    expect(html).toContain('Total leverage');
     expect(html).toContain('Net worth');
     expect(html).toContain('Unmanaged');
     expect(html).toContain('font-mono text-[12px] font-semibold text-[#6D5B4C]');
@@ -49,7 +54,7 @@ describe('PortfolioDashboardTopBar', () => {
     expect(html).toContain('xl:justify-center');
     expect(html).not.toContain('xl:flex-none');
     expect(html).toContain('xl:gap-x-12');
-    expect(html).toContain('xl:grid-cols-[max-content_max-content_max-content_auto]');
+    expect(html).toContain('xl:grid-cols-[max-content_max-content_max-content_max-content_auto]');
     expect(html).not.toContain('>Soon<');
     expect(html).toContain('Selected Benchmark');
     expect(html).toContain('rounded-[20px] border border-[#eadac7] bg-[#fffdf8]/98');

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/walletDashboardView.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/walletDashboardView.ts
@@ -200,6 +200,10 @@ function buildProjectionTopbarView(
         liabilitiesValue: formatUsd(portfolio.summary.liabilitiesUsd),
       },
       {
+        label: 'Total leverage',
+        value: formatLeverage(portfolio.summary.grossExposureUsd, portfolio.summary.netWorthUsd),
+      },
+      {
         label: 'Net worth',
         value: formatUsd(portfolio.summary.netWorthUsd),
       },
@@ -974,6 +978,14 @@ function formatCompactNumber(value: number): string {
 
 function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
+}
+
+function formatLeverage(grossExposureUsd: number, navUsd: number): string {
+  if (navUsd <= 0) {
+    return 'N/A';
+  }
+
+  return `${(grossExposureUsd / navUsd).toFixed(2)}x`;
 }
 
 function formatCompactReference(value: string): string {

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/walletDashboardView.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/walletDashboardView.ts
@@ -591,9 +591,13 @@ function buildLegacyWalletDashboardView(portfolio: WalletPortfolioView): WalletD
           liabilitiesValue: formatUsd(liabilitiesUsd),
         },
         {
+          label: 'Total leverage',
+          value: formatLeverage(grossExposureUsd, netWorthUsd),
+        },
+        {
           label: 'Net worth',
           value: formatUsd(netWorthUsd),
-      },
+        },
       {
         label: 'Unmanaged',
         value: formatUsd(cashUsd),

--- a/typescript/clients/web-ag-ui/apps/web/src/components/wallet/walletDashboardView.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/components/wallet/walletDashboardView.unit.test.ts
@@ -69,6 +69,7 @@ describe('wallet dashboard view', () => {
     expect(view.topbar.benchmarkAssetLabel).toBe('USDC');
     expect(view.topbar.metrics.map((metric) => metric.label)).toEqual([
       'Gross exposure',
+      'Total leverage',
       'Net worth',
       'Unmanaged',
     ]);
@@ -78,6 +79,10 @@ describe('wallet dashboard view', () => {
         value: '$2,800.00',
         positiveAssetsValue: '$2,700.00',
         liabilitiesValue: '$100.00',
+      },
+      {
+        label: 'Total leverage',
+        value: '1.08x',
       },
       {
         label: 'Net worth',
@@ -263,10 +268,15 @@ describe('wallet dashboard view', () => {
     expect(view.summary.activeLaneCount).toBe(1);
     expect(view.topbar.metrics.map((metric) => metric.label)).toEqual([
       'Gross exposure',
+      'Total leverage',
       'Net worth',
       'Unmanaged',
     ]);
-    expect(view.topbar.metrics[2]).toMatchObject({
+    expect(view.topbar.metrics[1]).toMatchObject({
+      label: 'Total leverage',
+      value: '1.13x',
+    });
+    expect(view.topbar.metrics[3]).toMatchObject({
       label: 'Unmanaged',
       value: '$35.00',
     });

--- a/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
@@ -257,7 +257,20 @@ export interface PortfolioManagerMandateApproval {
 export interface PortfolioManagerMandateInput extends Record<string, unknown> {
   betaExposureCapPct?: number;
   riskBudgetBps?: number;
-  minimumCashUsd?: number;
+    maxDrawdownPct?: number;
+  targetVolatilityPct?: number;
+  maxSingleAssetAllocationPct?: number;
+  rebalanceThresholdPct?: number;
+  maxLeverageRatio?: number;
+    maxPerpsAllocationPct?: number;
+  maxPredictionMarketsAllocationPct?: number;
+  maxNftAllocationPct?: number;
+  maxMemecoinAllocationPct?: number;
+  maxRwaAllocationPct?: number;
+  maxIlliquidAllocationPct?: number;
+  betaExposureTarget?: number;
+  riskToleranceScore?: number;
+  minUndeployedCashBps?: number;
 }
 
 export interface ManagedLendingCollateralAssetPolicyInput {
@@ -289,6 +302,7 @@ export interface PortfolioManagerFirstManagedMandateInput {
 export interface PortfolioManagerSetupInput {
   walletAddress: `0x${string}`;
   portfolioMandate: PortfolioManagerMandateApproval;
+  portfolioManagerMandate?: PortfolioManagerMandateInput;
   firstManagedMandate: PortfolioManagerFirstManagedMandateInput;
 }
 

--- a/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/types/agent.ts
@@ -254,6 +254,12 @@ export interface PortfolioManagerMandateApproval {
   riskLevel: 'medium';
 }
 
+export interface PortfolioManagerMandateInput extends Record<string, unknown> {
+  betaExposureCapPct?: number;
+  riskBudgetBps?: number;
+  minimumCashUsd?: number;
+}
+
 export interface ManagedLendingCollateralAssetPolicyInput {
   asset: string;
   max_allocation_pct: number;

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/portfolioManagerSetup.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/portfolioManagerSetup.ts
@@ -1,4 +1,4 @@
-import type { PortfolioManagerSetupInput } from '../types/agent';
+import type { PortfolioManagerMandateInput, PortfolioManagerSetupInput } from '../types/agent';
 import {
   buildManagedLendingPolicy,
   DEFAULT_MANAGED_LENDING_COLLATERAL_ASSET,
@@ -13,6 +13,7 @@ const DEFAULT_PORTFOLIO_MANAGER_SETUP = {
     approved: true,
     riskLevel: 'medium',
   },
+  portfolioManagerMandate: {} satisfies PortfolioManagerMandateInput,
   firstManagedMandate: {
     targetAgentId: 'ember-lending',
     targetAgentKey: 'ember-lending-primary',
@@ -56,6 +57,7 @@ export function buildPortfolioManagerSetupInput(
   return {
     walletAddress,
     portfolioMandate: DEFAULT_PORTFOLIO_MANAGER_SETUP.portfolioMandate,
+    portfolioManagerMandate: DEFAULT_PORTFOLIO_MANAGER_SETUP.portfolioManagerMandate,
     firstManagedMandate: {
       targetAgentId: DEFAULT_PORTFOLIO_MANAGER_SETUP.firstManagedMandate.targetAgentId,
       targetAgentKey: DEFAULT_PORTFOLIO_MANAGER_SETUP.firstManagedMandate.targetAgentKey,

--- a/typescript/clients/web-ag-ui/apps/web/src/utils/portfolioManagerSetup.unit.test.ts
+++ b/typescript/clients/web-ag-ui/apps/web/src/utils/portfolioManagerSetup.unit.test.ts
@@ -12,6 +12,7 @@ describe('buildPortfolioManagerSetupInput', () => {
         approved: true,
         riskLevel: 'medium',
       },
+      portfolioManagerMandate: {},
       firstManagedMandate: {
         targetAgentId: 'ember-lending',
         targetAgentKey: 'ember-lending-primary',
@@ -52,6 +53,7 @@ describe('buildPortfolioManagerSetupInput', () => {
         approved: true,
         riskLevel: 'medium',
       },
+      portfolioManagerMandate: {},
       firstManagedMandate: {
         targetAgentId: 'ember-lending',
         targetAgentKey: 'ember-lending-primary',


### PR DESCRIPTION
## Summary
- surfaces lending and portfolio-manager mandate editors in the correct onboarding/active states
- gates agent-page bio mandate cards until onboarding is completed
- adds total leverage to the wallet top bar and aligns mandate setup payload hydration
- hardens runtime artifact sync for pnpm snapshot/hardlink installs during concurrent builds

## Validation
- pnpm lint && pnpm test:ci && pnpm build

Closes #657
